### PR TITLE
fix: Add cross-platform md5 helper for Linux compatibility

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -452,17 +452,20 @@ size=$(get_file_size "/path/to/file")
 # Get file modification time as Unix epoch
 mtime=$(get_file_mtime "/path/to/file")
 
+# Get MD5 hash of file
+hash=$(get_file_md5 "/path/to/file")
+
 # OS detection
 if is_macos; then
     # macOS-specific code
 fi
 ```
 
-**Why this exists:** The `stat` command has different syntax on macOS vs Linux:
-- macOS: `stat -f%z file` (format flag)
-- Linux: `stat -c%s file` (format flag)
+**Why this exists:** Common commands differ between macOS and Linux:
+- `stat`: macOS uses `-f%z`, Linux uses `-c%s`
+- `md5`: macOS has `md5`, Linux has `md5sum`
 
-The fallback pattern `stat -f... || stat -c...` doesn't work because Linux's `stat -f` shows filesystem info and exits 0 (success).
+The fallback pattern `cmd1 || cmd2` doesn't work reliably because some commands exit 0 with wrong output.
 
 ### logging.sh - Structured Logging
 

--- a/scripts/lib/compat.sh
+++ b/scripts/lib/compat.sh
@@ -69,3 +69,24 @@ is_macos() {
 is_linux() {
     [[ "$_KAPSIS_OS" == "Linux" ]]
 }
+
+#-------------------------------------------------------------------------------
+# get_file_md5 <file>
+#
+# Returns MD5 hash of file. Works on both macOS and Linux.
+# macOS uses 'md5', Linux uses 'md5sum'.
+#-------------------------------------------------------------------------------
+get_file_md5() {
+    local file="$1"
+
+    if [[ ! -f "$file" ]]; then
+        echo ""
+        return 1
+    fi
+
+    if [[ "$_KAPSIS_OS" == "Darwin" ]]; then
+        md5 -q "$file" 2>/dev/null
+    else
+        md5sum "$file" 2>/dev/null | cut -d' ' -f1
+    fi
+}

--- a/tests/lib/test-framework.sh
+++ b/tests/lib/test-framework.sh
@@ -69,6 +69,20 @@ get_file_size() {
     fi
 }
 
+# Get MD5 hash of file (macOS uses 'md5', Linux uses 'md5sum')
+get_file_md5() {
+    local file="$1"
+    if [[ ! -f "$file" ]]; then
+        echo ""
+        return 1
+    fi
+    if [[ "$_TEST_OS" == "Darwin" ]]; then
+        md5 -q "$file" 2>/dev/null
+    else
+        md5sum "$file" 2>/dev/null | cut -d' ' -f1
+    fi
+}
+
 #===============================================================================
 # OUTPUT FUNCTIONS
 #===============================================================================

--- a/tests/test-host-unchanged.sh
+++ b/tests/test-host-unchanged.sh
@@ -17,12 +17,18 @@ source "$SCRIPT_DIR/lib/test-framework.sh"
 
 # Records checksums of all files in test project
 record_file_checksums() {
-    find "$TEST_PROJECT" -type f -exec md5 {} \; 2>/dev/null | sort > "$TEST_PROJECT/../checksums-before.txt"
+    # Use cross-platform get_file_md5 from test-framework.sh
+    while IFS= read -r -d '' file; do
+        echo "$(get_file_md5 "$file")  $file"
+    done < <(find "$TEST_PROJECT" -type f -print0 2>/dev/null) | sort > "$TEST_PROJECT/../checksums-before.txt"
 }
 
 # Compares current checksums with recorded ones
 verify_file_checksums() {
-    find "$TEST_PROJECT" -type f -exec md5 {} \; 2>/dev/null | sort > "$TEST_PROJECT/../checksums-after.txt"
+    # Use cross-platform get_file_md5 from test-framework.sh
+    while IFS= read -r -d '' file; do
+        echo "$(get_file_md5 "$file")  $file"
+    done < <(find "$TEST_PROJECT" -type f -print0 2>/dev/null) | sort > "$TEST_PROJECT/../checksums-after.txt"
     diff -q "$TEST_PROJECT/../checksums-before.txt" "$TEST_PROJECT/../checksums-after.txt" >/dev/null 2>&1
 }
 


### PR DESCRIPTION
## Summary

Found another cross-platform compatibility issue: the `md5` command exists on macOS but Linux uses `md5sum`.

### Changes

**New helper: `get_file_md5()`**
- Added to `scripts/lib/compat.sh` 
- Added to `tests/lib/test-framework.sh`
- macOS: Uses `md5 -q file`
- Linux: Uses `md5sum file | cut -d' ' -f1`

**Updated:**
- `tests/test-host-unchanged.sh` - Uses `get_file_md5()` instead of raw `md5` command
- `docs/ARCHITECTURE.md` - Documented the new helper

### Why this was needed

The `record_file_checksums()` and `verify_file_checksums()` functions in `test-host-unchanged.sh` were using the macOS-only `md5` command, which would fail on Linux CI runners.

## Test plan

- [ ] CI passes on Linux runners
- [ ] `test-host-unchanged.sh` passes