### PR TITLE
feat(ci): automate CHANGELOG.md updates on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -295,6 +295,90 @@ jobs:
 
           echo "✓ Inputs validated: version=$VERSION, repo=$REPO"
 
+      - name: Update CHANGELOG.md
+        run: |
+          set -euo pipefail
+
+          VERSION="${{ needs.validate.outputs.version }}"
+          REPO="${{ github.repository }}"
+          CHANGELOG_FILE="CHANGELOG.md"
+          DATE=$(date -u +%Y-%m-%d)
+
+          # Check if this version already exists (idempotency)
+          if grep -q "^## \[${VERSION}\]" "$CHANGELOG_FILE"; then
+            echo "Version ${VERSION} already in CHANGELOG, skipping"
+            exit 0
+          fi
+
+          echo "Updating CHANGELOG.md for v${VERSION} (${DATE})"
+
+          # Create a temporary file for the new changelog
+          {
+            # Keep header lines (title and format description)
+            head -7 "$CHANGELOG_FILE"
+            echo ""
+
+            # Add new version section
+            echo "## [${VERSION}] - ${DATE}"
+            echo ""
+
+            # Extract content from [Unreleased] section (between ## [Unreleased] and next ## [...])
+            # Skip empty unreleased section
+            UNRELEASED_CONTENT=$(sed -n '/^## \[Unreleased\]/,/^## \[/{ /^## \[/d; p; }' "$CHANGELOG_FILE" | sed '/^$/d')
+
+            if [[ -n "$UNRELEASED_CONTENT" ]]; then
+              echo "$UNRELEASED_CONTENT"
+              echo ""
+            else
+              echo "### Changed"
+              echo "- Release v${VERSION}"
+              echo ""
+            fi
+
+            # Add empty [Unreleased] section and rest of changelog (skip old unreleased content)
+            echo "## [Unreleased]"
+            echo ""
+
+            # Get everything after [Unreleased] section's content (starting from next version)
+            sed -n '/^## \[Unreleased\]/,/^## \[/{ /^## \[Unreleased\]/d; /^## \[/p; }' "$CHANGELOG_FILE"
+            sed -n '/^## \[Unreleased\]/,/^## \[/{d}; /^## \[/,$p' "$CHANGELOG_FILE" | tail -n +2
+
+          } > "${CHANGELOG_FILE}.new"
+
+          # Update comparison links at the bottom
+          # Add new version link and update Unreleased link
+          if grep -q "^\[Unreleased\]:" "${CHANGELOG_FILE}.new"; then
+            # Update existing Unreleased link to point to new version
+            sed -i.bak "s|\[Unreleased\]: https://github.com/${REPO}/compare/v[^.]*\.[^.]*\.[^.]*\.\.\.HEAD|\[Unreleased\]: https://github.com/${REPO}/compare/v${VERSION}...HEAD|" "${CHANGELOG_FILE}.new"
+          fi
+
+          # Check if version link already exists, if not add it
+          if ! grep -q "^\[${VERSION}\]:" "${CHANGELOG_FILE}.new"; then
+            # Find the previous version from the changelog
+            PREV_VERSION=$(grep -o '^\[[0-9]*\.[0-9]*\.[0-9]*\]:' "${CHANGELOG_FILE}.new" | head -1 | tr -d '[]:'  || echo "")
+
+            if [[ -n "$PREV_VERSION" ]]; then
+              # Insert new version link before the first version link
+              sed -i.bak "/^\[${PREV_VERSION}\]:/i\\
+[${VERSION}]: https://github.com/${REPO}/releases/tag/v${VERSION}
+" "${CHANGELOG_FILE}.new"
+            else
+              # Append at end if no version links exist
+              echo "[${VERSION}]: https://github.com/${REPO}/releases/tag/v${VERSION}" >> "${CHANGELOG_FILE}.new"
+            fi
+          fi
+
+          rm -f "${CHANGELOG_FILE}.new.bak"
+          mv "${CHANGELOG_FILE}.new" "$CHANGELOG_FILE"
+
+          # Validate update succeeded
+          if ! grep -q "^## \[${VERSION}\] - ${DATE}" "$CHANGELOG_FILE"; then
+            echo "::error::Failed to update CHANGELOG.md"
+            exit 1
+          fi
+
+          echo "✓ Updated CHANGELOG.md to v${VERSION}"
+
       - name: Update Homebrew formula
         run: |
           set -euo pipefail
