### PR TITLE
fix(packaging): update all packages to v0.7.6 with hardened CI automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -259,17 +259,217 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  update-packages:
+    name: Update Package Definitions
+    runs-on: ubuntu-latest
+    needs: [validate, release]
+    if: needs.release.result == 'success'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Validate inputs
+        run: |
+          set -euo pipefail
+
+          VERSION="${{ needs.validate.outputs.version }}"
+          REPO="${{ github.repository }}"
+
+          # Validate version format (semver)
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version format: $VERSION (expected: X.Y.Z)"
+            exit 1
+          fi
+
+          # Validate repository format (defense-in-depth against injection)
+          if [[ ! "$REPO" =~ ^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$ ]]; then
+            echo "::error::Invalid repository format: $REPO"
+            exit 1
+          fi
+
+          echo "✓ Inputs validated: version=$VERSION, repo=$REPO"
+
+      - name: Update Homebrew formula
+        run: |
+          set -euo pipefail
+
+          VERSION="${{ needs.validate.outputs.version }}"
+          REPO="${{ github.repository }}"
+          TARBALL_URL="https://github.com/${REPO}/archive/refs/tags/v${VERSION}.tar.gz"
+          FORMULA_FILE="packaging/homebrew/kapsis.rb"
+
+          # Download tarball with retry and calculate SHA256
+          echo "Downloading tarball from: $TARBALL_URL"
+          MAX_RETRIES=3
+          RETRY_COUNT=0
+
+          while [[ $RETRY_COUNT -lt $MAX_RETRIES ]]; do
+            if SHA256=$(curl -fsSL --retry 3 "$TARBALL_URL" | sha256sum | cut -d' ' -f1); then
+              # Validate SHA256 format (exactly 64 hex characters)
+              if [[ "$SHA256" =~ ^[a-f0-9]{64}$ ]]; then
+                echo "SHA256: $SHA256"
+                break
+              else
+                echo "::warning::Invalid SHA256 format: $SHA256"
+              fi
+            fi
+
+            RETRY_COUNT=$((RETRY_COUNT + 1))
+            if [[ $RETRY_COUNT -lt $MAX_RETRIES ]]; then
+              echo "Retrying ($RETRY_COUNT/$MAX_RETRIES)..."
+              sleep 10
+            else
+              echo "::error::Failed to calculate valid SHA256 after $MAX_RETRIES attempts"
+              exit 1
+            fi
+          done
+
+          # Update the formula between markers using sed
+          sed -i.bak \
+            -e "/RELEASE_VERSION_MARKER_START/,/RELEASE_VERSION_MARKER_END/{
+              s|url \"https://github.com/.*/archive/refs/tags/v[^\"]*\.tar\.gz\"|url \"https://github.com/${REPO}/archive/refs/tags/v${VERSION}.tar.gz\"|
+              s|sha256 \"[a-f0-9]*\"|sha256 \"${SHA256}\"|
+              s|version \"[^\"]*\"|version \"${VERSION}\"|
+            }" "$FORMULA_FILE"
+
+          rm -f "${FORMULA_FILE}.bak"
+
+          # Validate all updates succeeded
+          if ! grep -q "url \"https://github.com/${REPO}/archive/refs/tags/v${VERSION}\.tar\.gz\"" "$FORMULA_FILE"; then
+            echo "::error::Failed to update Homebrew formula URL"
+            exit 1
+          fi
+          if ! grep -q "sha256 \"${SHA256}\"" "$FORMULA_FILE"; then
+            echo "::error::Failed to update Homebrew formula SHA256"
+            exit 1
+          fi
+          if ! grep -q "version \"${VERSION}\"" "$FORMULA_FILE"; then
+            echo "::error::Failed to update Homebrew formula version"
+            exit 1
+          fi
+
+          echo "✓ Updated Homebrew formula to v${VERSION}"
+
+      - name: Update RPM spec
+        run: |
+          set -euo pipefail
+
+          VERSION="${{ needs.validate.outputs.version }}"
+          SPEC_FILE="packaging/rpm/kapsis.spec"
+
+          # Update version on the line with RELEASE_VERSION_MARKER (inline marker approach)
+          sed -i.bak \
+            -e "s/^Version:[[:space:]]*[^#]*# RELEASE_VERSION_MARKER/Version:        ${VERSION}  # RELEASE_VERSION_MARKER/" \
+            "$SPEC_FILE"
+
+          rm -f "${SPEC_FILE}.bak"
+
+          # Validate update succeeded
+          if ! grep -q "^Version:[[:space:]]*${VERSION}[[:space:]]*# RELEASE_VERSION_MARKER" "$SPEC_FILE"; then
+            echo "::error::Failed to update RPM spec version"
+            exit 1
+          fi
+
+          echo "✓ Updated RPM spec to v${VERSION}"
+
+      - name: Update Debian changelog
+        run: |
+          set -euo pipefail
+
+          VERSION="${{ needs.validate.outputs.version }}"
+          CHANGELOG_FILE="packaging/debian/debian/changelog"
+          DATE=$(date -R)
+
+          # Check if this version already exists (idempotency)
+          if grep -q "^kapsis (${VERSION}-1)" "$CHANGELOG_FILE"; then
+            echo "Version ${VERSION} already in changelog, skipping"
+            exit 0
+          fi
+
+          # Prepend new changelog entry
+          {
+            echo "kapsis (${VERSION}-1) unstable; urgency=medium"
+            echo ""
+            echo "  * Update to v${VERSION}"
+            echo ""
+            echo " -- Aviad Shiber <aviadshiber@gmail.com>  ${DATE}"
+            echo ""
+            cat "$CHANGELOG_FILE"
+          } > "${CHANGELOG_FILE}.new"
+
+          mv "${CHANGELOG_FILE}.new" "$CHANGELOG_FILE"
+
+          # Validate update succeeded
+          if ! head -1 "$CHANGELOG_FILE" | grep -q "^kapsis (${VERSION}-1)"; then
+            echo "::error::Failed to update Debian changelog"
+            exit 1
+          fi
+
+          echo "✓ Updated Debian changelog to v${VERSION}"
+
+      - name: Commit and push package updates
+        run: |
+          set -euo pipefail
+
+          VERSION="${{ needs.validate.outputs.version }}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add packaging/
+
+          # Only commit if there are changes
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
+
+          git commit -m "chore(packaging): update all packages to v${VERSION}"
+
+          # Push with retry logic for concurrent updates
+          MAX_RETRIES=3
+          RETRY_COUNT=0
+
+          while [[ $RETRY_COUNT -lt $MAX_RETRIES ]]; do
+            if git push origin main; then
+              echo "✓ Successfully pushed package updates"
+              exit 0
+            fi
+
+            RETRY_COUNT=$((RETRY_COUNT + 1))
+            if [[ $RETRY_COUNT -lt $MAX_RETRIES ]]; then
+              echo "Push failed, rebasing and retrying ($RETRY_COUNT/$MAX_RETRIES)..."
+              git pull --rebase origin main
+              sleep 5
+            fi
+          done
+
+          echo "::error::Failed to push after $MAX_RETRIES attempts"
+          exit 1
+
   notify:
     name: Post-Release
     runs-on: ubuntu-latest
