### PR TITLE
fix(ci): Use PAT to trigger Release workflow on tag push

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -9,6 +9,9 @@ name: Auto Release
 #
 # Note: Since main is a protected branch, this workflow only creates tags.
 # Git tags are the source of truth for versioning.
+#
+# IMPORTANT: Uses RELEASE_TOKEN (PAT) to push tags so that the Release
+# workflow is triggered. GITHUB_TOKEN doesn't trigger other workflows.
 
 on:
   # Triggered automatically when CI workflow completes on main
@@ -113,8 +116,9 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
-          # Checkout main branch (not detached HEAD) so we can push commits
+          # Use PAT to push tags - this triggers the Release workflow
+          # GITHUB_TOKEN pushes don't trigger other workflows (prevents loops)
+          token: ${{ secrets.RELEASE_TOKEN }}
           ref: main
 
       - name: Verify we're on the right commit


### PR DESCRIPTION
## Summary

The Release workflow wasn't being triggered when Auto Release pushed a tag because `GITHUB_TOKEN` pushes don't trigger other workflows (GitHub's loop prevention).

## Changes

- Use `RELEASE_TOKEN` (PAT) instead of `GITHUB_TOKEN` for the release job checkout
- Added documentation comment explaining why PAT is needed

## Setup Required

Before merging, add the `RELEASE_TOKEN` secret:

1. **Create a Fine-grained PAT:**
   - Go to: GitHub Settings → Developer settings → Personal access tokens → Fine-grained tokens
   - Name: `kapsis-release-token`
   - Repository access: Only select `kapsis`
   - Permissions:
     - **Contents**: Read and write
     - **Workflows**: Read and write (optional, for workflow triggering)

2. **Add as Repository Secret:**
   - Go to: https://github.com/aviadshiber/kapsis/settings/secrets/actions
   - New repository secret
   - Name: `RELEASE_TOKEN`
   - Value: paste the PAT

## Test Plan

- [ ] Add RELEASE_TOKEN secret to repository
- [ ] Merge this PR
- [ ] Verify Auto Release creates tag
- [ ] Verify Release workflow is triggered by tag push
- [ ] Verify GitHub Release is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)