### PR TITLE
security: Fix high severity vulnerabilities (Phase 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main, master]
 
+# Security: Explicitly define minimal permissions
+permissions:
+  contents: read
+
 # Cancel in-progress runs for the same branch
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/scripts/lib/logging.sh
+++ b/scripts/lib/logging.sh
@@ -170,8 +170,10 @@ _do_rotation() {
     # Rotate current log
     [[ -f "$base_path" ]] && mv "$base_path" "${base_path}.1"
 
-    # Create new empty log file
+    # Create new empty log file with secure permissions
+    # Security: Logs may contain sensitive paths/info - restrict to owner only
     touch "$base_path"
+    chmod 600 "$base_path"
 
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] [INFO] [logging] Log rotated (previous file: ${base_path}.1)" >> "$base_path"
 }
@@ -349,10 +351,10 @@ log_success() {
 # =============================================================================
 
 # Log a command before executing it (useful for debugging)
+# Security: Use "$@" instead of eval to prevent command injection
 log_cmd() {
-    local cmd="$*"
-    log_debug "Executing: $cmd"
-    eval "$cmd"
+    log_debug "Executing: $*"
+    "$@"
     local rc=$?
     if [[ $rc -ne 0 ]]; then
         log_debug "Command exited with code: $rc"

--- a/scripts/lib/status.sh
+++ b/scripts/lib/status.sh
@@ -336,8 +336,10 @@ EOF
 )
 
     # Atomic write: temp file + mv
+    # Security: Restrict status file permissions (contains project/agent metadata)
     local temp_file="${_KAPSIS_STATUS_FILE}.tmp.$$"
     if echo "$json" > "$temp_file" 2>/dev/null; then
+        chmod 600 "$temp_file" 2>/dev/null || true
         mv "$temp_file" "$_KAPSIS_STATUS_FILE" 2>/dev/null || {
             rm -f "$temp_file" 2>/dev/null
             return 1

--- a/scripts/worktree-manager.sh
+++ b/scripts/worktree-manager.sh
@@ -182,7 +182,9 @@ create_worktree() {
     # Ensure worktree is writable by container user (fixes UID mapping in rootless podman)
     # This is necessary because git worktree creates files with the host user's umask,
     # which may not be writable when mounted into a container with different UID mapping
-    chmod -R a+rwX "$worktree_path" 2>/dev/null || true
+    # Security: Use u+rwX,g+rX instead of a+rwX to avoid world-writable files
+    # With --userns=keep-id, the container user maps to the host user
+    chmod -R u+rwX,g+rX "$worktree_path" 2>/dev/null || true
 
     log_success "Worktree ready: $worktree_path"
     echo "$worktree_path"

--- a/tests/lib/test-framework.sh
+++ b/tests/lib/test-framework.sh
@@ -582,9 +582,10 @@ setup_container_test() {
     mkdir -p "$CONTAINER_TEST_UPPER"
     mkdir -p "$CONTAINER_TEST_SANDBOX/work"
 
-    # Make upper and work directories world-writable for rootless Podman
-    # Even with --userns=keep-id, overlay mount internals may need broader permissions
-    chmod 777 "$CONTAINER_TEST_UPPER" "$CONTAINER_TEST_SANDBOX/work"
+    # Make upper and work directories accessible for rootless Podman
+    # Security: Use 755 instead of 777 to prevent world-writable directories
+    # With --userns=keep-id, owner permissions are sufficient
+    chmod 755 "$CONTAINER_TEST_UPPER" "$CONTAINER_TEST_SANDBOX/work"
 
     log_info "Container test setup: $CONTAINER_TEST_ID"
 }
@@ -886,7 +887,8 @@ check_overlay_rw_support() {
     # On macOS, test if native overlay works (typically read-only with virtio-fs)
     local test_dir="$HOME/.kapsis-overlay-test-$$"
     mkdir -p "$test_dir/lower" "$test_dir/upper" "$test_dir/work"
-    chmod 777 "$test_dir/lower" "$test_dir/upper" "$test_dir/work"
+    # Security: Use 755 instead of 777 to prevent world-writable test directories
+    chmod 755 "$test_dir/lower" "$test_dir/upper" "$test_dir/work"
     echo "test" > "$test_dir/lower/test.txt"
 
     # Try to write via native overlay mount with --userns=keep-id (rootless security model)
@@ -941,8 +943,8 @@ run_podman_isolated() {
 
     local sandbox="$HOME/.ai-sandboxes/$container_id"
     mkdir -p "$sandbox/upper" "$sandbox/work"
-    # Make directories world-writable for rootless Podman without --userns=keep-id
-    chmod 777 "$sandbox/upper" "$sandbox/work"
+    # Security: Use 755 instead of 777 - with --userns=keep-id, owner permissions suffice
+    chmod 755 "$sandbox/upper" "$sandbox/work"
 
     if [[ "${KAPSIS_USE_FUSE_OVERLAY:-}" == "true" ]]; then
         # fuse-overlayfs: true Copy-on-Write inside container


### PR DESCRIPTION
## Summary

Fixes HIGH severity vulnerabilities identified in the security scan. This PR should be merged **after** PR #44 which contains the critical fixes and SSH verification system.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Depends on: #44

## Changes Made

### File Permission Hardening
- `test-framework.sh`: Replace `chmod 777` with `755` (3 locations)
- `worktree-manager.sh`: Replace `chmod a+rwX` with `u+rwX,g+rX`
- `logging.sh`: Add `chmod 600` for log files after creation
- `status.sh`: Add `chmod 600` for status files before move

### Code Injection Prevention
- `logging.sh`: Replace `eval` with `"$@"` in `log_cmd` function
- `launch-agent.sh`: Replace `xargs` with `sed` for safe whitespace trimming
- `launch-agent.sh`: Replace `sed` with parameter expansion for path stripping

### CI/CD Security
- `ci.yml`: Add explicit minimal permissions block (`contents: read`)

## Testing

- [ ] Quick tests pass (`./tests/run-all-tests.sh --quick`)
- [ ] ShellCheck passes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Merge Order

1. Merge PR #44 first (SSH verification + critical fixes)
2. Rebase this PR on main
3. Merge this PR