-    needs: [validate, release]
-    if: success()
+    needs: [validate, release, update-packages]
+    if: always() && needs.release.result == 'success'
     steps:
       - name: Release Summary
         run: |
           VERSION="${{ needs.validate.outputs.version }}"
-          echo "## Release v$VERSION completed successfully!" >> $GITHUB_STEP_SUMMARY
+          PACKAGES_STATUS="${{ needs.update-packages.result }}"
+
+          echo "## Release v$VERSION completed!" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- GitHub Release created" >> $GITHUB_STEP_SUMMARY
-          echo "- Container image artifact uploaded" >> $GITHUB_STEP_SUMMARY
-          echo "- Checksums generated" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ GitHub Release created" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ Container image artifact uploaded" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ Checksums generated" >> $GITHUB_STEP_SUMMARY
+
+          if [[ "$PACKAGES_STATUS" == "success" ]]; then
+            echo "- ✅ All package definitions updated (Homebrew, RPM, Debian)" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- ⚠️ Package updates: $PACKAGES_STATUS" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,19 +44,25 @@
 ## Version Documentation Updates
 When completing a PR that will trigger a release, update version references in documentation:
 
-1. **Determine the new version** based on conventional commit type:
+1. **Verify current date**: Always run `date -u` to get the correct UTC date before updating changelogs or documentation with dates. Do not assume the year.
+
+2. **Determine the new version** based on conventional commit type:
    - `feat:` → minor bump (0.7.5 → 0.8.0)
    - `fix:` → patch bump (0.7.5 → 0.7.6)
    - `feat!:` or `BREAKING CHANGE:` → major bump (0.7.5 → 1.0.0)
 
