### PR TITLE
fix: prevent dry-run from creating filesystem artifacts

### DIFF
--- a/tests/lib/test-framework.sh
+++ b/tests/lib/test-framework.sh
@@ -258,6 +258,19 @@ assert_dir_exists() {
     fi
 }
 
+# assert_dir_not_exists <path> <message>
+assert_dir_not_exists() {
+    local path="$1"
+    local message="${2:-Directory should not exist}"
+
+    if [[ ! -d "$path" ]]; then
+        return 0
+    else
+        _log_failure "$message" "Directory exists but shouldn't: $path"
+        return 1
+    fi
+}
+
 # assert_exit_code <expected> <actual> <message>
 assert_exit_code() {
     local expected="$1"

--- a/tests/test-dry-run-completeness.sh
+++ b/tests/test-dry-run-completeness.sh
@@ -148,6 +148,120 @@ test_dry_run_shows_cpu_limit() {
 }
 
 #===============================================================================
+# DRY-RUN SIDE EFFECTS TESTS (Issue: kapsis-dry-run-side-effects)
+#===============================================================================
+
+test_dry_run_no_worktree_created() {
+    log_test "Testing dry-run does not create worktree"
+
+    # Initialize git repo for branch test
+    cd "$TEST_PROJECT"
+    git init -q
+    git config user.email "test@test.com"
+    git config user.name "Test"
+    touch .gitkeep
+    git add .
+    git commit -q -m "init"
+    cd - > /dev/null
+
+    # Use a unique agent ID to avoid conflicts
+    local agent_id="dry-run-test-$$"
+    local project_name
+    project_name=$(basename "$TEST_PROJECT")
+    local worktree_path="$HOME/.kapsis/worktrees/${project_name}-${agent_id}"
+
+    # Run dry-run
+    "$LAUNCH_SCRIPT" "$agent_id" "$TEST_PROJECT" --agent claude \
+        --task "test" --branch "feature/dry-run-test-$$" --dry-run 2>&1 || true
+
+    # Verify no worktree was created
+    assert_dir_not_exists "$worktree_path" "Worktree should not be created in dry-run"
+}
+
+test_dry_run_no_sanitized_git_created() {
+    log_test "Testing dry-run does not create sanitized git directory"
+
+    # Initialize git repo for branch test
+    cd "$TEST_PROJECT"
+    if [[ ! -d .git ]]; then
+        git init -q
+        git config user.email "test@test.com"
+        git config user.name "Test"
+        touch .gitkeep
+        git add .
+        git commit -q -m "init"
+    fi
+    cd - > /dev/null
+
+    # Use a unique agent ID to avoid conflicts
+    local agent_id="dry-run-test-sanitized-$$"
+    local sanitized_path="$HOME/.kapsis/sanitized-git/${agent_id}"
+
+    # Run dry-run
+    "$LAUNCH_SCRIPT" "$agent_id" "$TEST_PROJECT" --agent claude \
+        --task "test" --branch "feature/dry-run-test-$$" --dry-run 2>&1 || true
+
+    # Verify no sanitized git directory was created
+    assert_dir_not_exists "$sanitized_path" "Sanitized git should not be created in dry-run"
+}
+
+test_dry_run_no_branch_created() {
+    log_test "Testing dry-run does not create git branch"
+
+    # Initialize git repo for branch test
+    cd "$TEST_PROJECT"
+    if [[ ! -d .git ]]; then
+        git init -q
+        git config user.email "test@test.com"
+        git config user.name "Test"
+        touch .gitkeep
+        git add .
+        git commit -q -m "init"
+    fi
+    cd - > /dev/null
+
+    local branch_name="feature/dry-run-no-create-$$"
+
+    # Run dry-run
+    "$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --agent claude \
+        --task "test" --branch "$branch_name" --dry-run 2>&1 || true
+
+    # Verify no branch was created
+    cd "$TEST_PROJECT"
+    local branch_exists=false
+    if git rev-parse --verify "$branch_name" >/dev/null 2>&1; then
+        branch_exists=true
+    fi
+    cd - > /dev/null
+
+    assert_false "[[ $branch_exists == true ]]" "Branch '$branch_name' should not be created in dry-run"
+}
+
+test_dry_run_shows_would_create_messages() {
+    log_test "Testing dry-run shows [DRY-RUN] would create messages"
+
+    # Initialize git repo for branch test
+    cd "$TEST_PROJECT"
+    if [[ ! -d .git ]]; then
+        git init -q
+        git config user.email "test@test.com"
+        git config user.name "Test"
+        touch .gitkeep
+        git add .
+        git commit -q -m "init"
+    fi
+    cd - > /dev/null
+
+    local output
+    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --agent claude \
+        --task "test" --branch "feature/dry-run-msg-$$" --dry-run 2>&1) || true
+
+    assert_contains "$output" "[DRY-RUN]" "Should show DRY-RUN prefix"
+    assert_contains "$output" "Would create worktree" "Should indicate worktree would be created"
+    assert_contains "$output" "Would create sanitized git" "Should indicate sanitized git would be created"
+}
+
+#===============================================================================
 # MAIN
 #===============================================================================
 
@@ -170,6 +284,12 @@ main() {
     run_test test_dry_run_shows_env_vars
     run_test test_dry_run_shows_memory_limit
     run_test test_dry_run_shows_cpu_limit
+
+    # Side effects tests (Issue: kapsis-dry-run-side-effects)
+    run_test test_dry_run_no_worktree_created
+    run_test test_dry_run_no_sanitized_git_created
+    run_test test_dry_run_no_branch_created
+    run_test test_dry_run_shows_would_create_messages
 
     # Cleanup
     cleanup_test_project

--- a/tests/test-version-fetch.sh
+++ b/tests/test-version-fetch.sh
@@ -96,7 +96,8 @@ test_jq_parse_missing_tag_name() {
     local json_response='{"name": "Some Release", "draft": false}'
 
     local version
-    version=$(echo "$json_response" | jq -r '.tag_name | ltrimstr("v")')
+    # Handle null case before calling ltrimstr (which requires string input)
+    version=$(echo "$json_response" | jq -r '.tag_name | if . == null then "null" else ltrimstr("v") end')
 
     assert_equals "null" "$version" "Should return null when tag_name is missing"
 }


### PR DESCRIPTION
## Summary

- Fix `--dry-run` creating git worktrees, branches, and sanitized git directories as side effects
- Add `ensure_dir()` helper and DRY_RUN guards throughout `launch-agent.sh`
- Show `[DRY-RUN]` prefixed messages indicating what would be created
- Fix shellcheck SC2295 warnings in parameter expansions
- Fix jq null handling in `test-version-fetch.sh` for jq 1.8+ compatibility

## Test plan

- [x] Added `test_dry_run_no_worktree_created` - verifies no worktree created in dry-run
- [x] Added `test_dry_run_no_sanitized_git_created` - verifies no sanitized git dir created
- [x] Added `test_dry_run_no_branch_created` - verifies no git branch created
- [x] Added `test_dry_run_shows_would_create_messages` - verifies [DRY-RUN] output
- [x] Added `assert_dir_not_exists()` assertion to test framework
- [x] All existing tests pass

Fixes: kapsis-dry-run-side-effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)