### PR TITLE
fix(ci): remove obsolete CHANGELOG check warning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,15 +54,6 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Release version: $VERSION"
 
-      - name: Check CHANGELOG entry
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          if ! grep -q "\[$VERSION\]" CHANGELOG.md; then
-            echo "::warning::No CHANGELOG entry found for version $VERSION"
-          else
-            echo "CHANGELOG entry found for version $VERSION"
-          fi
-
   test:
     name: Run Tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Remove the CHANGELOG entry check that always warned before automation ran

The warning was misleading since the `update-packages` job now automatically creates the CHANGELOG entry for each release. The check ran before the automation, so it always showed a warning even though everything worked correctly.

## Test plan
- [ ] Merge this PR
- [ ] Verify CI passes and auto-release triggers
- [ ] Confirm Release workflow runs without the warning annotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)