-2. **Check current version**: `git tag --sort=-v:refname | head -1`
+3. **Check current version**: `git tag --sort=-v:refname | head -1`
 
-3. **Update hardcoded versions** in these files if they exist:
+4. **Update hardcoded versions** in these files if they exist:
    - `docs/INSTALL.md` - example version in install commands
-   - `packaging/homebrew/kapsis.rb` - formula version
+   - `packaging/homebrew/kapsis.rb` - formula version (auto-updated by CI)
+   - `packaging/rpm/kapsis.spec` - RPM version (auto-updated by CI)
+   - `packaging/debian/debian/changelog` - Debian changelog (auto-updated by CI)
    - Any other docs with explicit version numbers
 
-4. **Prefer dynamic fetching** where possible - the landing page and install docs already fetch versions dynamically from GitHub API.
+5. **Prefer dynamic fetching** where possible - the landing page and install docs already fetch versions dynamically from GitHub API.
+
+6. **Package definitions are auto-updated** by CI on release - see `.github/workflows/release.yml` `update-packages` job.
 
 ## Security & Configuration Tips
 - Copy `agent-sandbox.yaml.template` to `agent-sandbox.yaml` and keep secrets in keychain-backed fields.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Container tests and security scans only run on merge to main (not on PRs)
 - CI Success job properly gates all required checks
 
-## [1.0.0] - 2024-XX-XX
+## [0.7.6] - 2025-12-28
+
+### Fixed
+- Package manager installations now work without GitHub authentication
+- Homebrew formula updated to v0.7.6 with correct SHA256
+- RPM spec updated to v0.7.6
+- Debian changelog updated to v0.7.6
+
+### Added
+- CI automation to update all package definitions (Homebrew, RPM, Debian) on release
+- Input validation and retry logic for package updates
+- Livecheck block in Homebrew formula for version tracking
+
+## [0.1.0] - 2025-12-24
 
 ### Added
 - Initial release of Kapsis sandbox orchestration platform
@@ -58,5 +71,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Setup and installation guide
 - Contributing guidelines
 
-[Unreleased]: https://github.com/aviadshiber/kapsis/compare/v1.0.0...HEAD
-[1.0.0]: https://github.com/aviadshiber/kapsis/releases/tag/v1.0.0
+[Unreleased]: https://github.com/aviadshiber/kapsis/compare/v0.7.6...HEAD
+[0.7.6]: https://github.com/aviadshiber/kapsis/releases/tag/v0.7.6
+[0.1.0]: https://github.com/aviadshiber/kapsis/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -387,8 +387,40 @@ BREAKING CHANGE: Config files must now use YAML format instead of JSON."
 4. **Determines version** → Calculates new version based on commit types (feat → minor, fix → patch, breaking → major)
 5. **Creates git tag** → Pushes `v{X.Y.Z}` tag
 6. **Release workflow triggers** → Builds container, creates GitHub Release
+7. **Package definitions updated** → Homebrew, RPM, and Debian packages are automatically updated
 
 > **Note:** Since `main` is a protected branch, the Auto Release workflow creates only the git tag. Git tags are the source of truth for versioning.
