### PR TITLE
fix(tests): Use KAPSIS_TEST_IMAGE in all container tests

### DIFF
--- a/tests/test-agent-id-unique.sh
+++ b/tests/test-agent-id-unique.sh
@@ -32,7 +32,7 @@ test_same_id_blocked() {
         --userns=keep-id \
         --security-opt label=disable \
         -v "$TEST_PROJECT:/workspace:O,upperdir=$sandbox_dir/upper,workdir=$sandbox_dir/work" \
-        kapsis-sandbox:latest \
+        $KAPSIS_TEST_IMAGE \
         sleep 30 2>/dev/null || {
             log_info "First container failed to start (may be image missing)"
             rm -rf "$sandbox_dir"
@@ -45,7 +45,7 @@ test_same_id_blocked() {
     output=$(podman run --rm \
         --name "$agent_id" \
         --hostname "$agent_id" \
-        kapsis-sandbox:latest \
+        $KAPSIS_TEST_IMAGE \
         echo "should not run" 2>&1) || exit_code=$?
 
     # Cleanup
@@ -80,7 +80,7 @@ test_different_ids_allowed() {
         --userns=keep-id \
         --security-opt label=disable \
         -v "$TEST_PROJECT:/workspace:O,upperdir=$sandbox1/upper,workdir=$sandbox1/work" \
-        kapsis-sandbox:latest \
+        $KAPSIS_TEST_IMAGE \
         sleep 30 2>/dev/null || {
             rm -rf "$sandbox1" "$sandbox2"
             return 0  # Skip if image missing
@@ -93,7 +93,7 @@ test_different_ids_allowed() {
         --userns=keep-id \
         --security-opt label=disable \
         -v "$TEST_PROJECT:/workspace:O,upperdir=$sandbox2/upper,workdir=$sandbox2/work" \
-        kapsis-sandbox:latest \
+        $KAPSIS_TEST_IMAGE \
         sleep 30 2>/dev/null || exit_code=$?
 
     # Check both are running
@@ -126,7 +126,7 @@ test_volumes_isolated() {
         --name "$agent_id1" \
         --userns=keep-id \
         -v "${agent_id1}-m2:/home/developer/.m2/repository" \
-        kapsis-sandbox:latest \
+        $KAPSIS_TEST_IMAGE \
         bash -c "mkdir -p /home/developer/.m2/repository/test && echo 'agent1' > /home/developer/.m2/repository/test/marker.txt" 2>/dev/null || {
             return 0  # Skip if image missing
         }
@@ -137,7 +137,7 @@ test_volumes_isolated() {
         --name "$agent_id2" \
         --userns=keep-id \
         -v "${agent_id2}-m2:/home/developer/.m2/repository" \
-        kapsis-sandbox:latest \
+        $KAPSIS_TEST_IMAGE \
         bash -c "cat /home/developer/.m2/repository/test/marker.txt 2>/dev/null || echo 'not found'" 2>&1)
 
     # Cleanup volumes
@@ -164,7 +164,7 @@ test_sandbox_dirs_isolated() {
         --userns=keep-id \
         --security-opt label=disable \
         -v "$TEST_PROJECT:/workspace:O,upperdir=$sandbox1/upper,workdir=$sandbox1/work" \
-        kapsis-sandbox:latest \
+        $KAPSIS_TEST_IMAGE \
         bash -c "echo 'from agent 1' > /workspace/agent1-file.txt" 2>/dev/null || {
             rm -rf "$sandbox1" "$sandbox2"
             return 0  # Skip if image missing
@@ -177,7 +177,7 @@ test_sandbox_dirs_isolated() {
         --userns=keep-id \
         --security-opt label=disable \
         -v "$TEST_PROJECT:/workspace:O,upperdir=$sandbox2/upper,workdir=$sandbox2/work" \
-        kapsis-sandbox:latest \
+        $KAPSIS_TEST_IMAGE \
         bash -c "cat /workspace/agent1-file.txt 2>/dev/null || echo 'not found'" 2>&1)
 
     # Cleanup
@@ -219,7 +219,7 @@ test_reuse_after_cleanup() {
         --userns=keep-id \
         --security-opt label=disable \
         -v "$TEST_PROJECT:/workspace:O,upperdir=$sandbox/upper,workdir=$sandbox/work" \
-        kapsis-sandbox:latest \
+        $KAPSIS_TEST_IMAGE \
         echo "first run" 2>/dev/null || {
             rm -rf "$sandbox"
             return 0  # Skip if image missing
@@ -236,7 +236,7 @@ test_reuse_after_cleanup() {
         --userns=keep-id \
         --security-opt label=disable \
         -v "$TEST_PROJECT:/workspace:O,upperdir=$sandbox/upper,workdir=$sandbox/work" \
-        kapsis-sandbox:latest \
+        $KAPSIS_TEST_IMAGE \
         echo "second run" 2>/dev/null || exit_code=$?
 
     rm -rf "$sandbox"

--- a/tests/test-cleanup-sandbox.sh
+++ b/tests/test-cleanup-sandbox.sh
@@ -56,7 +56,7 @@ test_named_volumes_removable() {
         --name "vol-test-$$" \
         --userns=keep-id \
         -v "${volume_name}:/data" \
-        kapsis-sandbox:latest \
+        $KAPSIS_TEST_IMAGE \
         bash -c "echo 'data' > /data/test.txt" 2>/dev/null || {
             podman volume rm "$volume_name" 2>/dev/null || true
             return 0  # Skip if image missing
@@ -83,7 +83,7 @@ test_stopped_container_removable() {
     podman run \
         --name "$container_name" \
         --userns=keep-id \
-        kapsis-sandbox:latest \
+        $KAPSIS_TEST_IMAGE \
         echo "done" 2>/dev/null || {
             return 0  # Skip if image missing
         }
@@ -113,7 +113,7 @@ test_force_remove_running() {
         --userns=keep-id \
         --security-opt label=disable \
         -v "$TEST_PROJECT:/workspace:O,upperdir=$sandbox/upper,workdir=$sandbox/work" \
-        kapsis-sandbox:latest \
+        $KAPSIS_TEST_IMAGE \
         sleep 300 2>/dev/null || {
             rm -rf "$sandbox"
             return 0  # Skip if image missing

--- a/tests/test-git-new-branch.sh
+++ b/tests/test-git-new-branch.sh
@@ -41,7 +41,7 @@ test_branch_flag_creates_branch() {
         -e KAPSIS_PROJECT="test" \
         -e KAPSIS_USE_FUSE_OVERLAY=true \
         -e KAPSIS_BRANCH="$branch_name" \
-        kapsis-sandbox:latest \
+        $KAPSIS_TEST_IMAGE \
         bash -c "cd /workspace && git branch --show-current" 2>&1) || true
 
     cleanup_container_test
@@ -137,8 +137,8 @@ test_multiple_branches_different_agents() {
         # Check files in upper volumes
         local agent1_has_file
         local agent2_has_file
-        agent1_has_file=$(podman run --rm -v "${agent1}-upper:/upper:ro" kapsis-sandbox:latest bash -c "test -f /upper/data/agent1.txt && echo YES || echo NO" 2>&1)
-        agent2_has_file=$(podman run --rm -v "${agent2}-upper:/upper:ro" kapsis-sandbox:latest bash -c "test -f /upper/data/agent2.txt && echo YES || echo NO" 2>&1)
+        agent1_has_file=$(podman run --rm -v "${agent1}-upper:/upper:ro" $KAPSIS_TEST_IMAGE bash -c "test -f /upper/data/agent1.txt && echo YES || echo NO" 2>&1)
+        agent2_has_file=$(podman run --rm -v "${agent2}-upper:/upper:ro" $KAPSIS_TEST_IMAGE bash -c "test -f /upper/data/agent2.txt && echo YES || echo NO" 2>&1)
 
         cleanup_isolated_container "$agent1"
         cleanup_isolated_container "$agent2"
@@ -180,7 +180,7 @@ test_branch_env_var_passed() {
         --name "$CONTAINER_TEST_ID" \
         --userns=keep-id \
         -e KAPSIS_BRANCH="$branch_name" \
-        kapsis-sandbox:latest \
+        $KAPSIS_TEST_IMAGE \
         bash -c 'echo $KAPSIS_BRANCH' 2>&1) || true
 
     cleanup_container_test

--- a/tests/test-maven-auth.sh
+++ b/tests/test-maven-auth.sh
@@ -34,7 +34,7 @@ test_token_decoding() {
         --name "$CONTAINER_TEST_ID" \
         --userns=keep-id \
         -e DOCKER_ARTIFACTORY_TOKEN="$encoded_token" \
-        kapsis-sandbox:latest \
+        $KAPSIS_TEST_IMAGE \
         bash -c 'echo "USER=$KAPSIS_MAVEN_USERNAME PASS=$KAPSIS_MAVEN_PASSWORD"' 2>&1) || true
 
     cleanup_container_test
@@ -59,7 +59,7 @@ test_token_decoding_with_special_chars() {
         --name "$CONTAINER_TEST_ID" \
         --userns=keep-id \
         -e DOCKER_ARTIFACTORY_TOKEN="$encoded_token" \
-        kapsis-sandbox:latest \
+        $KAPSIS_TEST_IMAGE \
         bash -c 'echo "USER=$KAPSIS_MAVEN_USERNAME"' 2>&1) || true
 
     cleanup_container_test
@@ -83,7 +83,7 @@ test_token_not_decoded_if_credentials_set() {
         --userns=keep-id \
         -e DOCKER_ARTIFACTORY_TOKEN="$encoded_token" \
         -e KAPSIS_MAVEN_USERNAME="$preset_username" \
-        kapsis-sandbox:latest \
+        $KAPSIS_TEST_IMAGE \
         bash -c 'echo "USER=$KAPSIS_MAVEN_USERNAME"' 2>&1) || true
 
     cleanup_container_test
@@ -104,7 +104,7 @@ test_invalid_token_handled_gracefully() {
         --name "$CONTAINER_TEST_ID" \
         --userns=keep-id \
         -e DOCKER_ARTIFACTORY_TOKEN="not-valid-base64!!!" \
-        kapsis-sandbox:latest \
+        $KAPSIS_TEST_IMAGE \
         bash -c 'echo "USER=${KAPSIS_MAVEN_USERNAME:-unset} PASS=${KAPSIS_MAVEN_PASSWORD:-unset}"' 2>&1) || exit_code=$?
 
     cleanup_container_test
@@ -125,7 +125,7 @@ test_ge_extension_prepopulated() {
         --name "$CONTAINER_TEST_ID" \
         --userns=keep-id \
         -v "kapsis-test-m2:/home/developer/.m2/repository" \
-        kapsis-sandbox:latest \
+        $KAPSIS_TEST_IMAGE \
         bash -c 'ls -la ~/.m2/repository/com/gradle/gradle-enterprise-maven-extension/1.20/*.jar 2>/dev/null && echo "GE_FOUND=yes" || echo "GE_FOUND=no"' 2>&1) || true
 
     cleanup_container_test
@@ -144,7 +144,7 @@ test_ge_extension_entrypoint_log() {
         --name "$CONTAINER_TEST_ID" \
         --userns=keep-id \
         -v "kapsis-test-m2-log:/home/developer/.m2/repository" \
-        kapsis-sandbox:latest \
+        $KAPSIS_TEST_IMAGE \
         bash -c 'echo done' 2>&1) || true
 
     cleanup_container_test
@@ -166,7 +166,7 @@ test_maven_mirror_url_substitution() {
         --name "$CONTAINER_TEST_ID" \
         --userns=keep-id \
         -e KAPSIS_MAVEN_MIRROR_URL="$test_mirror_url" \
-        kapsis-sandbox:latest \
+        $KAPSIS_TEST_IMAGE \
         bash -c 'mvn help:effective-settings 2>&1 | grep -A2 "<mirror>" | head -10' 2>&1) || true
 
     cleanup_container_test
@@ -185,7 +185,7 @@ test_maven_credentials_in_settings() {
     output=$(podman run --rm \
         --name "$CONTAINER_TEST_ID" \
         --userns=keep-id \
-        kapsis-sandbox:latest \
+        $KAPSIS_TEST_IMAGE \
         bash -c 'cat /opt/kapsis/maven/settings.xml | grep -A3 "<server>"' 2>&1) || true
 
     cleanup_container_test
@@ -208,7 +208,7 @@ test_entrypoint_logs_token_decoding() {
         --name "$CONTAINER_TEST_ID" \
         --userns=keep-id \
         -e DOCKER_ARTIFACTORY_TOKEN="$encoded_token" \
-        kapsis-sandbox:latest \
+        $KAPSIS_TEST_IMAGE \
         bash -c 'echo done' 2>&1) || true
 
     cleanup_container_test
@@ -277,7 +277,7 @@ run_in_container_with_env() {
         --userns=keep-id \
         "${env_args[@]}" \
         -v "$TEST_PROJECT:/workspace:rw" \
-        kapsis-sandbox:latest \
+        $KAPSIS_TEST_IMAGE \
         bash -c "$command" 2>&1
 }
 
@@ -294,8 +294,8 @@ main() {
         exit 0
     fi
 
-    if ! podman image exists kapsis-sandbox:latest 2>/dev/null; then
-        log_skip "kapsis-sandbox:latest image not found - run ./scripts/build-image.sh first"
+    if ! podman image exists $KAPSIS_TEST_IMAGE 2>/dev/null; then
+        log_skip "$KAPSIS_TEST_IMAGE image not found - run ./scripts/build-image.sh first"
         exit 0
     fi
 

--- a/tests/test-parallel-agents.sh
+++ b/tests/test-parallel-agents.sh
@@ -55,7 +55,7 @@ test_two_agents_run_simultaneously() {
         --userns=keep-id \
         --security-opt label=disable \
         -v "$TEST_PROJECT:/workspace:O,upperdir=$sandbox1/upper,workdir=$sandbox1/work" \
-        kapsis-sandbox:latest \
+        $KAPSIS_TEST_IMAGE \
         sleep 10 2>/dev/null || {
             cleanup_parallel_sandboxes 2
             return 0  # Skip if image missing
@@ -66,7 +66,7 @@ test_two_agents_run_simultaneously() {
         --userns=keep-id \
         --security-opt label=disable \
         -v "$TEST_PROJECT:/workspace:O,upperdir=$sandbox2/upper,workdir=$sandbox2/work" \
-        kapsis-sandbox:latest \
+        $KAPSIS_TEST_IMAGE \
         sleep 10 2>/dev/null
 
     # Both should be running
@@ -97,7 +97,7 @@ test_agents_have_isolated_filesystems() {
         --userns=keep-id \
         --security-opt label=disable \
         -v "$TEST_PROJECT:/workspace:O,upperdir=$sandbox1/upper,workdir=$sandbox1/work" \
-        kapsis-sandbox:latest \
+        $KAPSIS_TEST_IMAGE \
         bash -c "echo 'agent1' > /workspace/agent1-file.txt" 2>/dev/null || {
             cleanup_parallel_sandboxes 2
             return 0
@@ -110,7 +110,7 @@ test_agents_have_isolated_filesystems() {
         --userns=keep-id \
         --security-opt label=disable \
         -v "$TEST_PROJECT:/workspace:O,upperdir=$sandbox2/upper,workdir=$sandbox2/work" \
-        kapsis-sandbox:latest \
+        $KAPSIS_TEST_IMAGE \
         bash -c "cat /workspace/agent1-file.txt 2>/dev/null || echo 'not found'" 2>&1)
 
     cleanup_parallel_sandboxes 2
@@ -129,7 +129,7 @@ test_agents_have_isolated_volumes() {
         --name "$name1" \
         --userns=keep-id \
         -v "${name1}-m2:/home/developer/.m2/repository" \
-        kapsis-sandbox:latest \
+        $KAPSIS_TEST_IMAGE \
         bash -c "mkdir -p /home/developer/.m2/repository/test && echo 'agent1' > /home/developer/.m2/repository/test/marker.txt" 2>/dev/null || {
             podman volume rm "${name1}-m2" "${name2}-m2" 2>/dev/null || true
             return 0
@@ -141,7 +141,7 @@ test_agents_have_isolated_volumes() {
         --name "$name2" \
         --userns=keep-id \
         -v "${name2}-m2:/home/developer/.m2/repository" \
-        kapsis-sandbox:latest \
+        $KAPSIS_TEST_IMAGE \
         bash -c "cat /home/developer/.m2/repository/test/marker.txt 2>/dev/null || echo 'not found'" 2>&1)
 
     podman volume rm "${name1}-m2" "${name2}-m2" 2>/dev/null || true
@@ -162,7 +162,7 @@ test_concurrent_file_operations() {
             --userns=keep-id \
             --security-opt label=disable \
             -v "$TEST_PROJECT:/workspace:O,upperdir=$sandbox/upper,workdir=$sandbox/work" \
-            kapsis-sandbox:latest \
+            $KAPSIS_TEST_IMAGE \
             bash -c "echo 'agent$i' > /workspace/shared-name.txt && sleep 5" 2>/dev/null || true
     done
 
@@ -206,7 +206,7 @@ test_no_cross_contamination_on_git() {
         --userns=keep-id \
         --security-opt label=disable \
         -v "$TEST_PROJECT:/workspace:O,upperdir=$sandbox1/upper,workdir=$sandbox1/work" \
-        kapsis-sandbox:latest \
+        $KAPSIS_TEST_IMAGE \
         bash -c "
             cd /workspace
             git config user.email 'agent1@test.com'
@@ -226,7 +226,7 @@ test_no_cross_contamination_on_git() {
         --userns=keep-id \
         --security-opt label=disable \
         -v "$TEST_PROJECT:/workspace:O,upperdir=$sandbox2/upper,workdir=$sandbox2/work" \
-        kapsis-sandbox:latest \
+        $KAPSIS_TEST_IMAGE \
         bash -c "cd /workspace && git log --oneline -1" 2>&1)
 
     cleanup_parallel_sandboxes 2
@@ -251,7 +251,7 @@ test_resource_limits_per_agent() {
         --userns=keep-id \
         --security-opt label=disable \
         -v "$TEST_PROJECT:/workspace:O,upperdir=$sandbox1/upper,workdir=$sandbox1/work" \
-        kapsis-sandbox:latest \
+        $KAPSIS_TEST_IMAGE \
         sleep 10 2>/dev/null || {
             cleanup_parallel_sandboxes 2
             return 0
@@ -264,7 +264,7 @@ test_resource_limits_per_agent() {
         --userns=keep-id \
         --security-opt label=disable \
         -v "$TEST_PROJECT:/workspace:O,upperdir=$sandbox2/upper,workdir=$sandbox2/work" \
-        kapsis-sandbox:latest \
+        $KAPSIS_TEST_IMAGE \
         sleep 10 2>/dev/null
 
     # Both should be running with different limits

--- a/tests/test-preflight-check.sh
+++ b/tests/test-preflight-check.sh
@@ -309,11 +309,11 @@ test_image_check_existing() {
 
     # Use an image we know exists from test prerequisites
     local result=0
-    if podman image exists kapsis-sandbox:latest 2>/dev/null; then
-        check_images "kapsis-sandbox:latest" || result=$?
+    if podman image exists $KAPSIS_TEST_IMAGE 2>/dev/null; then
+        check_images "$KAPSIS_TEST_IMAGE" || result=$?
         assert_equals 0 "$result" "Existing image should pass"
     else
-        skip_test "test_image_check_existing" "kapsis-sandbox:latest not built"
+        skip_test "test_image_check_existing" "$KAPSIS_TEST_IMAGE not built"
     fi
 }
 
@@ -351,8 +351,8 @@ test_preflight_full_pass() {
     fi
 
     # Skip if image not built
-    if ! podman image exists kapsis-sandbox:latest 2>/dev/null; then
-        skip_test "test_preflight_full_pass" "kapsis-sandbox:latest not built"
+    if ! podman image exists $KAPSIS_TEST_IMAGE 2>/dev/null; then
+        skip_test "test_preflight_full_pass" "$KAPSIS_TEST_IMAGE not built"
         return 0
     fi
 
@@ -368,7 +368,7 @@ test_preflight_full_pass() {
 
     local output
     local result=0
-    output=$(preflight_check "$test_repo" "feature/new-branch" "$spec_file" "kapsis-sandbox:latest" "1" 2>&1) || result=$?
+    output=$(preflight_check "$test_repo" "feature/new-branch" "$spec_file" "$KAPSIS_TEST_IMAGE" "1" 2>&1) || result=$?
 
     rm -rf "$test_repo"
     rm -f "$spec_file"
@@ -394,7 +394,7 @@ test_preflight_branch_conflict_fails() {
 
     local output
     local result=0
-    output=$(preflight_check "$test_repo" "feature/conflict-branch" "" "kapsis-sandbox:latest" "1" 2>&1) || result=$?
+    output=$(preflight_check "$test_repo" "feature/conflict-branch" "" "$KAPSIS_TEST_IMAGE" "1" 2>&1) || result=$?
 
     rm -rf "$test_repo"
 
@@ -413,7 +413,7 @@ test_preflight_error_messages_actionable() {
     source "$PREFLIGHT_SCRIPT"
 
     local output
-    output=$(preflight_check "$test_repo" "feature/my-branch" "" "kapsis-sandbox:latest" "1" 2>&1) || true
+    output=$(preflight_check "$test_repo" "feature/my-branch" "" "$KAPSIS_TEST_IMAGE" "1" 2>&1) || true
 
     rm -rf "$test_repo"
 


### PR DESCRIPTION
## Summary

Fix CI failures by replacing hardcoded `kapsis-sandbox:latest` with `$KAPSIS_TEST_IMAGE` variable in all container tests.

## Root Cause

After merging PR #10, container tests failed in CI because they used hardcoded `kapsis-sandbox:latest` image name instead of the CI image `kapsis-test:ci` (set via `KAPSIS_IMAGE` env var).

## Changes

Replace `kapsis-sandbox:latest` → `$KAPSIS_TEST_IMAGE` in:
- `test-env-api-keys.sh` (15 occurrences)
- `test-git-new-branch.sh` (4 occurrences)
- `test-agent-id-unique.sh` (10 occurrences)
- `test-maven-auth.sh` (12 occurrences)
- `test-parallel-agents.sh` (11 occurrences)
- `test-cleanup-sandbox.sh` (3 occurrences)
- `test-preflight-check.sh` (8 occurrences)

## Test Plan

- [x] Verified no hardcoded `kapsis-sandbox:latest` remains in test files
- [ ] CI should pass after merge