### PR TITLE
fix(tests): Use single volume for fuse-overlayfs upper and work dirs

### DIFF
--- a/tests/test-git-new-branch.sh
+++ b/tests/test-git-new-branch.sh
@@ -34,8 +34,7 @@ test_branch_flag_creates_branch() {
         --cap-add SYS_ADMIN \
         --security-opt label=disable \
         -v "$TEST_PROJECT:/lower:ro" \
-        -v "${CONTAINER_TEST_ID}-upper:/upper" \
-        -v "${CONTAINER_TEST_ID}-work:/work" \
+        -v "${CONTAINER_TEST_ID}-overlay:/overlay" \
         -v "${CONTAINER_TEST_ID}-m2:/home/developer/.m2/repository" \
         -e KAPSIS_AGENT_ID="$CONTAINER_TEST_ID" \
         -e KAPSIS_PROJECT="test" \
@@ -137,8 +136,8 @@ test_multiple_branches_different_agents() {
         # Check files in upper volumes
         local agent1_has_file
         local agent2_has_file
-        agent1_has_file=$(podman run --rm -v "${agent1}-upper:/upper:ro" $KAPSIS_TEST_IMAGE bash -c "test -f /upper/data/agent1.txt && echo YES || echo NO" 2>&1)
-        agent2_has_file=$(podman run --rm -v "${agent2}-upper:/upper:ro" $KAPSIS_TEST_IMAGE bash -c "test -f /upper/data/agent2.txt && echo YES || echo NO" 2>&1)
+        agent1_has_file=$(podman run --rm -v "${agent1}-overlay:/overlay:ro" $KAPSIS_TEST_IMAGE bash -c "test -f /overlay/upper/agent1.txt && echo YES || echo NO" 2>&1)
+        agent2_has_file=$(podman run --rm -v "${agent2}-overlay:/overlay:ro" $KAPSIS_TEST_IMAGE bash -c "test -f /overlay/upper/agent2.txt && echo YES || echo NO" 2>&1)
 
         cleanup_isolated_container "$agent1"
         cleanup_isolated_container "$agent2"


### PR DESCRIPTION
## Summary

Fixes the "Invalid cross-device link" (EXDEV) error when using fuse-overlayfs on GitHub Actions CI by using a single named volume instead of separate volumes for upperdir and workdir.

### Problem
- fuse-overlayfs requires `upperdir` and `workdir` to be on the same filesystem
- Previous approach used separate named volumes (`${id}-upper:/upper` and `${id}-work:/work`)
- On Linux CI, separate named volumes = separate filesystems = EXDEV errors

### Solution
- Use single volume `${container_id}-overlay:/overlay` mounted to container
- entrypoint.sh creates `/overlay/upper` and `/overlay/work` subdirectories
- Both directories now share the same underlying filesystem

### Changes
- Updated test framework to use single volume mount
- Updated entrypoint.sh to detect new `/overlay` layout vs legacy separate volumes
- Fixed test-git-new-branch.sh volume references
- Fixed test-cleanup-sandbox.sh to use `skip_if_no_overlay_rw` for proper fuse-overlayfs mode on macOS
- Updated `assert_file_in_upper` and `assert_file_not_in_upper` helpers

### Test Results
- All 19 test scripts pass locally on macOS
- Preserves rootless security model with `--userns=keep-id`

## Test plan
- [x] Run full test suite locally (`./tests/run-all-tests.sh -q`)
- [ ] Verify CI passes on GitHub Actions

Reference: https://docs.kernel.org/filesystems/overlayfs.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)