### PR TITLE
fix(ci): Use KAPSIS_IMAGE env var and fix Linux stat syntax

### DIFF
--- a/scripts/launch-agent.sh
+++ b/scripts/launch-agent.sh
@@ -58,7 +58,8 @@ AUTO_BRANCH=false
 NO_PUSH=false
 INTERACTIVE=false
 DRY_RUN=false
-IMAGE_NAME="kapsis-sandbox:latest"
+# Use KAPSIS_IMAGE env var if set (for CI), otherwise default
+IMAGE_NAME="${KAPSIS_IMAGE:-kapsis-sandbox:latest}"
 SANDBOX_MODE=""  # auto-detect, worktree, or overlay
 WORKTREE_PATH=""
 SANITIZED_GIT_PATH=""

--- a/tests/test-host-unchanged.sh
+++ b/tests/test-host-unchanged.sh
@@ -158,8 +158,14 @@ test_timestamps_unchanged() {
     setup_container_test "host-time"
 
     # Record modification time before
+    # Note: stat -f is "format" on macOS but "filesystem" on Linux
+    # Use OS detection for correct syntax
     local mtime_before
-    mtime_before=$(stat -f "%m" "$TEST_PROJECT/pom.xml" 2>/dev/null || stat -c "%Y" "$TEST_PROJECT/pom.xml")
+    if [[ "$(uname)" == "Darwin" ]]; then
+        mtime_before=$(stat -f "%m" "$TEST_PROJECT/pom.xml")
+    else
+        mtime_before=$(stat -c "%Y" "$TEST_PROJECT/pom.xml")
+    fi
 
     # Modify file in container
     sleep 2  # Ensure time would change
@@ -167,7 +173,11 @@ test_timestamps_unchanged() {
 
     # Check modification time after
     local mtime_after
-    mtime_after=$(stat -f "%m" "$TEST_PROJECT/pom.xml" 2>/dev/null || stat -c "%Y" "$TEST_PROJECT/pom.xml")
+    if [[ "$(uname)" == "Darwin" ]]; then
+        mtime_after=$(stat -f "%m" "$TEST_PROJECT/pom.xml")
+    else
+        mtime_after=$(stat -c "%Y" "$TEST_PROJECT/pom.xml")
+    fi
 
     cleanup_container_test
 


### PR DESCRIPTION
## Summary

- **launch-agent.sh**: Use `KAPSIS_IMAGE` env var for image name with fallback to `kapsis-sandbox:latest`. This allows CI to override the image name.
- **test-host-unchanged.sh**: Fix `stat` command for cross-platform compatibility. macOS uses `stat -f "%m"` (format flag) while Linux uses `stat -c "%Y"`. The previous fallback approach didn't work because `stat -f` on Linux shows filesystem info and exits successfully, not modification time.

## Test plan

- [ ] CI passes on this PR
- [ ] `test-host-unchanged.sh` passes on Linux (GitHub Actions)
- [ ] `test-env-api-keys.sh` passes (uses correct image from KAPSIS_IMAGE)

Fixes remaining CI failures from PR #11.