### PR TITLE
feat: auto-generate agent IDs with optional --agent-id flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ Kapsis is a **hermetically isolated AI agent sandbox** for running multiple AI c
 ```bash
 # Build & run
 ./scripts/build-image.sh                    # Build container image
-./scripts/launch-agent.sh 1 ~/project --agent claude --task "..."
+./scripts/launch-agent.sh ~/project --agent claude --task "..."
 
 # Test
 ./tests/run-all-tests.sh --quick            # Fast tests (~10s)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ For log environment variables, file locations, and rotation settings, see [docs/
 Quick reference:
 ```bash
 # Enable debug logging
-KAPSIS_DEBUG=1 ./scripts/launch-agent.sh 1 ~/project --task "test"
+KAPSIS_DEBUG=1 ./scripts/launch-agent.sh ~/project --task "test"
 
 # View logs
 tail -f ~/.kapsis/logs/kapsis-launch-agent.log

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ cp agent-sandbox.yaml.template agent-sandbox.yaml
 
 # 5. Run an agent
 kapsis 1 ~/project --task "fix failing tests"
-# or: ./scripts/launch-agent.sh 1 ~/project --task "fix failing tests"
+# or: ./scripts/launch-agent.sh ~/project --task "fix failing tests"
 ```
 
 ## Agent Profiles
@@ -86,7 +86,7 @@ Kapsis includes pre-built agent profiles that install the agent directly into th
 
 ```bash
 # Use the pre-built agent image
-./scripts/launch-agent.sh 1 ~/project \
+./scripts/launch-agent.sh ~/project \
     --image kapsis-claude-cli:latest \
     --task "implement rate limiting"
 
@@ -112,20 +112,20 @@ Profiles are defined in `configs/agents/`. Create custom profiles by copying an 
 
 ```bash
 # Simple inline task
-./scripts/launch-agent.sh 1 ~/project --task "fix failing tests in UserService"
+./scripts/launch-agent.sh ~/project --task "fix failing tests in UserService"
 
 # Complex task with spec file
-./scripts/launch-agent.sh 1 ~/project --spec ./specs/feature.md
+./scripts/launch-agent.sh ~/project --spec ./specs/feature.md
 
 # Interactive mode (manual exploration)
-./scripts/launch-agent.sh 1 ~/project --interactive
+./scripts/launch-agent.sh ~/project --interactive
 ```
 
 ### Git Branch Workflow
 
 ```bash
 # Create new branch and work on task
-./scripts/launch-agent.sh 1 ~/project \
+./scripts/launch-agent.sh ~/project \
     --branch feature/DEV-123 \
     --spec ./specs/task.md
 
@@ -133,7 +133,7 @@ Profiles are defined in `configs/agents/`. Create custom profiles by copying an 
 # Review PR, request changes
 # Update spec with feedback, re-run:
 
-./scripts/launch-agent.sh 1 ~/project \
+./scripts/launch-agent.sh ~/project \
     --branch feature/DEV-123 \
     --spec ./specs/task-v2.md
 
@@ -144,17 +144,17 @@ Profiles are defined in `configs/agents/`. Create custom profiles by copying an 
 
 ```bash
 # Run multiple agents on same project, different branches
-./scripts/launch-agent.sh 1 ~/project \
+./scripts/launch-agent.sh ~/project \
     --config configs/claude.yaml \
     --branch feature/DEV-123-api \
     --spec ./specs/api.md &
 
-./scripts/launch-agent.sh 2 ~/project \
+./scripts/launch-agent.sh ~/project \
     --config configs/codex.yaml \
     --branch feature/DEV-123-ui \
     --spec ./specs/ui.md &
 
-./scripts/launch-agent.sh 3 ~/project \
+./scripts/launch-agent.sh ~/project \
     --config configs/aider.yaml \
     --branch feature/DEV-123-tests \
     --spec ./specs/tests.md &
@@ -264,7 +264,7 @@ See [docs/CLEANUP.md](docs/CLEANUP.md) for full options and troubleshooting.
 
 ```bash
 # Enable debug output
-KAPSIS_DEBUG=1 ./scripts/launch-agent.sh 1 ~/project --task "test"
+KAPSIS_DEBUG=1 ./scripts/launch-agent.sh ~/project --task "test"
 
 # View logs
 tail -f ~/.kapsis/logs/kapsis-launch-agent.log

--- a/agent-sandbox.yaml.template
+++ b/agent-sandbox.yaml.template
@@ -4,7 +4,7 @@
 # Usage:
 #   cp agent-sandbox.yaml.template agent-sandbox.yaml
 #   # Edit agent-sandbox.yaml with your settings
-#   ./scripts/launch-agent.sh 1 ~/project --spec ./specs/task.md
+#   ./scripts/launch-agent.sh ~/project --spec ./specs/task.md
 
 #===============================================================================
 # AGENT CONFIGURATION

--- a/configs/aider.yaml
+++ b/configs/aider.yaml
@@ -1,5 +1,5 @@
 # Kapsis Configuration - Aider Agent
-# Use with: ./scripts/launch-agent.sh 1 ~/project --config configs/aider.yaml
+# Use with: ./scripts/launch-agent.sh ~/project --config configs/aider.yaml
 
 agent:
   # Aider with message file input and auto-yes

--- a/configs/claude.yaml
+++ b/configs/claude.yaml
@@ -1,5 +1,5 @@
 # Kapsis Configuration - Claude Code Agent
-# Use with: ./scripts/launch-agent.sh 1 ~/project --config configs/claude.yaml
+# Use with: ./scripts/launch-agent.sh ~/project --config configs/claude.yaml
 
 agent:
   # Claude Code with spec file input

--- a/configs/codex.yaml
+++ b/configs/codex.yaml
@@ -1,5 +1,5 @@
 # Kapsis Configuration - Codex CLI Agent
-# Use with: ./scripts/launch-agent.sh 1 ~/project --config configs/codex.yaml
+# Use with: ./scripts/launch-agent.sh ~/project --config configs/codex.yaml
 
 agent:
   # Codex CLI with full auto approval

--- a/configs/interactive.yaml
+++ b/configs/interactive.yaml
@@ -1,5 +1,5 @@
 # Kapsis Configuration - Interactive Shell
-# Use with: ./scripts/launch-agent.sh 1 ~/project --config configs/interactive.yaml --interactive
+# Use with: ./scripts/launch-agent.sh ~/project --config configs/interactive.yaml --interactive
 
 agent:
   # Just drop into bash for manual exploration

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -303,7 +303,7 @@ Kapsis provides JSON-based status reporting for external monitoring with **agent
 
 ```bash
 # Launch with branch
-./launch-agent.sh 1 ~/project --branch feature/DEV-123 --spec task.md
+./launch-agent.sh ~/project --branch feature/DEV-123 --spec task.md
 
 # Agent commits and pushes automatically
 # Review PR → Request changes → Update spec → Re-run
@@ -319,7 +319,7 @@ Kapsis provides JSON-based status reporting for external monitoring with **agent
 
 ```bash
 # Launch without branch
-./launch-agent.sh 1 ~/project --spec task.md
+./launch-agent.sh ~/project --spec task.md
 
 # Review changes in upper directory
 tree ~/.ai-sandboxes/project-1/upper/

--- a/docs/CONFIG-REFERENCE.md
+++ b/docs/CONFIG-REFERENCE.md
@@ -138,7 +138,7 @@ maven:
 #
 # Example setup:
 #   export DOCKER_ARTIFACTORY_TOKEN=$(echo -n "user:pass" | base64)
-#   ./scripts/launch-agent.sh 1 ~/project --task "build"
+#   ./scripts/launch-agent.sh ~/project --task "build"
 #
 # In your config:
 environment:
@@ -705,7 +705,7 @@ Use `build-agent-image.sh` to create agent-specific container images:
 
 ```bash
 # Method 1: --image flag (highest priority)
-./scripts/launch-agent.sh 1 ~/project \
+./scripts/launch-agent.sh ~/project \
     --image kapsis-claude-cli:latest \
     --task "implement feature"
 
@@ -785,14 +785,14 @@ kapsis-launch-agent.log.5    # Oldest (will be deleted on next rotation)
 
 ```bash
 # Enable debug logging for troubleshooting
-KAPSIS_DEBUG=1 ./scripts/launch-agent.sh 1 ~/project --task "test"
+KAPSIS_DEBUG=1 ./scripts/launch-agent.sh ~/project --task "test"
 
 # Debug with custom log directory
 KAPSIS_LOG_LEVEL=DEBUG KAPSIS_LOG_DIR=/tmp/kapsis-debug \
-  ./scripts/launch-agent.sh 1 ~/project --task "test"
+  ./scripts/launch-agent.sh ~/project --task "test"
 
 # Console-only logging (no file)
-KAPSIS_LOG_TO_FILE=false ./scripts/launch-agent.sh 1 ~/project --task "test"
+KAPSIS_LOG_TO_FILE=false ./scripts/launch-agent.sh ~/project --task "test"
 
 # View logs in real-time
 tail -f ~/.kapsis/logs/kapsis-launch-agent.log
@@ -924,7 +924,7 @@ for a in active:
 To disable status reporting entirely:
 
 ```bash
-KAPSIS_STATUS_ENABLED=false ./scripts/launch-agent.sh 1 ~/project --task "test"
+KAPSIS_STATUS_ENABLED=false ./scripts/launch-agent.sh ~/project --task "test"
 ```
 
 ---

--- a/docs/GIT-WORKFLOW.md
+++ b/docs/GIT-WORKFLOW.md
@@ -72,7 +72,7 @@ The git workflow enables AI agents to push changes to branches for PR-based revi
 │  │   # Add: "PR Feedback: Handle null case gracefully"                 │   │
 │  │                                                                     │   │
 │  │   # Re-launch — agent continues from remote branch state!           │   │
-│  │   ./launch-agent.sh 1 ~/project \                                   │   │
+│  │   ./launch-agent.sh ~/project \                                   │   │
 │  │       --branch feature/DEV-123 \                                    │   │
 │  │       --spec ./specs/task.md                                        │   │
 │  │                                                                     │   │
@@ -160,7 +160,7 @@ cat > specs/add-user-endpoint.md << 'EOF'
 EOF
 
 # Launch agent with new branch
-./scripts/launch-agent.sh 1 ~/project \
+./scripts/launch-agent.sh ~/project \
     --branch feature/DEV-123-user-preferences \
     --spec ./specs/add-user-endpoint.md
 ```
@@ -177,7 +177,7 @@ cat >> specs/add-user-endpoint.md << 'EOF'
 EOF
 
 # Re-launch with same branch — continues from remote state
-./scripts/launch-agent.sh 1 ~/project \
+./scripts/launch-agent.sh ~/project \
     --branch feature/DEV-123-user-preferences \
     --spec ./specs/add-user-endpoint.md
 ```
@@ -186,7 +186,7 @@ EOF
 
 ```bash
 # Let Kapsis generate branch name
-./scripts/launch-agent.sh 1 ~/project \
+./scripts/launch-agent.sh ~/project \
     --auto-branch \
     --spec ./specs/fix-tests.md
 
@@ -197,7 +197,7 @@ EOF
 
 ```bash
 # Commit but don't push (for review before push)
-./scripts/launch-agent.sh 1 ~/project \
+./scripts/launch-agent.sh ~/project \
     --branch feature/DEV-123 \
     --no-push \
     --spec ./specs/task.md
@@ -257,17 +257,17 @@ One-line description (used for commit message)
 
 ```bash
 # Run multiple agents on same project, different branches
-./scripts/launch-agent.sh 1 ~/project \
+./scripts/launch-agent.sh ~/project \
     --config configs/claude.yaml \
     --branch feature/DEV-123-backend \
     --spec ./specs/backend.md &
 
-./scripts/launch-agent.sh 2 ~/project \
+./scripts/launch-agent.sh ~/project \
     --config configs/claude.yaml \
     --branch feature/DEV-123-frontend \
     --spec ./specs/frontend.md &
 
-./scripts/launch-agent.sh 3 ~/project \
+./scripts/launch-agent.sh ~/project \
     --config configs/claude.yaml \
     --branch feature/DEV-123-tests \
     --spec ./specs/tests.md &
@@ -338,7 +338,7 @@ Kapsis automatically generates PR/MR URLs for:
 
 ```bash
 # Check SSH key is mounted
-./scripts/launch-agent.sh 1 ~/project --interactive
+./scripts/launch-agent.sh ~/project --interactive
 # Inside container:
 ssh -T git@github.com
 ```
@@ -367,7 +367,7 @@ git checkout feature/DEV-123
 git pull origin feature/DEV-123
 
 # Then launch agent