+
+### What's Automated vs Manual
+
+| Task | Status | Notes |
+|------|--------|-------|
+| Version bump | ✅ Automated | Based on conventional commits |
+| Git tag creation | ✅ Automated | Auto-release workflow |
+| GitHub Release | ✅ Automated | With auto-generated release notes |
+| Container image | ✅ Automated | Built and attached to release |
+| Homebrew formula | ✅ Automated | Version + SHA256 updated |
+| RPM spec | ✅ Automated | Version updated |
+| Debian changelog | ✅ Automated | New entry prepended |
+| **CHANGELOG.md** | ⚠️ **Manual** | Move entries from `[Unreleased]` to version section |
+| **docs/INSTALL.md** | ⚠️ **Manual** | Update version examples if needed |
+| **README badges** | ⚠️ **Manual** | Update if version badges are used |
+
+### Post-Release Manual Steps
+
+After a release is created, maintainers should:
+
+1. **Update CHANGELOG.md** (if not done in the PR):
+   - Move entries from `[Unreleased]` to the new version section
+   - Update the comparison links at the bottom
+
+2. **Review documentation** for version-specific content:
+   - `docs/INSTALL.md` - version examples
+   - `README.md` - any hardcoded versions
+
+3. **Announce the release** (if significant):
+   - Update project documentation
+   - Notify users of breaking changes
 
 ### Manual Releases
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -113,8 +113,8 @@ This will install Kapsis to `~/.local` and add it to your PATH.
 ### Install Script Options
 
 ```bash
-# Install specific version
-KAPSIS_VERSION=1.0.0 curl -fsSL https://raw.githubusercontent.com/aviadshiber/kapsis/main/scripts/install.sh | bash
+# Install specific version (check releases page for latest: https://github.com/aviadshiber/kapsis/releases)
+KAPSIS_VERSION=0.7.6 curl -fsSL https://raw.githubusercontent.com/aviadshiber/kapsis/main/scripts/install.sh | bash
 
 # Install to custom location
 KAPSIS_PREFIX=/opt/kapsis curl -fsSL https://raw.githubusercontent.com/aviadshiber/kapsis/main/scripts/install.sh | bash
@@ -139,11 +139,14 @@ cd kapsis
 ### From Release Tarball
 
 ```bash
