### PR TITLE
security(ci): pin yq version with SHA256 verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,8 +103,11 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y jq
-          # Install yq for YAML parsing
-          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          # Install yq for YAML parsing (pinned version with checksum)
+          YQ_VERSION="v4.50.1"
+          YQ_SHA256="c7a1278e6bbc4924f41b56db838086c39d13ee25dcb22089e7fbf16ac901f0d4"
+          sudo wget -qO /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
+          echo "${YQ_SHA256}  /usr/local/bin/yq" | sha256sum -c -
           sudo chmod +x /usr/local/bin/yq
 
       - name: Configure git for tests
@@ -150,8 +153,11 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y podman fuse-overlayfs slirp4netns jq
-          # Install yq for YAML parsing
-          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          # Install yq for YAML parsing (pinned version with checksum)
+          YQ_VERSION="v4.50.1"
+          YQ_SHA256="c7a1278e6bbc4924f41b56db838086c39d13ee25dcb22089e7fbf16ac901f0d4"
+          sudo wget -qO /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
+          echo "${YQ_SHA256}  /usr/local/bin/yq" | sha256sum -c -
           sudo chmod +x /usr/local/bin/yq
 
       - name: Configure Podman for rootless


### PR DESCRIPTION
## Summary
- Pin yq to v4.50.1 (latest stable release) with SHA256 checksum verification
- Prevents supply chain attacks from compromised releases

## Changes
- Updated `quick-tests` and `container-tests` jobs in CI workflow
- Download from specific version URL instead of `/latest`
- Verify SHA256 checksum before executing

## Security Rationale
From security review: downloading from `/latest` without checksum verification could allow an attacker to inject malicious code if they compromise the yq release.

## Verification
SHA256 checksum for `yq_linux_amd64` v4.50.1:
```
c7a1278e6bbc4924f41b56db838086c39d13ee25dcb22089e7fbf16ac901f0d4
```

## Test plan
- [ ] CI runs successfully with pinned version
- [ ] Checksum verification passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)