### PR TITLE
fix(hooks): Simplify git hooks handling in rootless container

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -154,7 +154,7 @@ git worktree add
 ├── .git (file) ──────────────────────→ ├── .git-safe/ (sanitized, ro)
 ├── src/                                │   ├── config (minimal)
 ├── pom.xml                             │   ├── objects → (ro link)
-└── ...                                 │   └── hooks/ (EMPTY)
+└── ...                                 │   └── hooks/ (sandbox isolated)
                                         ├── src/
                                         └── pom.xml
     ↓                                       ↓
@@ -167,7 +167,7 @@ Post-container: git commit/push         Agent makes changes
 **Security features:**
 - Worktrees created on HOST (trusted environment)
 - Container receives sanitized .git view (read-only)
-- Empty hooks directory prevents hook-based attacks
+- Hooks run in sandbox isolation (cannot affect host)
 - Objects mounted read-only prevents corruption
 - Git commit/push runs on HOST after container exits
 

--- a/docs/CONFIG-REFERENCE.md
+++ b/docs/CONFIG-REFERENCE.md
@@ -195,6 +195,19 @@ sandbox:
   interactive_merge: true
 
 #===============================================================================
+# GIT HOOKS
+#===============================================================================
+# In a rootless isolated container, git hooks aren't a security concern -
+# they can only affect the sandboxed environment. Hooks run normally by
+# default; if they fail (e.g., referencing tools not in the container),
+# it's graceful degradation.
+#
+# To explicitly disable hooks, set KAPSIS_DISABLE_HOOKS=true
+#
+# git_hooks:
+#   disable: false  # Set via KAPSIS_DISABLE_HOOKS env var
+
+#===============================================================================
 # GIT WORKFLOW
 #===============================================================================
 git:


### PR DESCRIPTION
## Summary
- Removes hook disabling logic that added unnecessary complexity
- In rootless containers with `--userns=keep-id`, hooks can only affect the sandbox
- Lets hooks run naturally - if they fail (missing tools), it's graceful degradation

## Background
The previous approach tried to disable hooks by redirecting `core.hooksPath`, but this was unnecessary in an isolated container environment. Git hooks in a rootless sandbox cannot escape the container's isolation, so they pose no security risk.

## Test plan
- [x] All 19 tests pass locally
- [ ] CI tests pass after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)