### PR TITLE
fix: Replace GNU-specific find -printf with portable alternative

### DIFF
--- a/scripts/launch-agent.sh
+++ b/scripts/launch-agent.sh
@@ -1058,7 +1058,8 @@ post_container_overlay() {
             log_success "Agent made $changes_count file change(s)"
             echo ""
             echo "Changed files:"
-            find "$UPPER_DIR" -type f -printf "  %P\n" 2>/dev/null | head -20
+            # Cross-platform: -printf is GNU-specific, use sed to strip prefix
+            find "$UPPER_DIR" -type f 2>/dev/null | sed "s|^${UPPER_DIR}/|  |" | head -20
             echo ""
             echo "Upper directory: $UPPER_DIR"
             echo ""


### PR DESCRIPTION
## Summary

The `-printf` option for `find` is GNU-specific and doesn't exist on macOS/BSD `find`.

### Change

Replace:
```bash
find "$UPPER_DIR" -type f -printf "  %P\n" 2>/dev/null | head -20
```

With:
```bash
find "$UPPER_DIR" -type f 2>/dev/null | sed "s|^${UPPER_DIR}/|  |" | head -20
```

### Impact

This fixes the "Changed files:" output when running `launch-agent.sh` on macOS.

## Test plan

- [ ] Verify changed files list displays correctly on macOS
- [ ] Verify changed files list displays correctly on Linux