### PR TITLE
fix(security): Add rootless Podman config to container-scan job

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -44,7 +44,14 @@ jobs:
       - name: Install Podman
         run: |
           sudo apt-get update
-          sudo apt-get install -y podman
+          sudo apt-get install -y podman fuse-overlayfs slirp4netns
+
+      - name: Configure Podman for rootless
+        run: |
+          mkdir -p ~/.config/containers
+          echo '[storage]' > ~/.config/containers/storage.conf
+          echo 'driver = "overlay"' >> ~/.config/containers/storage.conf
+          podman --version
 
       - name: Build container image
         run: |


### PR DESCRIPTION
The container-scan job was missing fuse-overlayfs and slirp4netns packages needed for rootless Podman, as well as the storage overlay configuration. This matches the setup in the CI workflow.

## Summary

<!-- Briefly describe what this PR does -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Relates to #456" -->

## Changes Made

<!-- List the specific changes made in this PR -->

-

## Testing

<!-- Describe how you tested your changes -->

- [ ] Quick tests pass (`./tests/run-all-tests.sh --quick`)
- [ ] Container tests pass (`./tests/run-all-tests.sh --container`)
- [ ] ShellCheck passes (`shellcheck -x scripts/*.sh tests/*.sh`)
- [ ] Manual testing performed

### Test Details

<!-- Describe any specific testing scenarios -->

## Checklist

<!-- Mark completed items with an "x" -->

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated CHANGELOG.md (if applicable)

## Screenshots / Logs

<!-- If applicable, add screenshots or log output to help explain your changes -->

## Additional Notes

<!-- Any additional information that reviewers should know -->