-./scripts/launch-agent.sh 1 ~/project --branch feature/DEV-123 --spec task.md
+./scripts/launch-agent.sh ~/project --branch feature/DEV-123 --spec task.md
 ```
 
 ### No Changes Detected

--- a/docs/SECURITY-HARDENING.md
+++ b/docs/SECURITY-HARDENING.md
@@ -1,0 +1,1515 @@
+# Kapsis Container Security Hardening Design
+
+## Executive Summary
+
+This document provides a comprehensive container hardening design for the Kapsis AI agent sandbox. The goal is to minimize attack surface, prevent container escape, and limit blast radius if an agent is compromised, while maintaining functionality for AI coding agents.
+
+**Current State Analysis:**
+- Rootless Podman with `--userns=keep-id` (good baseline)
+- Non-root user (developer, UID 1000)
+- Memory/CPU limits configurable
+- NO seccomp profile (all ~300+ syscalls allowed)
+- SELinux/AppArmor disabled (`--security-opt label=disable`)
+- No explicit capability dropping
+- No cgroup v2 hardening beyond memory/CPU
+
+**Target Security Posture:**
+- Defense-in-depth with multiple isolation layers
+- Principle of least privilege for syscalls and capabilities
+- Fail-secure defaults with opt-in relaxation
+- Cross-platform support (macOS Podman Machine, Linux native)
+
+---
+
+## Table of Contents
+
+1. [Seccomp Profile Design](#1-seccomp-profile-design)
+2. [Capability Dropping](#2-capability-dropping)
+3. [Filesystem Hardening](#3-filesystem-hardening)
+4. [Process Isolation](#4-process-isolation)
+5. [Resource Limits](#5-resource-limits)
+6. [AppArmor/SELinux Profiles](#6-apparmorselinux-profiles)
+7. [Implementation Plan](#7-implementation-plan)
+8. [Configuration Reference](#8-configuration-reference)
+9. [Testing Strategy](#9-testing-strategy)
+
+---
+
+## 1. Seccomp Profile Design
+
+### 1.1 Overview
+
+Seccomp (Secure Computing Mode) filters syscalls at the kernel level. By default, Podman uses a permissive profile allowing ~300+ syscalls. We'll create a restrictive profile tailored to AI coding agents.
+
+### 1.2 Base Profile: `kapsis-agent-base.json`
+
+This profile allows syscalls required for:
+- Java/Node.js development (JVM, npm, Maven, Gradle)
+- Git operations (clone, commit, push)
+- Network access (HTTP/HTTPS for AI APIs)
+- File operations (read, write, create)
+
+```json
+{
+  "defaultAction": "SCMP_ACT_ERRNO",
+  "defaultErrnoRet": 1,
+  "archMap": [
+    {
+      "architecture": "SCMP_ARCH_X86_64",
+      "subArchitectures": [
+        "SCMP_ARCH_X86",
+        "SCMP_ARCH_X32"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_AARCH64",
+      "subArchitectures": [
+        "SCMP_ARCH_ARM"
+      ]
+    }
+  ],
+  "syscalls": [
+    {
+      "names": [
+        "accept", "accept4",
+        "access", "faccessat", "faccessat2",
+        "arch_prctl",
+        "bind",
+        "brk",
+        "capget", "capset",
+        "chdir", "fchdir",
+        "chmod", "fchmod", "fchmodat",
+        "chown", "fchown", "fchownat", "lchown",
+        "clock_getres", "clock_gettime", "clock_nanosleep",
+        "clone", "clone3",
+        "close", "close_range",
+        "connect",
+        "copy_file_range",
+        "creat",
+        "dup", "dup2", "dup3",
+        "epoll_create", "epoll_create1", "epoll_ctl", "epoll_pwait", "epoll_wait",
+        "eventfd", "eventfd2",
+        "execve", "execveat",
+        "exit", "exit_group",
+        "fallocate",
+        "fadvise64",
+        "flock",
+        "fork",
+        "fstat", "fstatat64", "fstatfs", "fstatfs64",
+        "fsync", "fdatasync",
+        "ftruncate",
+        "futex", "futex_waitv",
+        "getcwd",
+        "getdents", "getdents64",
+        "getegid", "geteuid", "getgid", "getuid",
+        "getgroups",
+        "getitimer", "setitimer",
+        "getpeername",
+        "getpgid", "getpgrp", "getpid", "getppid",
+        "getrandom",
+        "getresgid", "getresuid",
+        "getrlimit", "setrlimit", "prlimit64",
+        "getsid",
+        "getsockname", "getsockopt",
+        "gettid",
+        "gettimeofday",
+        "getxattr", "fgetxattr", "lgetxattr",
+        "inotify_add_watch", "inotify_init", "inotify_init1", "inotify_rm_watch",
+        "io_cancel", "io_destroy", "io_getevents", "io_setup", "io_submit",
+        "io_uring_enter", "io_uring_register", "io_uring_setup",
+        "ioctl",
+        "kill",
+        "lchown",
+        "link", "linkat",
+        "listen",
+        "lseek", "llseek",
+        "lstat",
+        "madvise",
+        "memfd_create",
+        "mincore",
+        "mkdir", "mkdirat",
+        "mknod", "mknodat",
+        "mlock", "mlock2", "munlock", "mlockall", "munlockall",
+        "mmap", "mmap2",
+        "mprotect",
+        "mremap",
+        "msync",
+        "munmap",
+        "name_to_handle_at",
+        "nanosleep",
+        "newfstatat",
+        "open", "openat", "openat2",
+        "pause",
+        "pipe", "pipe2",
+        "poll", "ppoll",
+        "prctl",
+        "pread64", "preadv", "preadv2",
+        "pwrite64", "pwritev", "pwritev2",
+        "read", "readv",
+        "readahead",
+        "readlink", "readlinkat",
+        "recvfrom", "recvmsg", "recvmmsg",
+        "remap_file_pages",
+        "rename", "renameat", "renameat2",
+        "restart_syscall",
+        "rmdir",
+        "rseq",
+        "rt_sigaction", "rt_sigpending", "rt_sigprocmask", "rt_sigqueueinfo",
+        "rt_sigreturn", "rt_sigsuspend", "rt_sigtimedwait",
+        "sched_getaffinity", "sched_getattr", "sched_getparam", "sched_getscheduler",
+        "sched_setaffinity", "sched_setattr", "sched_setparam", "sched_setscheduler",
+        "sched_get_priority_max", "sched_get_priority_min",
+        "sched_yield",
+        "select", "pselect6",
+        "semctl", "semget", "semop", "semtimedop",
+        "sendfile", "sendfile64",
+        "sendmsg", "sendmmsg", "sendto",
+        "set_robust_list", "get_robust_list",
+        "set_tid_address",
+        "setfsgid", "setfsuid",
+        "setgid", "setgroups",
+        "setns",
+        "setpgid", "setsid",
+        "setresgid", "setresuid",
+        "setsockopt",
+        "setuid",
+        "shmat", "shmctl", "shmdt", "shmget",
+        "shutdown",
+        "sigaltstack",
+        "signalfd", "signalfd4",
+        "socket", "socketpair",
+        "splice",
+        "stat", "statfs", "statx",
+        "symlink", "symlinkat",
+        "sync", "syncfs",
+        "sysinfo",
+        "tee",
+        "tgkill",
+        "time",
+        "timer_create", "timer_delete", "timer_getoverrun", "timer_gettime", "timer_settime",
+        "timerfd_create", "timerfd_gettime", "timerfd_settime",
+        "times",
+        "tkill",
+        "truncate",
+        "umask",
+        "uname",
+        "unlink", "unlinkat",
+        "unshare",
+        "utime", "utimes", "utimensat", "futimesat",
+        "vfork",
+        "wait4", "waitid", "waitpid",
+        "write", "writev"
+      ],
+      "action": "SCMP_ACT_ALLOW"
+    },
+    {
+      "names": ["personality"],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {"index": 0, "value": 0, "op": "SCMP_CMP_EQ"}
+      ]
+    },
+    {
+      "names": ["personality"],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {"index": 0, "value": 8, "op": "SCMP_CMP_EQ"}
+      ]
+    },
+    {
+      "names": ["personality"],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {"index": 0, "value": 131072, "op": "SCMP_CMP_EQ"}
+      ]
+    },
+    {
+      "names": ["personality"],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {"index": 0, "value": 131080, "op": "SCMP_CMP_EQ"}
+      ]
+    },
+    {
+      "names": ["personality"],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {"index": 0, "value": 4294967295, "op": "SCMP_CMP_EQ"}
+      ]
+    }
+  ]
+}
+```
+
+### 1.3 Blocked Syscalls (Security-Critical)
+
+The following syscalls are explicitly blocked by the default-deny policy:
+
+| Syscall | Risk | Notes |
+|---------|------|-------|
+| `ptrace` | Container escape | Process tracing/debugging |
+| `mount`, `umount`, `umount2` | Filesystem manipulation | Already blocked by capability drop |
+| `reboot` | System disruption | Kernel control |
+| `swapon`, `swapoff` | Resource exhaustion | Memory management |
+| `sethostname`, `setdomainname` | Identity spoofing | Network identity |
+| `acct` | Information disclosure | Process accounting |
+| `init_module`, `delete_module` | Kernel modification | Module loading |
+| `kexec_load`, `kexec_file_load` | Kernel replacement | Boot modification |
+| `perf_event_open` | Information disclosure | Performance monitoring |
+| `bpf` | Kernel manipulation | eBPF programs |
+| `userfaultfd` | Container escape vector | Memory fault handling |
+| `lookup_dcookie` | Information disclosure | Kernel data structures |
+| `keyctl` | Credential theft | Kernel keyring |
+| `add_key`, `request_key` | Credential manipulation | Kernel keyring |
+
+### 1.4 Agent-Specific Profiles
+
+#### 1.4.1 Claude CLI Profile (`kapsis-claude.json`)
+
+Claude Code requires Node.js and may spawn subprocesses. Uses base profile with no additions.
+
+```json
+{
+  "extends": "kapsis-agent-base.json",
+  "comment": "Claude Code CLI - Node.js based agent"
+}
+```
+
+#### 1.4.2 Aider Profile (`kapsis-aider.json`)
+
+Aider uses Python and may require additional syscalls for pip operations.
+
+```json
+{
+  "extends": "kapsis-agent-base.json",
+  "syscalls": [
+    {
+      "names": ["flock"],
+      "action": "SCMP_ACT_ALLOW",
+      "comment": "pip file locking"
+    }
+  ]
+}
+```
+
+#### 1.4.3 Interactive/Debug Profile (`kapsis-interactive.json`)
+
+For debugging, allows additional syscalls but still blocks dangerous ones.
+
+```json
+{
+  "extends": "kapsis-agent-base.json",
+  "syscalls": [
+    {
+      "names": ["ptrace"],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {"index": 0, "value": 0, "op": "SCMP_CMP_EQ"},
+        {"comment": "PTRACE_TRACEME only - for strace on self"}
+      ]
+    }
+  ]
+}
+```
+
+### 1.5 macOS vs Linux Considerations
+
+| Platform | Seccomp Support | Implementation |
+|----------|-----------------|----------------|
+| Linux (native) | Full kernel support | Use `--security-opt seccomp=<profile>.json` |
+| macOS (Podman Machine) | Via Linux VM | Same flag, VM kernel applies it |
+
+**macOS Note:** Podman Machine runs a Linux VM, so seccomp profiles work identically. The VM's kernel enforces the seccomp policy.
+
+### 1.6 Profile Loading Implementation
+
+```bash
+# In launch-agent.sh build_container_command()
+SECCOMP_PROFILE="${KAPSIS_ROOT}/security/seccomp/kapsis-agent-base.json"
+
+# Check for agent-specific profile
+if [[ -f "${KAPSIS_ROOT}/security/seccomp/kapsis-${AGENT_NAME}.json" ]]; then
+    SECCOMP_PROFILE="${KAPSIS_ROOT}/security/seccomp/kapsis-${AGENT_NAME}.json"
+fi
+
+CONTAINER_CMD+=(
+    "--security-opt" "seccomp=${SECCOMP_PROFILE}"
+)
+```
+
+---
+
+## 2. Capability Dropping
+
+### 2.1 Current State
+
+Currently, Kapsis does not explicitly drop capabilities. Rootless Podman provides some protection, but the container still inherits capabilities from the non-root user namespace.
+
+### 2.2 Capability Analysis
+
+#### 2.2.1 Capabilities to Drop (All Unnecessary)
+
+| Capability | Risk | Drop? |
+|------------|------|-------|
+| `CAP_AUDIT_CONTROL` | Audit manipulation | YES |
+| `CAP_AUDIT_READ` | Information disclosure | YES |
+| `CAP_AUDIT_WRITE` | Audit tampering | YES |
+| `CAP_BLOCK_SUSPEND` | Denial of service | YES |
+| `CAP_BPF` | Kernel manipulation | YES |
+| `CAP_CHECKPOINT_RESTORE` | Container escape | YES |
+| `CAP_DAC_READ_SEARCH` | File access bypass | YES |
+| `CAP_IPC_LOCK` | Resource exhaustion | YES |
+| `CAP_IPC_OWNER` | IPC manipulation | YES |
+| `CAP_KILL` | Process termination | KEEP (for signal handling) |
+| `CAP_LEASE` | File lease manipulation | YES |
+| `CAP_LINUX_IMMUTABLE` | File attribute manipulation | YES |
+| `CAP_MAC_ADMIN` | MAC policy bypass | YES |
+| `CAP_MAC_OVERRIDE` | MAC policy bypass | YES |
+| `CAP_MKNOD` | Device creation | YES |
+| `CAP_NET_ADMIN` | Network configuration | YES |
+| `CAP_NET_BIND_SERVICE` | Privileged ports | YES |
+| `CAP_NET_BROADCAST` | Network broadcast | YES |
+| `CAP_NET_RAW` | Raw sockets | YES |
+| `CAP_PERFMON` | Performance monitoring | YES |
+| `CAP_SETFCAP` | Capability setting | YES |
+| `CAP_SETPCAP` | Capability modification | YES |
+| `CAP_SYS_ADMIN` | Container escape vector | YES |
+| `CAP_SYS_BOOT` | System reboot | YES |
+| `CAP_SYS_CHROOT` | Chroot manipulation | YES |
+| `CAP_SYS_MODULE` | Kernel modules | YES |
+| `CAP_SYS_NICE` | Process scheduling | KEEP (for Maven/Gradle) |
+| `CAP_SYS_PACCT` | Process accounting | YES |
+| `CAP_SYS_PTRACE` | Process tracing | YES |
+| `CAP_SYS_RAWIO` | Raw I/O access | YES |
+| `CAP_SYS_RESOURCE` | Resource limits bypass | YES |
+| `CAP_SYS_TIME` | System time modification | YES |
+| `CAP_SYS_TTY_CONFIG` | TTY configuration | YES |
+| `CAP_SYSLOG` | Syslog access | YES |
+| `CAP_WAKE_ALARM` | Wake alarms | YES |
+
+#### 2.2.2 Capabilities to Keep (Minimal Set)
+
+| Capability | Reason |
+|------------|--------|
+| `CAP_CHOWN` | File ownership (build artifacts) |
+| `CAP_DAC_OVERRIDE` | File permission bypass (limited) |
+| `CAP_FOWNER` | File owner operations |
+| `CAP_FSETID` | Set-ID bits on files |
+| `CAP_KILL` | Signal handling (process management) |
+| `CAP_SETGID` | Group ID changes |
+| `CAP_SETUID` | User ID changes |
+| `CAP_SETPCAP` | Remove to prevent escalation |
+| `CAP_SYS_NICE` | Process priority (build tools) |
+
+### 2.3 Implementation
+
+```bash
+# In launch-agent.sh build_container_command()
+CONTAINER_CMD+=(
+    "--cap-drop=ALL"
+    "--cap-add=CHOWN"
+    "--cap-add=DAC_OVERRIDE"
+    "--cap-add=FOWNER"
+    "--cap-add=FSETID"
+    "--cap-add=KILL"
+    "--cap-add=SETGID"
+    "--cap-add=SETUID"
+    "--cap-add=SYS_NICE"
+)
+```
+
+### 2.4 Configuration Option
+
+Add to `CONFIG-REFERENCE.md`:
+
+```yaml
+security:
+  # Capability management
+  capabilities:
+    # Drop all capabilities and add back only those needed
+    # Default: true (recommended)
+    drop_all: true
+
+    # Additional capabilities to add (use sparingly)
+    # These are added on top of the minimal set
+    add: []
+
+    # Capabilities to explicitly drop (in addition to drop_all)
+    drop: []
+```
+
+---
+
+## 3. Filesystem Hardening
+
+### 3.1 Read-Only Root Filesystem
+
+Make the container root filesystem read-only, with explicit writable paths.
+
+#### 3.1.1 Implementation
+
+```bash
+# In launch-agent.sh build_container_command()
+if [[ "${KAPSIS_READONLY_ROOT:-false}" == "true" ]]; then
+    CONTAINER_CMD+=(
+        "--read-only"
+        "--tmpfs=/tmp:rw,noexec,nosuid,size=1g"
+        "--tmpfs=/run:rw,noexec,nosuid,size=100m"
+        "--tmpfs=/var/tmp:rw,noexec,nosuid,size=500m"
+    )
+fi
+```
+
+#### 3.1.2 Required Writable Paths
+
+| Path | Purpose | Mount Type |
+|------|---------|------------|
+| `/workspace` | Project files | Volume (worktree or overlay) |
+| `/home/developer` | User home | tmpfs or volume |
+| `/home/developer/.m2/repository` | Maven cache | Named volume |
+| `/home/developer/.gradle` | Gradle cache | Named volume |
+| `/tmp` | Temporary files | tmpfs |
+| `/run` | Runtime files | tmpfs |
+| `/var/tmp` | Persistent temp | tmpfs |
+| `/kapsis-status` | Status reporting | Bind mount |
+
+### 3.2 Mount Options
+
+Apply security mount options to all volumes:
+
+| Option | Purpose | Apply To |
+|--------|---------|----------|
+| `noexec` | Prevent execution | `/tmp`, `/var/tmp`, config mounts |
+| `nosuid` | Prevent setuid | All mounts except `/workspace` |
+| `nodev` | Prevent device files | All mounts |
+
+#### 3.2.1 Implementation
+
+```bash
+# In generate_volume_mounts_worktree()
+
+# Status directory with security options
+VOLUME_MOUNTS+=("-v" "${status_dir}:/kapsis-status:noexec,nosuid,nodev")
+
+# Config files (read-only with noexec)
+# Already :ro, add noexec
+VOLUME_MOUNTS+=("-v" "${expanded_path}:${staging_path}:ro,noexec,nosuid,nodev")
+
+# Git objects (read-only)
+VOLUME_MOUNTS+=("-v" "${OBJECTS_PATH}:${CONTAINER_OBJECTS_PATH}:ro,noexec,nosuid,nodev")
+```
+
+### 3.3 Workspace Protection
+
+The `/workspace` mount needs special handling:
+
+```bash
+# Workspace needs exec for build tools, but apply other restrictions
+VOLUME_MOUNTS+=("-v" "${WORKTREE_PATH}:/workspace:nosuid,nodev")
+```
+
+### 3.4 Temporary Directory Hardening
+
+```bash
+# Add tmpfs mounts with size limits and noexec
+CONTAINER_CMD+=(
+    "--tmpfs=/tmp:rw,noexec,nosuid,nodev,size=${KAPSIS_TMP_SIZE:-1g}"
+    "--tmpfs=/var/tmp:rw,noexec,nosuid,nodev,size=${KAPSIS_VARTMP_SIZE:-500m}"
+)
+```
+
+### 3.5 Configuration Options
+
+```yaml
+security:
+  filesystem:
+    # Read-only root filesystem
+    # Default: false (enable when stable)
+    readonly_root: false
+
+    # Temporary directory size limits
+    tmp_size: 1g
+    var_tmp_size: 500m
+
+    # Apply noexec to config mounts
+    # Default: true
+    noexec_configs: true
+
+    # Apply noexec to temp directories
+    # Default: true (recommended)
+    noexec_tmp: true
+```
+
+---
+
+## 4. Process Isolation
+
+### 4.1 PID Namespace Isolation
+
+Podman already uses PID namespace isolation by default. Verify and enforce:
+
+```bash
+# In build_container_command()
+# Ensure PID namespace isolation (default, but explicit)
+CONTAINER_CMD+=(
+    "--pid=private"
+)
+```
+
+### 4.2 Process Count Limits
+
+Prevent fork bombs and runaway process creation:
+
+```bash
+# In build_container_command()
+PROCESS_LIMIT="${KAPSIS_PIDS_LIMIT:-1000}"
+CONTAINER_CMD+=(
+    "--pids-limit=${PROCESS_LIMIT}"
+)
+```
+
+**Recommended limits by agent type:**
+
+| Agent Type | PID Limit | Rationale |
+|------------|-----------|-----------|
+| claude | 500 | Node.js, moderate subprocess needs |
+| codex | 500 | Similar to Claude |
+| aider | 300 | Python, fewer subprocesses |
+| interactive | 1000 | Debugging flexibility |
+| java-build | 2000 | Maven/Gradle parallel builds |
+
+### 4.3 No New Privileges Flag
+
+Prevent privilege escalation via setuid binaries:
+
+```bash
+# In build_container_command()
+CONTAINER_CMD+=(
+    "--security-opt" "no-new-privileges:true"
+)
+```
+
+This blocks:
+- Setuid/setgid binary execution
+- Capability escalation
+- LSM (SELinux/AppArmor) transitions
+
+### 4.4 User Namespace Enforcement
+
+Ensure user namespace mapping is always enabled:
+
+```bash
+# Already using --userns=keep-id, but verify
+CONTAINER_CMD+=(
+    "--userns=keep-id"
+)
+```
+
+### 4.5 Network Namespace Options
+
+```bash
+# Default: connected to podman network (needed for AI APIs)
+# Option to restrict to localhost only
+if [[ "${KAPSIS_NETWORK_MODE:-bridge}" == "none" ]]; then
+    CONTAINER_CMD+=("--network=none")
+elif [[ "${KAPSIS_NETWORK_MODE:-bridge}" == "host" ]]; then
+    # NOT RECOMMENDED - only for debugging
+    log_warn "Using host network mode - reduced isolation"
+    CONTAINER_CMD+=("--network=host")
+fi
+```
+
+### 4.6 Configuration Options
+
+```yaml
+security:
+  process:
+    # Maximum number of processes in container
+    # Default: 1000
+    pids_limit: 1000
+
+    # Prevent privilege escalation
+    # Default: true (recommended)
+    no_new_privileges: true
+
+    # Network isolation mode
+    # Options: bridge (default), none, host
+    network_mode: bridge
+```
+
+---
+
+## 5. Resource Limits
+
+### 5.1 Current Limits
+
+Currently implemented:
+- Memory: `--memory=${RESOURCE_MEMORY}` (default: 8g)
+- CPU: `--cpus=${RESOURCE_CPUS}` (default: 4)
+
+### 5.2 Additional Limits
+
+#### 5.2.1 Disk Space Quota
+
+Podman doesn't have native disk quotas, but we can use volume size limits:
+
+```bash
+# For tmpfs mounts (already covered)
+--tmpfs=/tmp:size=1g
+
+# For named volumes (overlay storage driver limit)
+# Note: Requires overlay storage driver with size option
+# This may not work on all backends
+```
+
+**Alternative: Pre-check available space**
+
+```bash
+# In validate_inputs()
+check_disk_space() {
+    local required_mb="${KAPSIS_DISK_REQUIRED_MB:-5000}"  # 5GB default
+    local available_mb
+    available_mb=$(df -m "${SANDBOX_UPPER_BASE:-$HOME}" | tail -1 | awk '{print $4}')
+
+    if [[ "$available_mb" -lt "$required_mb" ]]; then
+        log_error "Insufficient disk space: ${available_mb}MB available, ${required_mb}MB required"
+        exit 1
+    fi
+}
+```
+
+#### 5.2.2 File Descriptor Limits
+
+```bash
+# In build_container_command()
+FD_LIMIT="${KAPSIS_ULIMIT_NOFILE:-65536}"
+CONTAINER_CMD+=(
+    "--ulimit" "nofile=${FD_LIMIT}:${FD_LIMIT}"
+)
+```
+
+#### 5.2.3 Memory Limits (Enhanced)
+
+```bash
+# Soft limit (can exceed temporarily)
+CONTAINER_CMD+=("--memory=${RESOURCE_MEMORY}")
+
+# Hard limit (OOM kill)
+CONTAINER_CMD+=("--memory-swap=${RESOURCE_MEMORY}")
+
+# Memory reservation (soft guarantee)
+MEMORY_RESERVATION="${KAPSIS_MEMORY_RESERVATION:-2g}"
+CONTAINER_CMD+=("--memory-reservation=${MEMORY_RESERVATION}")
+
+# OOM score adjustment (prefer killing container over host processes)
+CONTAINER_CMD+=("--oom-score-adj=500")
+```
+
+#### 5.2.4 CPU Limits (Enhanced)
+
+```bash
+# CPU quota (hard limit)
+CONTAINER_CMD+=("--cpus=${RESOURCE_CPUS}")
+
+# CPU shares (soft limit for scheduling)
+CPU_SHARES="${KAPSIS_CPU_SHARES:-1024}"
+CONTAINER_CMD+=("--cpu-shares=${CPU_SHARES}")
+
+# CPU period (for burst limiting)
+if [[ -n "${KAPSIS_CPU_PERIOD:-}" ]]; then
+    CONTAINER_CMD+=("--cpu-period=${KAPSIS_CPU_PERIOD}")
+fi
+```
+
+#### 5.2.5 Operation Timeouts
+
+Implement at the launch script level:
+
+```bash
+# In main(), wrap container run with timeout
+CONTAINER_TIMEOUT="${KAPSIS_TIMEOUT:-7200}"  # 2 hours default
+
+if [[ -n "$CONTAINER_TIMEOUT" ]] && [[ "$CONTAINER_TIMEOUT" -gt 0 ]]; then
+    log_info "Container timeout: ${CONTAINER_TIMEOUT}s"
+    timeout --signal=TERM --kill-after=60 "${CONTAINER_TIMEOUT}" \
+        "${CONTAINER_CMD[@]}" || {
+            EXIT_CODE=$?
+            if [[ $EXIT_CODE -eq 124 ]]; then
+                log_error "Container timed out after ${CONTAINER_TIMEOUT}s"
+                status_complete $EXIT_CODE "Container timeout"
+            fi
+        }
+else
+    "${CONTAINER_CMD[@]}"
+fi
+```
+
+### 5.3 Configuration Options
+
+```yaml
+resources:
+  # Memory configuration
+  memory: 8g
+  memory_swap: 8g           # Equal to memory = no swap
+  memory_reservation: 2g    # Soft guarantee
+
+  # CPU configuration
+  cpus: 4
+  cpu_shares: 1024          # Relative weight
+
+  # Process limits
+  pids_limit: 1000
+
+  # File descriptor limits
+  ulimit_nofile: 65536
+
+  # Timeout (seconds, 0 = unlimited)
+  timeout: 7200
+
+  # Disk space requirements (MB)
+  disk_required: 5000
+```
+
+---
+
+## 6. AppArmor/SELinux Profiles
+
+### 6.1 Current State
+
+SELinux/AppArmor is disabled (`--security-opt label=disable`) for overlay filesystem compatibility.
+
+### 6.2 Challenge: Overlay Filesystem
+
+The fuse-overlayfs used for Copy-on-Write requires:
+- FUSE device access
+- Mount syscalls within the container
+- Specific SELinux contexts for layered filesystems
+
+### 6.3 AppArmor Profile Design (Linux)
+
+Create `/etc/apparmor.d/kapsis-agent`:
+
+```apparmor
+#include <tunables/global>
+
+profile kapsis-agent flags=(attach_disconnected,mediate_deleted) {
+  #include <abstractions/base>
+  #include <abstractions/nameservice>
+  #include <abstractions/ssl_certs>
+
+  # Deny dangerous operations
+  deny @{PROC}/sys/kernel/[^c]* wklx,
+  deny @{PROC}/sys/kernel/core_pattern w,
+  deny @{PROC}/sys/fs/** wklx,
+  deny @{PROC}/sys/vm/** wklx,
+  deny @{PROC}/sysrq-trigger rwklx,
+  deny @{PROC}/kcore rwklx,
+  deny mount,
+  deny umount,
+  deny ptrace,
+
+  # Allow standard development operations
+  /workspace/** rwkl,
+  /home/developer/** rwkl,
+  /tmp/** rwk,
+  /var/tmp/** rwk,
+
+  # Maven/Gradle caches
+  /home/developer/.m2/** rwkl,
+  /home/developer/.gradle/** rwkl,
+
+  # Node.js
+  /opt/nvm/** rix,
+
+  # Java
+  /opt/sdkman/** rix,
+
+  # Git operations
+  /usr/bin/git rix,
+  /usr/lib/git-core/** rix,
+
+  # Network access (for AI APIs)
+  network inet tcp,
+  network inet6 tcp,
+  network inet udp,
+  network inet6 udp,
+
+  # Capabilities
+  capability chown,
+  capability dac_override,
+  capability fowner,
+  capability fsetid,
+  capability kill,
+  capability setgid,
+  capability setuid,
+  capability sys_nice,
+}
+```
+
+### 6.4 SELinux Policy Design (RHEL/CentOS)
+
+Create `kapsis-agent.te`:
+
+```selinux
+policy_module(kapsis_agent, 1.0)
+
+require {
+    type container_t;
+    type container_file_t;
+}
+
+# Define kapsis-specific type
+type kapsis_agent_t;
+type kapsis_agent_file_t;
+
+# Inherit from container types
+container_domain_template(kapsis_agent)
+
+# Allow file operations on workspace
+allow kapsis_agent_t kapsis_agent_file_t:file { read write create unlink };
+allow kapsis_agent_t kapsis_agent_file_t:dir { read write create search };
+
+# Network access for AI APIs
+allow kapsis_agent_t self:tcp_socket { create connect };
+allow kapsis_agent_t self:udp_socket { create };
+
+# Deny dangerous operations
+dontaudit kapsis_agent_t self:capability sys_admin;
+dontaudit kapsis_agent_t self:capability sys_ptrace;
+```
+
+### 6.5 Implementation Strategy
+
+```bash
+# In build_container_command()
+
+detect_lsm() {
+    # Check which LSM is active
+    if command -v aa-status &>/dev/null && aa-status &>/dev/null 2>&1; then
+        echo "apparmor"
+    elif command -v getenforce &>/dev/null && [[ "$(getenforce 2>/dev/null)" != "Disabled" ]]; then
+        echo "selinux"
+    else
+        echo "none"
+    fi
+}
+
+LSM_TYPE=$(detect_lsm)
+
+case "$LSM_TYPE" in
+    apparmor)
+        if [[ -f "/etc/apparmor.d/kapsis-agent" ]]; then
+            CONTAINER_CMD+=("--security-opt" "apparmor=kapsis-agent")
+        else
+            log_warn "AppArmor active but kapsis-agent profile not installed"
+            CONTAINER_CMD+=("--security-opt" "label=disable")
+        fi
+        ;;
+    selinux)
+        if semodule -l | grep -q kapsis_agent; then
+            CONTAINER_CMD+=("--security-opt" "label=type:kapsis_agent_t")
+        else
+            log_warn "SELinux active but kapsis_agent policy not installed"
+            CONTAINER_CMD+=("--security-opt" "label=disable")
+        fi
+        ;;
+    none)
+        CONTAINER_CMD+=("--security-opt" "label=disable")
+        ;;
+esac
+```
+
+### 6.6 Fallback Behavior
+
+When LSM profiles are not available:
+1. Log a warning
+2. Disable LSM labeling (`label=disable`)
+3. Rely on other hardening layers (seccomp, capabilities, namespaces)
+
+### 6.7 Configuration Options
+
+```yaml
+security:
+  lsm:
+    # AppArmor/SELinux profile management
+    # Options: auto, apparmor, selinux, disabled
+    # Default: auto (detect and use if available)
+    mode: auto
+
+    # Custom profile name (if using custom profile)
+    profile: kapsis-agent
+
+    # Fail if profile not found (vs. fallback to disabled)
+    # Default: false
+    require_profile: false
+```
+
+---
+
+## 7. Implementation Plan
+
+### 7.1 Phase 1: Core Hardening (Low Risk)
+
+**Timeline: 1-2 weeks**
+
+1. **Capability dropping**
+   - Add `--cap-drop=ALL` with minimal capability set
+   - Test all agent types
+   - Document any capability requirements per agent
+
+2. **No-new-privileges flag**
+   - Add `--security-opt no-new-privileges:true`
+   - Verify no setuid binaries are needed
+
+3. **Process limits**
+   - Add `--pids-limit` with sensible defaults
+   - Add file descriptor limits
+
+### 7.2 Phase 2: Seccomp Profiles (Medium Risk)
+
+**Timeline: 2-3 weeks**
+
+1. **Create base seccomp profile**
+   - Start with default Podman profile
+   - Remove dangerous syscalls
+   - Test extensively with all agent types
+
+2. **Agent-specific profiles**
+   - Profile Claude CLI
+   - Profile Aider
+   - Profile interactive mode
+
+3. **Add profile loading to launch-agent.sh**
+
+### 7.3 Phase 3: Filesystem Hardening (Medium Risk)
+
+**Timeline: 2-3 weeks**
+
+1. **Mount options**
+   - Add noexec/nosuid/nodev where safe
+   - Test Maven/Gradle builds
+
+2. **Read-only root (optional)**
+   - Implement as opt-in feature
+   - Ensure all writable paths are mounted
+
+### 7.4 Phase 4: LSM Profiles (Higher Risk)
+
+**Timeline: 3-4 weeks**
+
+1. **AppArmor profile**
+   - Develop and test profile
+   - Document installation
+   - Implement auto-detection
+
+2. **SELinux policy**
+   - Develop and test policy
+   - Document installation
+   - Implement auto-detection
+
+### 7.5 File Structure
+
+```
+kapsis/
+├── security/
+│   ├── seccomp/
+│   │   ├── kapsis-agent-base.json
+│   │   ├── kapsis-claude.json
+│   │   ├── kapsis-aider.json
+│   │   └── kapsis-interactive.json
+│   ├── apparmor/
+│   │   └── kapsis-agent
+│   ├── selinux/
+│   │   ├── kapsis-agent.te
+│   │   └── kapsis-agent.fc
+│   └── README.md
+├── scripts/
+│   └── lib/
+│       └── security.sh      # Security helper functions
+└── docs/
+    └── SECURITY-HARDENING.md  # This document
+```
+
+---
+
+## 8. Configuration Reference
+
+### 8.1 Full Security Configuration
+
+Add to `agent-sandbox.yaml`:
+
+```yaml
+#===============================================================================
+# SECURITY HARDENING
+#===============================================================================
+security:
+  # Security profile level
+  # Options: minimal, standard (default), strict, paranoid
+  profile: standard
+
+  # Seccomp configuration
+  seccomp:
+    # Enable seccomp filtering
+    # Default: true
+    enabled: true
+
+    # Profile to use
+    # Options: kapsis-agent-base, kapsis-<agent>, custom
+    profile: kapsis-agent-base
+
+    # Custom profile path (if profile: custom)
+    custom_profile: ""
+
+  # Capability configuration
+  capabilities:
+    # Drop all capabilities except minimal set
+    # Default: true
+    drop_all: true
+
+    # Additional capabilities to add
+    add: []
+
+    # Additional capabilities to drop
+    drop: []
+
+  # Filesystem hardening
+  filesystem:
+    # Read-only root filesystem
+    # Default: false
+    readonly_root: false
+
+    # Apply noexec to temporary directories
+    # Default: true
+    noexec_tmp: true
+
+    # Apply noexec to config mounts
+    # Default: true
+    noexec_configs: true
+
+    # Temp directory sizes
+    tmp_size: 1g
+    var_tmp_size: 500m
+
+  # Process isolation
+  process:
+    # Maximum number of processes
+    # Default: 1000
+    pids_limit: 1000
+
+    # Prevent privilege escalation
+    # Default: true
+    no_new_privileges: true
+
+    # User namespace mode
+    # Default: keep-id
+    userns: keep-id
+
+  # Linux Security Module configuration
+  lsm:
+    # Mode: auto, apparmor, selinux, disabled
+    # Default: auto
+    mode: auto
+
+    # Custom profile name
+    profile: kapsis-agent
+
+    # Fail if profile not available
+    # Default: false
+    require_profile: false
+
+  # Network isolation
+  network:
+    # Network mode: bridge, none, host
+    # Default: bridge
+    mode: bridge
+
+    # Allow external DNS
+    # Default: true
+    allow_dns: true
+```
+
+### 8.2 Security Profiles
+
+Pre-defined security profiles for convenience:
+
+| Profile | Description | Use Case |
+|---------|-------------|----------|
+| `minimal` | Only userns + basic limits | Development/testing |
+| `standard` | Capabilities + no-new-privs + limits | Production default |
+| `strict` | Standard + seccomp + noexec | High security |
+| `paranoid` | Strict + readonly root + LSM | Maximum security |
+
+#### Profile Definitions
+
+```yaml
+# security-profiles.yaml (internal)
+profiles:
+  minimal:
+    capabilities.drop_all: false
+    process.no_new_privileges: false
+    seccomp.enabled: false
+
+  standard:
+    capabilities.drop_all: true
+    process.no_new_privileges: true
+    process.pids_limit: 1000
+    seccomp.enabled: false
+
+  strict:
+    capabilities.drop_all: true
+    process.no_new_privileges: true
+    process.pids_limit: 500
+    seccomp.enabled: true
+    seccomp.profile: kapsis-agent-base
+    filesystem.noexec_tmp: true
+    filesystem.noexec_configs: true
+
+  paranoid:
+    capabilities.drop_all: true
+    process.no_new_privileges: true
+    process.pids_limit: 300
+    seccomp.enabled: true
+    seccomp.profile: kapsis-agent-base
+    filesystem.readonly_root: true
+    filesystem.noexec_tmp: true
+    filesystem.noexec_configs: true
+    lsm.mode: auto
+    lsm.require_profile: true
+```
+
+---
+
+## 9. Testing Strategy
+
+### 9.1 Unit Tests
+
+Add to `tests/`:
+
+#### 9.1.1 `test-security-capabilities.sh`
+
+```bash
+#!/usr/bin/env bash
+# Test: Security - Capabilities
+
+test_capabilities_dropped() {
+    log_test "Testing dangerous capabilities are dropped"
+
+    setup_container_test "sec-caps"
+
+    # Check capabilities
+    local output
+    output=$(run_in_container "cat /proc/self/status | grep CapEff")
+
+    cleanup_container_test
+
+    # CapEff should not contain dangerous capabilities
+    # CAP_SYS_ADMIN (21) should be missing
+    local cap_hex
+    cap_hex=$(echo "$output" | awk '{print $2}')
+
+    # Check bit 21 (SYS_ADMIN) is not set
+    # Full capabilities would be 0000003fffffffff
+    if [[ "$cap_hex" != *"ffffffff"* ]]; then
+        return 0
+    else
+        log_fail "Capabilities not properly dropped"
+        return 1
+    fi
+}
+```
+
+#### 9.1.2 `test-security-seccomp.sh`
+
+```bash
+#!/usr/bin/env bash
+# Test: Security - Seccomp
+
+test_seccomp_blocks_ptrace() {
+    log_test "Testing seccomp blocks ptrace"
+
+    setup_container_test "sec-seccomp"
+
+    # Try to use ptrace (should fail)
+    local exit_code=0
+    run_in_container "strace ls 2>&1" || exit_code=$?
+
+    cleanup_container_test
+
+    # Should fail with EPERM or similar
+    if [[ $exit_code -ne 0 ]]; then
+        return 0
+    else
+        log_fail "ptrace should be blocked by seccomp"
+        return 1
+    fi
+}
+
+test_seccomp_allows_build() {
+    log_test "Testing seccomp allows Maven build"
+
+    setup_container_test "sec-seccomp-build"
+
+    # Run a simple Maven command
+    local exit_code=0
+    run_in_container "mvn -v" || exit_code=$?
+
+    cleanup_container_test
+
+    assert_equals "0" "$exit_code" "Maven should work with seccomp"
+}
+```
+
+#### 9.1.3 `test-security-filesystem.sh`
+
+```bash
+#!/usr/bin/env bash
+# Test: Security - Filesystem Hardening
+
+test_tmp_noexec() {
+    log_test "Testing /tmp has noexec"
+
+    setup_container_test "sec-fs-noexec"
+
+    # Try to execute from /tmp (should fail if noexec)
+    local exit_code=0
+    run_in_container "cp /bin/ls /tmp/test_ls && chmod +x /tmp/test_ls && /tmp/test_ls" \
+        || exit_code=$?
+
+    cleanup_container_test
+
+    # With noexec, execution should fail
+    if [[ $exit_code -ne 0 ]]; then
+        return 0
+    else
+        # noexec might not be enabled, check mount options
+        log_info "noexec not enforced on /tmp (may be configuration)"
+        return 0  # Not a hard failure
+    fi
+}
+
+test_workspace_exec_allowed() {
+    log_test "Testing /workspace allows execution"
+
+    setup_container_test "sec-fs-exec"
+
+    # Execution from workspace should work (needed for builds)
+    local exit_code=0
+    run_in_container "echo '#!/bin/bash\necho test' > /workspace/test.sh && \
+        chmod +x /workspace/test.sh && /workspace/test.sh" || exit_code=$?
+
+    cleanup_container_test
+
+    assert_equals "0" "$exit_code" "Workspace should allow script execution"
+}
+```
+
+### 9.2 Integration Tests
+
+#### 9.2.1 Full Build Test
+
+Test that hardening doesn't break real-world builds:
+
+```bash
+#!/usr/bin/env bash
+# test-security-integration.sh
+
+test_maven_build_with_hardening() {
+    log_test "Testing Maven build with security hardening"
+
+    # Run actual Maven build with hardening enabled
+    KAPSIS_SECURITY_PROFILE=strict \
+        ./scripts/launch-agent.sh test-sec ~/projects/sample-java \
+        --task "mvn clean compile" \
+        --dry-run=false
+
+    assert_equals "0" "$?" "Maven build should succeed with hardening"
+}
+
+test_claude_agent_with_hardening() {
+    log_test "Testing Claude agent with security hardening"
+
+    # Run Claude with hardening (mock API)
+    KAPSIS_SECURITY_PROFILE=strict \
+    ANTHROPIC_API_KEY="test-key" \
+        ./scripts/launch-agent.sh test-sec ~/projects/sample \
+        --agent claude \
+        --task "echo test" \
+        --dry-run=false
+
+    # Should at least start without seccomp/capability errors
+    assert_not_equals "125" "$?" "Container should start with hardening"
+}
+```
+
+### 9.3 Syscall Audit Mode
+
+For development, add a syscall logging mode:
+
+```bash
+# In build_container_command()
+if [[ "${KAPSIS_SECCOMP_AUDIT:-false}" == "true" ]]; then
+    # Use audit profile that logs instead of blocking
+    SECCOMP_PROFILE="${KAPSIS_ROOT}/security/seccomp/kapsis-audit.json"
+    log_warn "Seccomp audit mode - syscalls are logged, not blocked"
+fi
+```
+
+Create `kapsis-audit.json`:
+
+```json
+{
+  "defaultAction": "SCMP_ACT_LOG",
+  "syscalls": []
+}
+```
+
+This logs all syscalls without blocking, useful for identifying what syscalls agents actually need.
+
+### 9.4 Test Matrix
+
+| Test | Linux Native | macOS Podman | CI (Linux) |
+|------|--------------|--------------|------------|
+| Capability drop | Yes | Yes | Yes |
+| Seccomp base | Yes | Yes | Yes |
+| No-new-privileges | Yes | Yes | Yes |
+| PID limits | Yes | Yes | Yes |
+| AppArmor | Ubuntu only | N/A | GitHub Actions |
+| SELinux | RHEL/Fedora | N/A | No |
+| Read-only root | Yes | Yes | Yes |
+| noexec mounts | Yes | Yes* | Yes |
+
+\* macOS Podman Machine may have limitations with mount options.
+
+---
+
+## 10. Migration Guide
+
+### 10.1 Existing Deployments
+
+For users upgrading from unhardened Kapsis:
+
+1. **Phase 1 (Safe)**
+   - Update to new version
+   - Default profile is `standard` (capabilities + no-new-privs)
+   - No seccomp by default
+
+2. **Phase 2 (Test)**
+   - Enable seccomp in test environment:
+     ```yaml
+     security:
+       profile: strict
+     ```
+   - Run full test suite
+
+3. **Phase 3 (Production)**
+   - Roll out `strict` profile
+   - Monitor for issues
+   - Adjust as needed
+
+### 10.2 Troubleshooting
+
+Common issues after enabling hardening:
+
+| Symptom | Likely Cause | Solution |
+|---------|--------------|----------|
+| "Operation not permitted" | Seccomp blocking syscall | Add syscall to profile |
+| "Permission denied" on build | Capability missing | Add required capability |
+| Scripts fail in /tmp | noexec mount | Move scripts to /workspace |
+| Network timeout | Network namespace | Check network mode |
+| Agent crashes on start | Seccomp profile issue | Enable audit mode |
+
+### 10.3 Debugging Commands
+
+```bash
+# Check what capabilities container has
+podman run --rm kapsis-sandbox:latest cat /proc/self/status | grep Cap
+
+# Check seccomp status
+podman run --rm kapsis-sandbox:latest grep Seccomp /proc/self/status
+
+# Check mount options
+podman run --rm kapsis-sandbox:latest mount | grep workspace
+
+# Run with syscall audit
+KAPSIS_SECCOMP_AUDIT=true ./scripts/launch-agent.sh ...
+```
+
+---
+
+## Appendix A: Syscall Reference
+
+### A.1 Syscalls Required by Agent Type
+
+| Syscall | Claude | Aider | Maven | Git | Notes |
+|---------|--------|-------|-------|-----|-------|
+| `clone`/`clone3` | Yes | Yes | Yes | No | Process creation |
+| `execve` | Yes | Yes | Yes | Yes | Program execution |
+| `socket` | Yes | Yes | Yes | Yes | Network/IPC |
+| `connect` | Yes | Yes | Yes | Yes | Network connections |
+| `mmap` | Yes | Yes | Yes | Yes | Memory mapping |
+| `futex` | Yes | Yes | Yes | Yes | Thread synchronization |
+| `epoll_*` | Yes | Yes | No | No | Event polling (Node.js) |
+| `io_uring_*` | No | No | Yes | No | Modern I/O (Java 21+) |
+
+### A.2 Syscalls Blocked for Security
+
+| Syscall | Risk Level | Blocked By |
+|---------|------------|------------|
+| `ptrace` | Critical | Seccomp profile |
+| `mount` | Critical | Capability + seccomp |
+| `bpf` | Critical | Seccomp profile |
+| `userfaultfd` | High | Seccomp profile |
+| `keyctl` | High | Seccomp profile |
+| `kexec_load` | Critical | Seccomp profile |
+| `init_module` | Critical | Seccomp profile |
+| `reboot` | Critical | Capability + seccomp |
+
+---
+
+## Appendix B: Quick Reference
+
+### B.1 Podman Security Flags Summary
+
+```bash
+podman run \
+    --rm -it \
+    --userns=keep-id \
+    --cap-drop=ALL \
+    --cap-add=CHOWN,DAC_OVERRIDE,FOWNER,FSETID,KILL,SETGID,SETUID,SYS_NICE \
+    --security-opt no-new-privileges:true \
+    --security-opt seccomp=/path/to/kapsis-agent-base.json \
+    --pids-limit=1000 \
+    --memory=8g \
+    --memory-swap=8g \
+    --cpus=4 \
+    --ulimit nofile=65536:65536 \
+    --tmpfs /tmp:rw,noexec,nosuid,nodev,size=1g \
+    kapsis-sandbox:latest
+```
+
+### B.2 Configuration Quick Start
+
+```yaml
+# Recommended production configuration
+security:
+  profile: strict
+  seccomp:
+    enabled: true
+    profile: kapsis-agent-base
+  capabilities:
+    drop_all: true
+  process:
+    pids_limit: 1000
+    no_new_privileges: true
+  filesystem:
+    noexec_tmp: true
+    noexec_configs: true
+```
+
+---
+
+## Document History
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0 | 2025-12-28 | SRE Team | Initial design document |

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -48,13 +48,13 @@ source ~/.zshrc
 
 ```bash
 # Interactive shell in sandbox
-./scripts/launch-agent.sh 1 ~/your-project
+./scripts/launch-agent.sh ~/your-project
 
 # With git branch (recommended)
-./scripts/launch-agent.sh 1 ~/your-project --branch feature/test
+./scripts/launch-agent.sh ~/your-project --branch feature/test
 
 # With task specification
-./scripts/launch-agent.sh 1 ~/your-project --branch feature/DEV-123 --spec task.md
+./scripts/launch-agent.sh ~/your-project --branch feature/DEV-123 --spec task.md
 ```
 
 ## Setup Script Options

--- a/index.html
+++ b/index.html
@@ -207,12 +207,12 @@
                 <div class="p-6 font-mono text-sm overflow-x-auto">
                     <div class="flex mb-2">
                         <span class="text-emerald-400 mr-2">➜</span>
-                        <span class="text-white">./scripts/launch-agent.sh 1 ~/project --config claude.yaml &</span>
+                        <span class="text-white">./scripts/launch-agent.sh ~/project --config claude.yaml &</span>
                     </div>
                     <div class="text-slate-500 mb-2">[1] 45121 launched: Claude Code (Container ID: 8f9a2b)</div>
                     <div class="flex mb-2">
                         <span class="text-emerald-400 mr-2">➜</span>
-                        <span class="text-white">./scripts/launch-agent.sh 2 ~/project --config aider.yaml &</span>
+                        <span class="text-white">./scripts/launch-agent.sh ~/project --config aider.yaml &</span>
                     </div>
                     <div class="text-slate-500 mb-2">[2] 45122 launched: Aider (Container ID: 3c2d1e)</div>
                     <div class="flex mb-2">
@@ -634,7 +634,7 @@ filesystem:
                             <i class="fa-regular fa-copy" aria-hidden="true"></i>
                         </button>
                         <div class="text-slate-500 mb-2"># Syntax: ./scripts/launch-agent.sh [ID] [PROJECT_PATH] [FLAGS]</div>
-                        <pre id="launch-code">./scripts/launch-agent.sh 1 ~/my-project \
+                        <pre id="launch-code">./scripts/launch-agent.sh ~/my-project \
     --config configs/claude.yaml \
     --branch feature/new-api</pre>
                     </div>

--- a/quick-start.sh
+++ b/quick-start.sh
@@ -3,19 +3,20 @@
 # Kapsis Quick Start - Launch Claude Code Agent
 #
 # This script simplifies launching Claude Code agents with your config.
+# Agent IDs are automatically generated (6-character UUID).
 #
 # Usage:
-#   ./quick-start.sh <agent-id> <project> <branch> [spec-file]
+#   ./quick-start.sh <project> <branch> [spec-file]
 #
 # Examples:
-#   ./quick-start.sh 1 products feature/DEV-123
-#   ./quick-start.sh 1 products feature/DEV-123 my-task.md
-#   ./quick-start.sh 2 daredevil-ui feature/DEV-456 configs/specs/feature.md
+#   ./quick-start.sh products feature/DEV-123
+#   ./quick-start.sh products feature/DEV-123 my-task.md
+#   ./quick-start.sh daredevil-ui feature/DEV-456 configs/specs/feature.md
 #
-# For parallel agents on same project:
-#   ./quick-start.sh 1 products feature/DEV-123-auth &
-#   ./quick-start.sh 2 products feature/DEV-123-api &
-#   ./quick-start.sh 3 products feature/DEV-123-tests &
+# For parallel agents on same project (each gets unique auto-generated ID):
+#   ./quick-start.sh products feature/DEV-123-auth &
+#   ./quick-start.sh products feature/DEV-123-api &
+#   ./quick-start.sh products feature/DEV-123-tests &
 #===============================================================================
 
 set -euo pipefail

--- a/scripts/build-agent-image.sh
+++ b/scripts/build-agent-image.sh
@@ -133,7 +133,7 @@ if [[ $BUILD_EXIT -eq 0 ]]; then
     log_success "Image built successfully: $IMAGE_NAME"
     echo ""
     echo "To use this image, run:"
-    echo "  ./scripts/launch-agent.sh 1 ~/git/products --image $IMAGE_NAME --task \"Your task\""
+    echo "  ./scripts/launch-agent.sh ~/git/products --image $IMAGE_NAME --task \"Your task\""
     echo ""
     echo "Or update your config to use this image:"
     echo "  agent:"

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -117,4 +117,4 @@ fi
 
 echo ""
 log_info "To run a container:"
-echo "  ./scripts/launch-agent.sh 1 ~/project --task \"your task\""
+echo "  ./scripts/launch-agent.sh ~/project --task \"your task\""

--- a/setup.sh
+++ b/setup.sh
@@ -846,7 +846,7 @@ main() {
     echo "     export ANTHROPIC_API_KEY='your-key'"
     echo ""
     echo "  3. Launch an agent:"
-    echo "     ./scripts/launch-agent.sh 1 ~/your-project --branch feature/test"
+    echo "     ./scripts/launch-agent.sh ~/your-project --branch feature/test"
     echo ""
     echo "  Or use the quick-start script:"
     echo "     ./quick-start.sh 1 project-name feature/branch"

--- a/tests/lib/test-framework.sh
+++ b/tests/lib/test-framework.sh
@@ -341,6 +341,22 @@ assert_false() {
     fi
 }
 
+# assert_matches <text> <regex_pattern> <message>
+# Checks if text matches a regex pattern (extended regex)
+# Example: assert_matches "$output" "[a-f0-9]{6}" "Should contain 6-char hex"
+assert_matches() {
+    local text="$1"
+    local pattern="$2"
+    local message="${3:-Text should match pattern}"
+
+    if echo "$text" | grep -qE "$pattern"; then
+        return 0
+    else
+        _log_failure "$message" "Pattern '$pattern' not found in text"
+        return 1
+    fi
+}
+
 #===============================================================================
 # TEST EXECUTION
 #===============================================================================

--- a/tests/test-agent-auth-requirements.sh
+++ b/tests/test-agent-auth-requirements.sh
@@ -28,7 +28,7 @@ test_present_auth_succeeds() {
 
     local output
     local exit_code=0
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --agent claude --task "test" --dry-run 2>&1) || exit_code=$?
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --agent claude --task "test" --dry-run 2>&1) || exit_code=$?
 
     # Restore original
     if [[ -n "$original_key" ]]; then
@@ -60,7 +60,7 @@ EOF
     export ANTHROPIC_API_KEY="test-auth-key"
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
 
     unset ANTHROPIC_API_KEY
     rm -f "$test_config"
@@ -88,7 +88,7 @@ EOF
     export CUSTOM_TOKEN="custom-token"
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
 
     unset ANTHROPIC_API_KEY OPENAI_API_KEY CUSTOM_TOKEN
     rm -f "$test_config"
@@ -118,7 +118,7 @@ EOF
     export MY_API_KEY="env-value-wins"
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
 
     unset MY_API_KEY
     rm -f "$test_config"
@@ -145,7 +145,7 @@ EOF
     export MY_SECRET_KEY="$secret_key"
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
 
     unset MY_SECRET_KEY
     rm -f "$test_config"
@@ -182,7 +182,7 @@ EOF
     export CREDENTIALS="secret6"
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
 
     unset API_KEY SECRET_TOKEN AUTH_PASSWORD PRIVATE_KEY ACCESS_KEY CREDENTIALS
     rm -f "$test_config"
@@ -203,7 +203,7 @@ test_empty_key_handling() {
 
     local output
     local exit_code=0
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --agent claude --task "test" --dry-run 2>&1) || exit_code=$?
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --agent claude --task "test" --dry-run 2>&1) || exit_code=$?
 
     unset ANTHROPIC_API_KEY
 
@@ -228,7 +228,7 @@ EOF
 
     local output
     local exit_code=0
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || exit_code=$?
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || exit_code=$?
 
     rm -f "$test_config"
 
@@ -286,7 +286,7 @@ EOF
 
     local output
     local exit_code=0
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || exit_code=$?
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || exit_code=$?
 
     rm -f "$test_config"
 

--- a/tests/test-agent-config-mounts.sh
+++ b/tests/test-agent-config-mounts.sh
@@ -36,7 +36,7 @@ filesystem:
 EOF
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
 
     rm -f "$test_config" "$test_file"
 
@@ -64,7 +64,7 @@ filesystem:
 EOF
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
 
     rm -f "$test_config" "$test_file1" "$test_file2"
 
@@ -89,7 +89,7 @@ filesystem:
 EOF
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
 
     rm -f "$test_config" "$test_file"
 
@@ -110,7 +110,7 @@ filesystem:
 EOF
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
 
     rm -f "$test_config"
 
@@ -160,7 +160,7 @@ filesystem:
 EOF
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
 
     rm -f "$test_config"
 
@@ -182,7 +182,7 @@ EOF
 
     local output
     local exit_code=0
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || exit_code=$?
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || exit_code=$?
 
     rm -f "$test_config"
 
@@ -209,7 +209,7 @@ filesystem:
 EOF
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
 
     rm -f "$test_config"
     rm -rf "$test_dir"
@@ -231,7 +231,7 @@ EOF
 
     local output
     local exit_code=0
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || exit_code=$?
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || exit_code=$?
 
     rm -f "$test_config"
 
@@ -254,7 +254,7 @@ EOF
 
     local output
     local exit_code=0
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || exit_code=$?
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || exit_code=$?
 
     rm -f "$test_config"
 
@@ -278,7 +278,7 @@ filesystem:
 EOF
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
 
     rm -f "$test_config" "$test_file"
 

--- a/tests/test-agent-config-override.sh
+++ b/tests/test-agent-config-override.sh
@@ -50,7 +50,7 @@ test_config_overrides_agent() {
 
     # Provide both --agent and --config
     # --config should win
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" \
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" \
         --agent claude \
         --config "$TEST_PROJECT/my-custom-agent.yaml" \
         --task "test" \
@@ -67,7 +67,7 @@ test_agent_name_from_custom_config() {
     setup_custom_config
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" \
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" \
         --config "$TEST_PROJECT/my-custom-agent.yaml" \
         --task "test" \
         --dry-run 2>&1) || true
@@ -82,7 +82,7 @@ test_config_not_found_error() {
     local output
     local exit_code=0
 
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" \
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" \
         --config "/nonexistent/path/config.yaml" \
         --task "test" --dry-run 2>&1) || exit_code=$?
 
@@ -96,7 +96,7 @@ test_config_with_path() {
     setup_custom_config
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" \
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" \
         --config "$TEST_PROJECT/my-custom-agent.yaml" \
         --task "test" \
         --dry-run 2>&1) || true
@@ -111,7 +111,7 @@ test_config_resources_applied() {
     setup_custom_config
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" \
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" \
         --config "$TEST_PROJECT/my-custom-agent.yaml" \
         --task "test" \
         --dry-run 2>&1) || true

--- a/tests/test-agent-profile-loading.sh
+++ b/tests/test-agent-profile-loading.sh
@@ -25,7 +25,7 @@ test_valid_profile_loads() {
     local exit_code=0
 
     # Use claude profile which should exist
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --agent claude --task "test task" --dry-run 2>&1) || exit_code=$?
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --agent claude --task "test task" --dry-run 2>&1) || exit_code=$?
 
     # Should succeed
     assert_equals 0 "$exit_code" "Should exit with zero for valid profile"
@@ -38,7 +38,7 @@ test_profile_name_displayed() {
     log_test "Testing profile name is displayed in output"
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --agent claude --task "test" --dry-run 2>&1)
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --agent claude --task "test" --dry-run 2>&1)
 
     # Agent name should appear in output (case-insensitive match)
     if echo "$output" | grep -qi "claude"; then
@@ -55,7 +55,7 @@ test_unknown_profile_errors() {
     local output
     local exit_code=0
 
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --agent nonexistent --task "test" --dry-run 2>&1) || exit_code=$?
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --agent nonexistent --task "test" --dry-run 2>&1) || exit_code=$?
 
     # Should fail
     assert_not_equals 0 "$exit_code" "Should exit with non-zero for unknown profile"
@@ -68,7 +68,7 @@ test_unknown_profile_shows_available() {
     log_test "Testing unknown profile lists available agents"
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --agent foobar --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --agent foobar --task "test" --dry-run 2>&1) || true
 
     # Should list available agents
     assert_contains "$output" "claude" "Should list claude as available"
@@ -123,7 +123,7 @@ test_profile_shortcut_works() {
     local exit_code=0
 
     # Shortcut should work same as --agent
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --agent claude --task "test" --dry-run 2>&1) || exit_code=$?
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --agent claude --task "test" --dry-run 2>&1) || exit_code=$?
 
     assert_equals 0 "$exit_code" "Should succeed with --agent shortcut"
     assert_contains "$output" "DRY RUN" "Should complete dry-run"
@@ -158,7 +158,7 @@ EOF
 
     local output
     local exit_code=0
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --config "$test_profile" --task "test" --dry-run 2>&1) || exit_code=$?
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --config "$test_profile" --task "test" --dry-run 2>&1) || exit_code=$?
 
     unset MY_TEST_VAR
     rm -f "$test_profile"
@@ -177,7 +177,7 @@ test_profile_default_resolution() {
     local exit_code=0
 
     # Empty agent should fall through to default
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --agent "" --task "test" --dry-run 2>&1) || exit_code=$?
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --agent "" --task "test" --dry-run 2>&1) || exit_code=$?
 
     # Should succeed with default config
     assert_equals 0 "$exit_code" "Should succeed with empty agent name"
@@ -193,7 +193,7 @@ agent:
 EOF
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --agent claude --config "$test_config" --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --agent claude --config "$test_config" --task "test" --dry-run 2>&1) || true
 
     rm -f "$test_config"
 

--- a/tests/test-agent-shortcut.sh
+++ b/tests/test-agent-shortcut.sh
@@ -21,7 +21,7 @@ test_agent_claude() {
     log_test "Testing --agent claude"
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --agent claude --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --agent claude --task "test" --dry-run 2>&1) || true
 
     assert_contains "$output" "CLAUDE" "Agent name should be displayed in uppercase"
     assert_contains "$output" "configs/claude.yaml" "Should use claude.yaml config"
@@ -32,7 +32,7 @@ test_agent_codex() {
     log_test "Testing --agent codex"
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --agent codex --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --agent codex --task "test" --dry-run 2>&1) || true
 
     assert_contains "$output" "CODEX" "Agent name should be displayed in uppercase"
     assert_contains "$output" "configs/codex.yaml" "Should use codex.yaml config"
@@ -42,7 +42,7 @@ test_agent_aider() {
     log_test "Testing --agent aider"
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --agent aider --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --agent aider --task "test" --dry-run 2>&1) || true
 
     assert_contains "$output" "AIDER" "Agent name should be displayed in uppercase"
     assert_contains "$output" "configs/aider.yaml" "Should use aider.yaml config"
@@ -52,7 +52,7 @@ test_agent_interactive() {
     log_test "Testing --agent interactive"
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --agent interactive --interactive --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --agent interactive --interactive --dry-run 2>&1) || true
 
     assert_contains "$output" "INTERACTIVE" "Agent name should be displayed in uppercase"
     assert_contains "$output" "configs/interactive.yaml" "Should use interactive.yaml config"
@@ -62,7 +62,7 @@ test_agent_display_in_banner() {
     log_test "Testing agent name in configuration summary"
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --agent claude --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --agent claude --task "test" --dry-run 2>&1) || true
 
     # In dry-run mode, check config summary shows agent (banner only shows during actual launch)
     assert_contains "$output" "Agent:         CLAUDE" "Config summary should show agent name"
@@ -72,7 +72,7 @@ test_agent_in_config_summary() {
     log_test "Testing agent in configuration summary"
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --agent codex --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --agent codex --task "test" --dry-run 2>&1) || true
 
     # Check configuration summary shows agent
     assert_contains "$output" "Agent:" "Configuration should show Agent line"

--- a/tests/test-agent-unknown.sh
+++ b/tests/test-agent-unknown.sh
@@ -23,7 +23,7 @@ test_unknown_agent_error() {
     local output
     local exit_code=0
 
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --agent nonexistent --task "test" --dry-run 2>&1) || exit_code=$?
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --agent nonexistent --task "test" --dry-run 2>&1) || exit_code=$?
 
     # Should fail
     assert_not_equals 0 "$exit_code" "Should exit with non-zero code"
@@ -37,7 +37,7 @@ test_unknown_agent_shows_available() {
     log_test "Testing that error shows available agents"
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --agent foobar --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --agent foobar --task "test" --dry-run 2>&1) || true
 
     # Should list available agents
     assert_contains "$output" "claude" "Should list claude as available"
@@ -50,7 +50,7 @@ test_unknown_agent_suggests_config() {
     log_test "Testing that error suggests --config alternative"
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --agent invalid --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --agent invalid --task "test" --dry-run 2>&1) || true
 
     # Should suggest using --config
     assert_contains "$output" "--config" "Should suggest using --config flag"
@@ -63,7 +63,7 @@ test_similar_agent_typo() {
     local exit_code=0
 
     # Common typos
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --agent cloude --task "test" --dry-run 2>&1) || exit_code=$?
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --agent cloude --task "test" --dry-run 2>&1) || exit_code=$?
 
     assert_not_equals 0 "$exit_code" "Should fail on typo"
     assert_contains "$output" "Unknown agent" "Should show unknown agent error"
@@ -76,7 +76,7 @@ test_empty_agent_name() {
     local exit_code=0
 
     # Empty agent name falls through to default config resolution
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --agent "" --task "test" --dry-run 2>&1) || exit_code=$?
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --agent "" --task "test" --dry-run 2>&1) || exit_code=$?
 
     # Should fall back to default (claude)
     assert_equals 0 "$exit_code" "Should succeed with default config"

--- a/tests/test-config-resolution.sh
+++ b/tests/test-config-resolution.sh
@@ -65,7 +65,7 @@ test_agent_flag_takes_precedence() {
     create_project_config
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" \
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" \
         --agent codex \
         --task "test" \
         --dry-run 2>&1) || true
@@ -83,7 +83,7 @@ test_project_config_found() {
     # Run from project directory without --agent
     cd "$TEST_PROJECT"
     local output
-    output=$("$LAUNCH_SCRIPT" 1 . --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" . --task "test" --dry-run 2>&1) || true
 
     # Should find and use project config
     assert_contains "$output" "agent-sandbox.yaml" "Should find project config"
@@ -99,7 +99,7 @@ test_kapsis_dir_config() {
 
     cd "$TEST_PROJECT"
     local output
-    output=$("$LAUNCH_SCRIPT" 1 . --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" . --task "test" --dry-run 2>&1) || true
 
     # Should find .kapsis/config.yaml (now that agent-sandbox.yaml is removed)
     assert_contains "$output" ".kapsis/config.yaml" "Should find .kapsis config"
@@ -113,7 +113,7 @@ test_fallback_to_claude() {
     rm -rf "$TEST_PROJECT/.kapsis"
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --task "test" --dry-run 2>&1) || true
 
     # Should fall back to claude.yaml
     assert_contains "$output" "claude" "Should fall back to claude config"
@@ -144,7 +144,7 @@ test_resolution_order_logging() {
     create_project_config
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --task "test" --dry-run 2>&1) || true
 
     # Should show which config was used
     assert_contains "$output" "Using agent:" "Should log which agent/config is used"

--- a/tests/test-dry-run-completeness.sh
+++ b/tests/test-dry-run-completeness.sh
@@ -20,7 +20,7 @@ test_dry_run_shows_agent() {
     log_test "Testing dry-run shows agent name"
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --agent claude --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --agent claude --task "test" --dry-run 2>&1) || true
 
     assert_contains "$output" "Agent:" "Should show Agent line"
     assert_contains "$output" "CLAUDE" "Should show agent name"
@@ -30,7 +30,7 @@ test_dry_run_shows_instance_id() {
     log_test "Testing dry-run shows instance ID"
 
     local output
-    output=$("$LAUNCH_SCRIPT" 42 "$TEST_PROJECT" --agent claude --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --agent-id 42 --agent claude --task "test" --dry-run 2>&1) || true
 
     assert_contains "$output" "Instance ID:" "Should show Instance ID line"
     assert_contains "$output" "42" "Should show correct instance ID"
@@ -40,7 +40,7 @@ test_dry_run_shows_project_path() {
     log_test "Testing dry-run shows project path"
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --agent claude --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --agent claude --task "test" --dry-run 2>&1) || true
 
     assert_contains "$output" "Project:" "Should show Project line"
     assert_contains "$output" "$TEST_PROJECT" "Should show project path"
@@ -50,7 +50,7 @@ test_dry_run_shows_image() {
     log_test "Testing dry-run shows container image"
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --agent claude --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --agent claude --task "test" --dry-run 2>&1) || true
 
     assert_contains "$output" "Image:" "Should show Image line"
     # Check for the actual image name (respects KAPSIS_IMAGE env var)
@@ -62,7 +62,7 @@ test_dry_run_shows_resources() {
     log_test "Testing dry-run shows resource limits"
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --agent claude --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --agent claude --task "test" --dry-run 2>&1) || true
 
     assert_contains "$output" "Resources:" "Should show Resources line"
     assert_contains "$output" "RAM" "Should show memory"
@@ -73,7 +73,7 @@ test_dry_run_shows_task() {
     log_test "Testing dry-run shows task description"
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --agent claude --task "fix the failing tests" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --agent claude --task "fix the failing tests" --dry-run 2>&1) || true
 
     assert_contains "$output" "Task:" "Should show Task line"
     assert_contains "$output" "fix the failing" "Should show task text"
@@ -93,7 +93,7 @@ test_dry_run_shows_branch() {
     cd - > /dev/null
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --agent claude --task "test" --branch "feature/test-123" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --agent claude --task "test" --branch "feature/test-123" --dry-run 2>&1) || true
 
     assert_contains "$output" "Branch:" "Should show Branch line"
     assert_contains "$output" "feature/test-123" "Should show branch name"
@@ -103,7 +103,7 @@ test_dry_run_shows_podman_command() {
     log_test "Testing dry-run shows podman command"
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --agent claude --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --agent claude --task "test" --dry-run 2>&1) || true
 
     assert_contains "$output" "DRY RUN" "Should indicate dry run"
     assert_contains "$output" "podman run" "Should show podman command"
@@ -113,7 +113,7 @@ test_dry_run_shows_volume_mounts() {
     log_test "Testing dry-run shows volume mounts"
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --agent claude --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --agent claude --task "test" --dry-run 2>&1) || true
 
     assert_contains "$output" "-v" "Should show volume mount flags"
     assert_contains "$output" "/workspace" "Should show workspace mount"
@@ -123,7 +123,7 @@ test_dry_run_shows_env_vars() {
     log_test "Testing dry-run shows environment variables"
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --agent claude --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --agent claude --task "test" --dry-run 2>&1) || true
 
     assert_contains "$output" "KAPSIS_AGENT_ID" "Should show agent ID env var"
     assert_contains "$output" "KAPSIS_PROJECT" "Should show project env var"
@@ -133,7 +133,7 @@ test_dry_run_shows_memory_limit() {
     log_test "Testing dry-run shows memory limit in command"
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --agent claude --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --agent claude --task "test" --dry-run 2>&1) || true
 
     assert_contains "$output" "--memory=" "Should show memory limit flag"
 }
@@ -142,7 +142,7 @@ test_dry_run_shows_cpu_limit() {
     log_test "Testing dry-run shows CPU limit in command"
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --agent claude --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --agent claude --task "test" --dry-run 2>&1) || true
 
     assert_contains "$output" "--cpus=" "Should show CPU limit flag"
 }
@@ -223,7 +223,7 @@ test_dry_run_no_branch_created() {
     local branch_name="feature/dry-run-no-create-$$"
 
     # Run dry-run
-    "$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --agent claude \
+    "$LAUNCH_SCRIPT" "$TEST_PROJECT" --agent claude \
         --task "test" --branch "$branch_name" --dry-run 2>&1 || true
 
     # Verify no branch was created
@@ -253,7 +253,7 @@ test_dry_run_shows_would_create_messages() {
     cd - > /dev/null
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --agent claude \
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --agent claude \
         --task "test" --branch "feature/dry-run-msg-$$" --dry-run 2>&1) || true
 
     assert_contains "$output" "[DRY-RUN]" "Should show DRY-RUN prefix"

--- a/tests/test-env-api-keys.sh
+++ b/tests/test-env-api-keys.sh
@@ -87,7 +87,7 @@ test_keys_not_in_dry_run() {
 
     export ANTHROPIC_API_KEY="$secret_key"
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --agent claude --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --agent claude --task "test" --dry-run 2>&1) || true
     unset ANTHROPIC_API_KEY
 
     # The actual key value should not appear in output
@@ -276,7 +276,7 @@ environment:
 EOF
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
 
     rm -f "$test_config"
 
@@ -309,7 +309,7 @@ EOF
     export ANTHROPIC_API_KEY="passthrough-value"
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
 
     unset ANTHROPIC_API_KEY
     rm -f "$test_config"
@@ -355,7 +355,7 @@ agent:
 EOF
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --config "$test_config" --task "test task" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --config "$test_config" --task "test task" --dry-run 2>&1) || true
 
     rm -f "$test_config"
 
@@ -403,7 +403,7 @@ agent:
 EOF
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --config "$test_config" --task "test task" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --config "$test_config" --task "test task" --dry-run 2>&1) || true
 
     rm -f "$test_config"
 
@@ -428,7 +428,7 @@ agent:
 EOF
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --config "$test_config" --interactive --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --config "$test_config" --interactive --dry-run 2>&1) || true
 
     rm -f "$test_config"
 
@@ -467,7 +467,7 @@ environment:
 EOF
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
 
     rm -f "$test_config"
 
@@ -494,7 +494,7 @@ EOF
     export GRAFANA_READONLY_TOKEN="graf-secret-value"
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
 
     unset CONTEXT7_API_KEY GRAFANA_READONLY_TOKEN
     rm -f "$test_config"
@@ -522,7 +522,7 @@ filesystem:
 EOF
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
 
     rm -f "$test_config"
 
@@ -551,7 +551,7 @@ image:
 EOF
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --config "$test_config" --image "my-custom-image:latest" --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --config "$test_config" --image "my-custom-image:latest" --task "test" --dry-run 2>&1) || true
 
     rm -f "$test_config"
 
@@ -584,7 +584,7 @@ environment:
 EOF
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
 
     rm -f "$test_config" "$test_file1" "$test_file2"
 
@@ -618,7 +618,7 @@ EOF
     export TEST_VAR3="value3"
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
 
     unset TEST_VAR1 TEST_VAR2 TEST_VAR3
     rm -f "$test_config"
@@ -651,7 +651,7 @@ EOF
     # We can't actually query keychain in tests, but we can verify the config parsing
     # by checking the dry-run output shows the variable would be processed
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
 
     rm -f "$test_config"
 
@@ -870,7 +870,7 @@ filesystem:
 EOF
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
 
     rm -f "$test_config" "$test_file1" "$test_file2"
 
@@ -895,7 +895,7 @@ filesystem:
 EOF
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
 
     rm -f "$test_config" "$test_file"
 
@@ -916,7 +916,7 @@ filesystem:
 EOF
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
 
     rm -f "$test_config"
 

--- a/tests/test-full-workflow.sh
+++ b/tests/test-full-workflow.sh
@@ -152,7 +152,7 @@ Implement a new logging feature.
 EOF
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --agent interactive --spec "$spec_file" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --agent interactive --spec "$spec_file" --dry-run 2>&1) || true
 
     rm -f "$spec_file"
 
@@ -165,7 +165,7 @@ test_workflow_interactive_mode() {
     log_test "Testing interactive mode workflow"
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --agent interactive --interactive --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --agent interactive --interactive --dry-run 2>&1) || true
 
     # Should show interactive config
     assert_contains "$output" "INTERACTIVE" "Should use interactive agent"
@@ -175,7 +175,7 @@ test_workflow_dry_run_complete() {
     log_test "Testing dry-run shows complete workflow"
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" \
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" \
         --agent claude \
         --task "fix tests" \
         --branch "feature/dry-run-test" \
@@ -194,7 +194,7 @@ test_workflow_error_handling() {
     # Non-existent project
     local output
     local exit_code=0
-    output=$("$LAUNCH_SCRIPT" 1 "/nonexistent" --task "test" 2>&1) || exit_code=$?
+    output=$("$LAUNCH_SCRIPT" "/nonexistent" --task "test" 2>&1) || exit_code=$?
 
     assert_not_equals 0 "$exit_code" "Should fail on invalid input"
     assert_contains "$output" "not exist" "Should show error message"

--- a/tests/test-git-auto-commit-push.sh
+++ b/tests/test-git-auto-commit-push.sh
@@ -105,7 +105,7 @@ test_no_push_flag_respected() {
 
     # Check dry-run output includes no-push setting
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --agent claude --task "test" --branch "test-branch" --no-push --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --agent claude --task "test" --branch "test-branch" --no-push --dry-run 2>&1) || true
 
     # Should show KAPSIS_NO_PUSH in env or command
     assert_contains "$output" "KAPSIS_NO_PUSH" "Should set KAPSIS_NO_PUSH env var" || \

--- a/tests/test-git-new-branch.sh
+++ b/tests/test-git-new-branch.sh
@@ -78,7 +78,7 @@ test_auto_branch_generates_name() {
 
     # This tests the launch script's auto-branch logic
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --auto-branch --task "fix login bug" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --auto-branch --task "fix login bug" --dry-run 2>&1) || true
 
     # Should have generated a branch name
     assert_contains "$output" "Branch:" "Should show branch name"
@@ -197,7 +197,7 @@ test_branch_flag_validation() {
 
     local output
     local exit_code=0
-    output=$("$LAUNCH_SCRIPT" 1 "$non_git_dir" --branch "test" --task "test" 2>&1) || exit_code=$?
+    output=$("$LAUNCH_SCRIPT" "$non_git_dir" --branch "test" --task "test" 2>&1) || exit_code=$?
 
     rm -rf "$non_git_dir"
 

--- a/tests/test-input-validation.sh
+++ b/tests/test-input-validation.sh
@@ -17,28 +17,70 @@ LAUNCH_SCRIPT="$KAPSIS_ROOT/scripts/launch-agent.sh"
 # TEST CASES
 #===============================================================================
 
-test_missing_agent_id() {
-    log_test "Testing error when agent-id missing"
+test_no_arguments() {
+    log_test "Testing error when no arguments provided"
 
     local output
     local exit_code=0
 
     output=$("$LAUNCH_SCRIPT" 2>&1) || exit_code=$?
 
-    assert_not_equals 0 "$exit_code" "Should fail when agent-id missing"
+    assert_not_equals 0 "$exit_code" "Should fail when no arguments provided"
     assert_contains "$output" "Usage" "Should show usage"
 }
 
-test_missing_project_path() {
-    log_test "Testing error when project-path missing"
+test_auto_generated_agent_id() {
+    log_test "Testing auto-generated agent ID"
 
     local output
     local exit_code=0
 
-    output=$("$LAUNCH_SCRIPT" 1 2>&1) || exit_code=$?
+    # Use dry-run to check auto-generation
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --task "test" --dry-run 2>&1) || exit_code=$?
 
-    assert_not_equals 0 "$exit_code" "Should fail when project-path missing"
-    assert_contains "$output" "Usage" "Should show usage"
+    assert_equals 0 "$exit_code" "Should succeed with auto-generated ID"
+    assert_contains "$output" "auto-generated" "Should mention auto-generated"
+    # Check for 6-char hex pattern
+    assert_matches "$output" "[a-f0-9]{6}" "Should contain 6-char hex ID"
+}
+
+test_explicit_agent_id() {
+    log_test "Testing explicit --agent-id option"
+
+    local output
+    local exit_code=0
+
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --agent-id "my-custom-id" --task "test" --dry-run 2>&1) || exit_code=$?
+
+    assert_equals 0 "$exit_code" "Should succeed with explicit agent ID"
+    assert_contains "$output" "my-custom-id" "Should use specified agent ID"
+    assert_not_contains "$output" "auto-generated" "Should NOT mention auto-generated"
+}
+
+test_deprecated_positional_agent_id() {
+    log_test "Testing deprecated positional agent-id shows warning"
+
+    local output
+    local exit_code=0
+
+    # Old CLI: launch-agent.sh <agent-id> <project-path>
+    output=$("$LAUNCH_SCRIPT" "old-id" "$TEST_PROJECT" --task "test" --dry-run 2>&1) || exit_code=$?
+
+    assert_equals 0 "$exit_code" "Should succeed with deprecated syntax"
+    assert_contains "$output" "DEPRECATED" "Should show deprecation warning"
+    assert_contains "$output" "old-id" "Should use the specified agent ID"
+}
+
+test_invalid_agent_id_format() {
+    log_test "Testing invalid agent ID format is rejected"
+
+    local output
+    local exit_code=0
+
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --agent-id "../bad/id" --task "test" 2>&1) || exit_code=$?
+
+    assert_not_equals 0 "$exit_code" "Should fail with invalid agent ID"
+    assert_contains "$output" "Invalid agent ID format" "Should mention invalid format"
 }
 
 test_nonexistent_project_path() {
@@ -47,7 +89,7 @@ test_nonexistent_project_path() {
     local output
     local exit_code=0
 
-    output=$("$LAUNCH_SCRIPT" 1 "/nonexistent/path/to/project" --task "test" 2>&1) || exit_code=$?
+    output=$("$LAUNCH_SCRIPT" "/nonexistent/path/to/project" --task "test" 2>&1) || exit_code=$?
 
     assert_not_equals 0 "$exit_code" "Should fail when project doesn't exist"
     assert_contains "$output" "not exist" "Should mention path doesn't exist"
@@ -59,7 +101,7 @@ test_task_required_without_interactive() {
     local output
     local exit_code=0
 
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --agent claude 2>&1) || exit_code=$?
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --agent claude 2>&1) || exit_code=$?
 
     assert_not_equals 0 "$exit_code" "Should fail without task input"
     assert_contains "$output" "Task input required" "Should mention task is required"
@@ -72,7 +114,7 @@ test_interactive_mode_no_task_required() {
     local exit_code=0
 
     # With --interactive and --dry-run, should not error about missing task
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --interactive --dry-run 2>&1) || exit_code=$?
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --interactive --dry-run 2>&1) || exit_code=$?
 
     # Should succeed (exit 0 from dry-run) or at least not fail on task validation
     assert_not_contains "$output" "Task input required" "Should not require task with --interactive"
@@ -84,7 +126,7 @@ test_nonexistent_spec_file() {
     local output
     local exit_code=0
 
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --spec "/nonexistent/spec.md" 2>&1) || exit_code=$?
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --spec "/nonexistent/spec.md" 2>&1) || exit_code=$?
 
     assert_not_equals 0 "$exit_code" "Should fail when spec file doesn't exist"
     assert_contains "$output" "not found" "Should mention spec file not found"
@@ -100,7 +142,7 @@ test_branch_requires_git_repo() {
     local output
     local exit_code=0
 
-    output=$("$LAUNCH_SCRIPT" 1 "$non_git_dir" --branch "test-branch" --task "test" 2>&1) || exit_code=$?
+    output=$("$LAUNCH_SCRIPT" "$non_git_dir" --branch "test-branch" --task "test" 2>&1) || exit_code=$?
 
     rm -rf "$non_git_dir"
 
@@ -118,7 +160,7 @@ test_auto_branch_requires_git_repo() {
     local output
     local exit_code=0
 
-    output=$("$LAUNCH_SCRIPT" 1 "$non_git_dir" --auto-branch --task "test" 2>&1) || exit_code=$?
+    output=$("$LAUNCH_SCRIPT" "$non_git_dir" --auto-branch --task "test" 2>&1) || exit_code=$?
 
     rm -rf "$non_git_dir"
 
@@ -132,7 +174,7 @@ test_unknown_option_error() {
     local output
     local exit_code=0
 
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --unknown-option --task "test" 2>&1) || exit_code=$?
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --unknown-option --task "test" 2>&1) || exit_code=$?
 
     assert_not_equals 0 "$exit_code" "Should fail on unknown option"
     assert_contains "$output" "Unknown option" "Should mention unknown option"
@@ -171,15 +213,26 @@ main() {
     # Setup
     setup_test_project
 
-    # Run tests
-    run_test test_missing_agent_id
-    run_test test_missing_project_path
+    # Run tests - basic argument validation
+    run_test test_no_arguments
     run_test test_nonexistent_project_path
+
+    # Run tests - agent ID handling
+    run_test test_auto_generated_agent_id
+    run_test test_explicit_agent_id
+    run_test test_deprecated_positional_agent_id
+    run_test test_invalid_agent_id_format
+
+    # Run tests - task and spec validation
     run_test test_task_required_without_interactive
     run_test test_interactive_mode_no_task_required
     run_test test_nonexistent_spec_file
+
+    # Run tests - git requirements
     run_test test_branch_requires_git_repo
     run_test test_auto_branch_requires_git_repo
+
+    # Run tests - help and error handling
     run_test test_unknown_option_error
     run_test test_help_flag
     run_test test_short_help_flag

--- a/tests/test-keychain-retrieval.sh
+++ b/tests/test-keychain-retrieval.sh
@@ -36,7 +36,7 @@ EOF
     export MY_API_KEY="$secret_key"
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
 
     unset MY_API_KEY
     rm -f "$test_config"
@@ -79,7 +79,7 @@ EOF
 
     local output
     local exit_code=0
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || exit_code=$?
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || exit_code=$?
 
     rm -f "$test_config"
 
@@ -134,7 +134,7 @@ EOF
     export SHARED_API_KEY="passthrough-value"
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || true
 
     unset SHARED_API_KEY
     rm -f "$test_config"
@@ -194,7 +194,7 @@ EOF
 
     local output
     local exit_code=0
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || exit_code=$?
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || exit_code=$?
 
     rm -f "$test_config"
 
@@ -219,7 +219,7 @@ EOF
 
     local output
     local exit_code=0
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || exit_code=$?
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --config "$test_config" --task "test" --dry-run 2>&1) || exit_code=$?
 
     unset MY_VAR
     rm -f "$test_config"

--- a/tests/test-path-spaces.sh
+++ b/tests/test-path-spaces.sh
@@ -24,7 +24,7 @@ test_project_path_with_spaces() {
     mkdir -p "$project_with_spaces"
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$project_with_spaces" --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$project_with_spaces" --task "test" --dry-run 2>&1) || true
 
     rm -rf "$project_with_spaces"
 
@@ -41,7 +41,7 @@ test_spec_file_with_spaces() {
     echo "# Test Spec" > "$spec_file"
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --spec "$spec_file" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --spec "$spec_file" --dry-run 2>&1) || true
 
     rm -f "$spec_file"
 
@@ -70,7 +70,7 @@ resources:
 EOF
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$TEST_PROJECT" --config "$config_file" --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$TEST_PROJECT" --config "$config_file" --task "test" --dry-run 2>&1) || true
 
     rm -f "$config_file"
 
@@ -87,7 +87,7 @@ test_nested_path_with_spaces() {
     mkdir -p "$nested_path"
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$nested_path" --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$nested_path" --task "test" --dry-run 2>&1) || true
 
     rm -rf "/tmp/kapsis tests"
 
@@ -103,7 +103,7 @@ test_path_with_special_chars() {
     mkdir -p "$special_path"
 
     local output
-    output=$("$LAUNCH_SCRIPT" 1 "$special_path" --task "test" --dry-run 2>&1) || true
+    output=$("$LAUNCH_SCRIPT" "$special_path" --task "test" --dry-run 2>&1) || true
 
     rm -rf "$special_path"
 


### PR DESCRIPTION
## Summary

This PR changes the Kapsis CLI to auto-generate agent IDs by default, simplifying usage while maintaining backward compatibility.

### Changes
- **Auto-generate 6-character UUID** for agent identification (e.g., `a3f2b1`)
- **Add `--agent-id` option** to specify ID for continuing sessions
- **Backward compatible** - old positional syntax still works with deprecation warning
- **Prominent display** of auto-generated ID with continuation hint
- **Agent ID validation** to ensure valid format

### CLI Change

**Before:**
```bash
kapsis <agent-id> <project-path> [options]
```

**After:**
```bash
kapsis <project-path> [options]                          # Auto-generates ID
kapsis <project-path> --agent-id <id> [options]         # Explicit ID (continue)
kapsis <agent-id> <project-path> [options]              # Deprecated (shows warning)
```

### Example Output
```
  Instance ID:   a3f2b1 (auto-generated)
  
  To continue this session: --agent-id a3f2b1
```

## Test Plan
- [x] All 21 quick tests pass
- [x] New tests added for auto-generation and explicit ID
- [x] Backward compatibility tested with deprecation warning
- [x] Invalid agent ID format rejection tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)