### PR TITLE
fix(ci): Remove invalid --container flag from test command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,8 +144,8 @@ jobs:
           chmod +x ./scripts/*.sh
           chmod +x ./scripts/lib/*.sh 2>/dev/null || true
 
-          # Run container tests
-          ./tests/run-all-tests.sh --container
+          # Run all tests (includes container tests)
+          ./tests/run-all-tests.sh
         timeout-minutes: 45
         env:
           KAPSIS_TEST_QUIET: "0"


### PR DESCRIPTION
The run-all-tests.sh script doesn't have a --container option. Running without --quick flag runs all tests including container tests.

## Summary

<!-- Briefly describe what this PR does -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Relates to #456" -->

## Changes Made

<!-- List the specific changes made in this PR -->

-

## Testing

<!-- Describe how you tested your changes -->

- [ ] Quick tests pass (`./tests/run-all-tests.sh --quick`)
- [ ] Container tests pass (`./tests/run-all-tests.sh --container`)
- [ ] ShellCheck passes (`shellcheck -x scripts/*.sh tests/*.sh`)
- [ ] Manual testing performed

### Test Details

<!-- Describe any specific testing scenarios -->

## Checklist

<!-- Mark completed items with an "x" -->

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated CHANGELOG.md (if applicable)

## Screenshots / Logs

<!-- If applicable, add screenshots or log output to help explain your changes -->

## Additional Notes

<!-- Any additional information that reviewers should know -->
