### PR TITLE
fix(ci): use RELEASE_TOKEN for package updates to bypass branch protection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -269,7 +269,9 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: main
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Use RELEASE_TOKEN (PAT) to bypass branch protection when pushing
+          # GITHUB_TOKEN cannot push to protected branches
+          token: ${{ secrets.RELEASE_TOKEN }}
           fetch-depth: 0
 
       - name: Validate inputs


### PR DESCRIPTION
## Summary
Fix the `update-packages` job failing due to branch protection rules.

## Problem
The v0.7.7 release failed at the "Commit and push package updates" step:
```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Required status check "CI Success" is expected.
```

`GITHUB_TOKEN` cannot push directly to protected branches.

## Solution
Use `RELEASE_TOKEN` (PAT) instead, consistent with how `auto-release.yml` handles tag pushes to bypass branch protection.

## Test Plan
- [ ] CI passes
- [ ] Next release should successfully update package definitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)