### PR TITLE
fix(ci): correct trivy-action SHA typo

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Run Trivy vulnerability scanner
         # Security: Pin to specific commit SHA to prevent supply chain attacks
-        uses: aquasecurity/trivy-action@6e7b7d1fd3e4fef0c5fa8cce1229c54b2c9a63cf  # v0.24.0
+        uses: aquasecurity/trivy-action@6e7b7d1fd3e4fef0c5fa8cce1229c54b2c9bd0d8  # v0.24.0
         with:
           input: 'kapsis-image.tar'
           format: 'sarif'
@@ -82,7 +82,7 @@ jobs:
 
       - name: Run Trivy (table output for logs)
         # Security: Pin to specific commit SHA to prevent supply chain attacks
-        uses: aquasecurity/trivy-action@6e7b7d1fd3e4fef0c5fa8cce1229c54b2c9a63cf  # v0.24.0
+        uses: aquasecurity/trivy-action@6e7b7d1fd3e4fef0c5fa8cce1229c54b2c9bd0d8  # v0.24.0
         with:
           input: 'kapsis-image.tar'
           format: 'table'


### PR DESCRIPTION
## Summary
- Fix invalid commit SHA for `aquasecurity/trivy-action` (typo in original PR)
- **Wrong:** `6e7b7d1fd3e4fef0c5fa8cce1229c54b2c9a63cf`
- **Correct:** `6e7b7d1fd3e4fef0c5fa8cce1229c54b2c9bd0d8`

This was causing the Security Scanning workflow to fail on main after PR #44 merge.

## Test plan
- [ ] CI passes
- [ ] Security Scanning workflow resolves trivy-action successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)