### PR TITLE
fix(tests): Use native overlay on Linux instead of fuse-overlayfs

### DIFF
--- a/tests/lib/test-framework.sh
+++ b/tests/lib/test-framework.sh
@@ -849,15 +849,14 @@ skip_if_no_container() {
 
 # check_overlay_rw_support
 # Checks if overlay mounts are read-write (they're read-only on macOS with virtio-fs)
-# For container tests, we use fuse-overlayfs on both Linux and macOS for consistent behavior.
-# This ensures the entrypoint sets up /workspace properly with CoW isolation.
+# On Linux: Native Podman overlay works correctly, use it directly
+# On macOS: virtio-fs makes overlay read-only, need fuse-overlayfs fallback
 check_overlay_rw_support() {
-    # Always use fuse-overlayfs for container tests to ensure consistent behavior
-    # across platforms and proper workspace setup by the entrypoint.
-    # Native overlay is faster but requires different entrypoint handling.
+    # On Linux, native overlay should always work
+    # Only macOS needs the fallback to fuse-overlayfs
+    # fuse-overlayfs with named Podman volumes on Linux causes "Invalid cross-device link" errors
     if [[ "$_TEST_OS" == "Linux" ]]; then
-        log_info "Linux detected - using fuse-overlayfs for consistent test behavior"
-        export KAPSIS_USE_FUSE_OVERLAY=true
+        log_info "Linux detected - using native overlay (recommended)"
         return 0
     fi
 


### PR DESCRIPTION
## Summary
- Reverts Linux-specific fuse-overlayfs usage from commit 4852de7
- fuse-overlayfs with named Podman volumes on Linux CI causes "Invalid cross-device link" errors
- Native Podman overlay works correctly on Linux

## Root Cause
When using fuse-overlayfs with named Podman volumes (`${CONTAINER_TEST_ID}-upper:/upper`), the filesystem creates cross-device links that fail on Linux CI:
```
mkdir: cannot create directory '/workspace/new-module': Invalid cross-device link
```

## Fix
On Linux: Use native overlay directly (works correctly)
On macOS: Continue using fuse-overlayfs (needed because virtio-fs makes native overlay read-only)

## Test plan
- [ ] CI passes all container tests on Linux
- [ ] No "Invalid cross-device link" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)