### PR TITLE
fix(container): Install yq from GitHub instead of apt

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -17,7 +17,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     wget \
     git \
     jq \
-    yq \
     unzip \
     zip \
     ca-certificates \
@@ -50,6 +49,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Create symlinks for common tool names
 RUN ln -sf /usr/bin/fdfind /usr/bin/fd
+
+# Install yq (Mike Farah's yq) - not available in Ubuntu 24.04 apt repos
+RUN wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 && \
+    chmod +x /usr/local/bin/yq
 
 #===============================================================================
 # JAVA INSTALLATION (SDKMAN for multiple versions)


### PR DESCRIPTION
Ubuntu 24.04 doesn't have Mike Farah's yq package in apt repositories. The PPA is not maintained for Ubuntu Noble. Download yq directly from GitHub releases instead.

## Summary

<!-- Briefly describe what this PR does -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Relates to #456" -->

## Changes Made

<!-- List the specific changes made in this PR -->

-

## Testing

<!-- Describe how you tested your changes -->

- [ ] Quick tests pass (`./tests/run-all-tests.sh --quick`)
- [ ] Container tests pass (`./tests/run-all-tests.sh --container`)
- [ ] ShellCheck passes (`shellcheck -x scripts/*.sh tests/*.sh`)
- [ ] Manual testing performed

### Test Details

<!-- Describe any specific testing scenarios -->

## Checklist

<!-- Mark completed items with an "x" -->

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated CHANGELOG.md (if applicable)

## Screenshots / Logs

<!-- If applicable, add screenshots or log output to help explain your changes -->

## Additional Notes

<!-- Any additional information that reviewers should know -->