+# Get latest version (or specify manually)
+VERSION=$(curl -s https://api.github.com/repos/aviadshiber/kapsis/releases/latest | grep -o '"tag_name": "v[^"]*' | cut -d'v' -f2)
+# Or specify manually: VERSION=0.7.6
+
 # Download release
-VERSION=1.0.0
-curl -LO https://github.com/aviadshiber/kapsis/archive/refs/tags/v${VERSION}.tar.gz
-tar xzf v${VERSION}.tar.gz
-cd kapsis-${VERSION}
+curl -LO "https://github.com/aviadshiber/kapsis/archive/refs/tags/v${VERSION}.tar.gz"
+tar xzf "v${VERSION}.tar.gz"
+cd "kapsis-${VERSION}"
 
 # Run setup
 ./setup.sh --all
@@ -330,7 +333,7 @@ If you prefer not to install jq, you can set the version manually by checking th
 
 ```bash
 # Replace with the latest version from the releases page
-VERSION="1.0.0"
+VERSION="0.7.6"  # Check https://github.com/aviadshiber/kapsis/releases for latest
 ```
 
 ## System Requirements

--- a/packaging/debian/debian/changelog
+++ b/packaging/debian/debian/changelog
@@ -1,4 +1,11 @@
-kapsis (1.0.0-1) unstable; urgency=medium
+kapsis (0.7.6-1) unstable; urgency=medium
+
+  * Update to v0.7.6
+  * Fix package versioning to match actual releases
+
+ -- Aviad Shiber <aviadshiber@gmail.com>  Sat, 28 Dec 2025 07:13:00 +0000
+
+kapsis (0.1.0-1) unstable; urgency=medium
 
   * Initial release
   * Multi-agent support: Claude Code, Aider, Codex, Gemini
@@ -10,4 +17,4 @@ kapsis (1.0.0-1) unstable; urgency=medium
   * Status reporting and monitoring CLI
   * Cleanup and disk reclamation utilities
 
- -- Aviad Shiber <aviadshiber@gmail.com>  Fri, 27 Dec 2024 12:00:00 +0000
+ -- Aviad Shiber <aviadshiber@gmail.com>  Wed, 24 Dec 2025 12:00:00 +0000

--- a/packaging/homebrew/kapsis.rb
+++ b/packaging/homebrew/kapsis.rb
@@ -9,11 +9,18 @@ class Kapsis < Formula
   license "MIT"
   head "https://github.com/aviadshiber/kapsis.git", branch: "main"
 
-  # Stable release - updated by CI on each release
-  # RELEASE_VERSION_MARKER - Do not remove, used by CI
-  url "https://github.com/aviadshiber/kapsis/archive/refs/tags/v1.0.0.tar.gz"
-  sha256 "PLACEHOLDER_SHA256"
-  version "1.0.0"
+  # Stable release - automatically updated by CI on each release
+  # RELEASE_VERSION_MARKER_START - Do not remove, used by CI
+  url "https://github.com/aviadshiber/kapsis/archive/refs/tags/v0.7.6.tar.gz"
+  sha256 "55ccd5d9f614153996cb2e7fcf2e7d2231ef320444be6d00dae3cddff9958d89"
+  version "0.7.6"
+  # RELEASE_VERSION_MARKER_END
+
+  # Homebrew livecheck - detects new releases automatically
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
 
   depends_on "bash" => "3.2"
   depends_on "git" => "2.0"

--- a/packaging/rpm/kapsis.spec
+++ b/packaging/rpm/kapsis.spec
@@ -1,5 +1,5 @@
 Name:           kapsis
-Version:        1.0.0
+Version:        0.7.6  # RELEASE_VERSION_MARKER - Do not remove, used by CI
 Release:        1%{?dist}
 Summary:        Hermetically isolated AI agent sandbox
 
@@ -133,7 +133,11 @@ chmod 755 %{buildroot}%{_bindir}/kapsis-quick
 %{_datadir}/%{name}/
 
 %changelog
-* Fri Dec 27 2024 Aviad Shiber <aviadshiber@gmail.com> - 1.0.0-1
+* Sun Dec 28 2025 Aviad Shiber <aviadshiber@gmail.com> - 0.7.6-1
+- Update to v0.7.6
+- Fix package versioning to match actual releases
+
+* Wed Dec 24 2025 Aviad Shiber <aviadshiber@gmail.com> - 0.1.0-1
 - Initial release
 - Multi-agent support: Claude Code, Aider, Codex, Gemini
 - Podman-based container isolation with rootless execution


### PR DESCRIPTION
## Summary
- Fix all package definitions and documentation pointing to non-existent v1.0.0
- Add hardened CI automation with validation, retry logic, and error handling
- Update documentation with automated vs manual release steps

## Problem
Installing via any package manager was failing because:
1. **Homebrew**: Referenced non-existent `v1.0.0` with `PLACEHOLDER_SHA256`
2. **RPM**: Spec file had `Version: 1.0.0` which doesn't exist
3. **Debian**: Changelog referenced `1.0.0-1` which doesn't exist
4. **Documentation**: `INSTALL.md` had hardcoded `VERSION=1.0.0` examples

This caused download failures and potential GitHub auth prompts.

## Solution

### Package Fixes
| Package | File | Change |
|---------|------|--------|
| Homebrew | `packaging/homebrew/kapsis.rb` | v0.7.6 + SHA256 + livecheck |
| RPM | `packaging/rpm/kapsis.spec` | v0.7.6 + inline version marker |
| Debian | `packaging/debian/debian/changelog` | v0.7.6 entry |

### CI Hardening (from DevOps Review)
| Fix | Description |
|-----|-------------|
| Input validation | Version format (semver) + repository format check |
| SHA256 validation | Verify 64 hex chars + retry on failure |
| Sed validation | Confirm all patterns matched after update |
| Push retry | Pull --rebase on concurrent push conflicts |
| Explicit success | Use `needs.release.result == 'success'` |
| Idempotency | Skip Debian entry if version already exists |

### Documentation Updates
| File | Change |
|------|--------|
| `CHANGELOG.md` | Fixed version history (0.1.0 initial, 0.7.6 current) |
| `CONTRIBUTING.md` | Added "What's Automated vs Manual" table |
| `CONTRIBUTING.md` | Added "Post-Release Manual Steps" section |
| `docs/INSTALL.md` | Fixed hardcoded version examples |

## Test Plan
- [ ] CI passes (shellcheck, tests)
- [ ] Package syntax valid (Homebrew, RPM, Debian)
- [ ] Documentation accurate
- [ ] Future releases will auto-update all packages

## Files Changed
- `.github/workflows/release.yml` - Hardened update-packages job
- `packaging/homebrew/kapsis.rb` - Fixed formula
- `packaging/rpm/kapsis.spec` - Fixed spec with inline marker
- `packaging/debian/debian/changelog` - Fixed changelog
- `CHANGELOG.md` - Fixed version history
- `CONTRIBUTING.md` - Added release automation docs
- `docs/INSTALL.md` - Fixed version examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)