@@ -422,7 +506,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          git add packaging/
+          git add packaging/ CHANGELOG.md
 
           # Only commit if there are changes
           if git diff --staged --quiet; then
@@ -430,7 +514,7 @@ jobs:
             exit 0
           fi
 
-          git commit -m "chore(packaging): update all packages to v${VERSION}"
+          git commit -m "chore(release): update CHANGELOG and packages to v${VERSION}"
 
           # Push with retry logic for concurrent updates
           MAX_RETRIES=3
@@ -471,6 +555,7 @@ jobs:
           echo "- ✅ Checksums generated" >> $GITHUB_STEP_SUMMARY
 
           if [[ "$PACKAGES_STATUS" == "success" ]]; then
+            echo "- ✅ CHANGELOG.md updated" >> $GITHUB_STEP_SUMMARY
             echo "- ✅ All package definitions updated (Homebrew, RPM, Debian)" >> $GITHUB_STEP_SUMMARY
           else
             echo "- ⚠️ Package updates: $PACKAGES_STATUS" >> $GITHUB_STEP_SUMMARY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Issue and PR templates
 - Pre-commit hooks configuration
 - CODEOWNERS file for automatic review requests
+- Automatic CHANGELOG.md updates on release
 
 ### Fixed
 - ShellCheck warnings in all shell scripts
@@ -28,6 +29,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Container tests and security scans only run on merge to main (not on PRs)
 - CI Success job properly gates all required checks
+
+## [0.7.8] - 2025-12-28
+
+### Fixed
+- Use RELEASE_TOKEN for package updates to bypass branch protection (#57)
+
+## [0.7.7] - 2025-12-28
+
+### Fixed
+- Update all packages to v0.7.6 with hardened CI automation (#56)
 
 ## [0.7.6] - 2025-12-28
 
@@ -41,6 +52,120 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI automation to update all package definitions (Homebrew, RPM, Debian) on release
 - Input validation and retry logic for package updates
 - Livecheck block in Homebrew formula for version tracking
+
+## [0.7.5] - 2025-12-27
+
+### Security
+- Add checksum verification and version pinning to install script (#54)
+
+## [0.7.4] - 2025-12-27
+
+### Fixed
+- Add copy button and fix code overflow on mobile landing page (#53)
+
+## [0.7.3] - 2025-12-27
+
+### Documentation
+- Clarify automatic dependency installation in setup.sh (#52)
+
+## [0.7.2] - 2025-12-27
+
+### Documentation
+- Prioritize package manager installation over script execution (#51)
+
+## [0.7.1] - 2025-12-27
+
+### Changed
+- Implement behavior-based tests for partial coverage features (#50)
+
+## [0.7.0] - 2025-12-27
+
+### Added
+- Package manager installation support (Homebrew, RPM, Debian) (#49)
+
+## [0.6.0] - 2025-12-26
+
+### Added
+- `--ssh-cache` option for cleanup script to clear SSH host key cache (#48)
+
+## [0.5.3] - 2025-12-26
+
+### Documentation
+- Add Security section to landing page with SSH and network features (#47)
+
+## [0.5.2] - 2025-12-26
+
+### Security
+- Fix high severity vulnerabilities (Phase 2) (#45)
+
+## [0.5.1] - 2025-12-26
+
+### Fixed
+- Correct trivy-action SHA typo in CI (#46)
+
+## [0.5.0] - 2025-12-26
+
+### Added
+- SSH host key verification system for secure git operations (#44)
+
+## [0.4.1] - 2025-12-25
+
+### Changed
+- Optimize CI with parallel jobs, smart filtering, and image caching (#43)
+
+## [0.4.0] - 2025-12-25
+
+### Added
+- GitHub Pages landing page (#42)
+- CI optimizations for faster builds
+
+## [0.3.0] - 2025-12-25
+
+### Added
+- Verify push before signaling success in git workflow (#41)
+
+## [0.2.6] - 2025-12-25
+
+### Fixed
+- Push even when agent commits itself (#39)
+
+## [0.2.5] - 2025-12-25
+
+### Fixed
+- Support --config flag for image name resolution in preflight checks (#38)
+
+## [0.2.4] - 2025-12-24
+
+### Fixed
+- Mount sanitized git at workspace root for native git support (#37)
+
+## [0.2.3] - 2025-12-24
+
+### Fixed
+- Worktree permissions for rootless podman in CI (#36)
+
+## [0.2.2] - 2025-12-24
+
+### Fixed
+- Improve test coverage and add container tests to PRs (#35)
+
+## [0.2.1] - 2025-12-24
+
+### Fixed
+- Use SDKMAN for Maven to avoid archive.apache.org timeouts (#34)
+
+## [0.2.0] - 2025-12-24
+
+### Added
+- Auto-generate changelog from conventional commits (#33)
+
+## [0.1.2] - 2025-12-24
+
+### Fixed
+- Use PAT to trigger Release workflow on tag push (#32)
+
+### Documentation
+- Add concise CLAUDE.md referencing existing documentation (#31)
 
 ## [0.1.0] - 2025-12-24
 
@@ -71,6 +196,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Setup and installation guide
 - Contributing guidelines
 
-[Unreleased]: https://github.com/aviadshiber/kapsis/compare/v0.7.6...HEAD
-[0.7.6]: https://github.com/aviadshiber/kapsis/releases/tag/v0.7.6
+[Unreleased]: https://github.com/aviadshiber/kapsis/compare/v0.7.8...HEAD
+[0.7.8]: https://github.com/aviadshiber/kapsis/compare/v0.7.7...v0.7.8
+[0.7.7]: https://github.com/aviadshiber/kapsis/compare/v0.7.6...v0.7.7
+[0.7.6]: https://github.com/aviadshiber/kapsis/compare/v0.7.5...v0.7.6
+[0.7.5]: https://github.com/aviadshiber/kapsis/compare/v0.7.4...v0.7.5
+[0.7.4]: https://github.com/aviadshiber/kapsis/compare/v0.7.3...v0.7.4
+[0.7.3]: https://github.com/aviadshiber/kapsis/compare/v0.7.2...v0.7.3
+[0.7.2]: https://github.com/aviadshiber/kapsis/compare/v0.7.1...v0.7.2
+[0.7.1]: https://github.com/aviadshiber/kapsis/compare/v0.7.0...v0.7.1
+[0.7.0]: https://github.com/aviadshiber/kapsis/compare/v0.6.0...v0.7.0
+[0.6.0]: https://github.com/aviadshiber/kapsis/compare/v0.5.3...v0.6.0
+[0.5.3]: https://github.com/aviadshiber/kapsis/compare/v0.5.2...v0.5.3
+[0.5.2]: https://github.com/aviadshiber/kapsis/compare/v0.5.1...v0.5.2
+[0.5.1]: https://github.com/aviadshiber/kapsis/compare/v0.5.0...v0.5.1
+[0.5.0]: https://github.com/aviadshiber/kapsis/compare/v0.4.1...v0.5.0
+[0.4.1]: https://github.com/aviadshiber/kapsis/compare/v0.4.0...v0.4.1
+[0.4.0]: https://github.com/aviadshiber/kapsis/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/aviadshiber/kapsis/compare/v0.2.6...v0.3.0
+[0.2.6]: https://github.com/aviadshiber/kapsis/compare/v0.2.5...v0.2.6
+[0.2.5]: https://github.com/aviadshiber/kapsis/compare/v0.2.4...v0.2.5
+[0.2.4]: https://github.com/aviadshiber/kapsis/compare/v0.2.3...v0.2.4
+[0.2.3]: https://github.com/aviadshiber/kapsis/compare/v0.2.2...v0.2.3
+[0.2.2]: https://github.com/aviadshiber/kapsis/compare/v0.2.1...v0.2.2
+[0.2.1]: https://github.com/aviadshiber/kapsis/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/aviadshiber/kapsis/compare/v0.1.2...v0.2.0
+[0.1.2]: https://github.com/aviadshiber/kapsis/compare/v0.1.0...v0.1.2
 [0.1.0]: https://github.com/aviadshiber/kapsis/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -399,10 +399,10 @@ BREAKING CHANGE: Config files must now use YAML format instead of JSON."
 | Git tag creation | ✅ Automated | Auto-release workflow |
 | GitHub Release | ✅ Automated | With auto-generated release notes |
 | Container image | ✅ Automated | Built and attached to release |
+| CHANGELOG.md | ✅ Automated | Moves `[Unreleased]` to version section |
 | Homebrew formula | ✅ Automated | Version + SHA256 updated |
 | RPM spec | ✅ Automated | Version updated |
 | Debian changelog | ✅ Automated | New entry prepended |
-| **CHANGELOG.md** | ⚠️ **Manual** | Move entries from `[Unreleased]` to version section |
 | **docs/INSTALL.md** | ⚠️ **Manual** | Update version examples if needed |
 | **README badges** | ⚠️ **Manual** | Update if version badges are used |
 
@@ -410,15 +410,11 @@ BREAKING CHANGE: Config files must now use YAML format instead of JSON."
 
 After a release is created, maintainers should:
 
-1. **Update CHANGELOG.md** (if not done in the PR):
-   - Move entries from `[Unreleased]` to the new version section
-   - Update the comparison links at the bottom
-
-2. **Review documentation** for version-specific content:
-   - `docs/INSTALL.md` - version examples
+1. **Review documentation** for version-specific content:
+   - `docs/INSTALL.md` - version examples (if hardcoded)
    - `README.md` - any hardcoded versions
 
-3. **Announce the release** (if significant):
+2. **Announce the release** (if significant):
    - Update project documentation
    - Notify users of breaking changes
 
@@ -448,4 +444,4 @@ When adding changes to your PR, update the `[Unreleased]` section in `CHANGELOG.
 - Your bug fix description
 ```
 
-> **Note:** Since `main` is protected, changelog entries remain in `[Unreleased]` until manually moved. Periodically, a maintainer should update the changelog to move entries to released version sections based on git tags.
+> **Note:** The release workflow automatically moves `[Unreleased]` content to the new version section. Just add your changes to `[Unreleased]` and the automation handles the rest.


### PR DESCRIPTION
## Summary
- Add CHANGELOG.md update step to release workflow
- Automatically moves `[Unreleased]` content to new version section
- Updates comparison links at bottom of CHANGELOG
- Backfills all 25 releases (v0.1.0 through v0.7.8)

## Changes

### Release Workflow
- New "Update CHANGELOG.md" step in `update-packages` job
- Idempotency: skips if version already exists
- Moves unreleased content to versioned section with date
- Updates version comparison links automatically

### Documentation
- Updated CONTRIBUTING.md to reflect CHANGELOG is now automated
- Removed manual CHANGELOG update from post-release steps

### CHANGELOG
- Backfilled all 25 releases with proper categorization
- Added all version comparison links

## Test plan
- [ ] CI passes all checks
- [ ] Verify next release (v0.7.9+) creates proper CHANGELOG entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)