### PR TITLE
ci: add GitHub Pages auto-deploy workflow

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,35 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'index.html'
+      - 'docs/**'
+      - '.github/workflows/deploy-pages.yml'
+  workflow_dispatch:  # Allow manual trigger
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./
+          publish_branch: gh-pages
+          # Only publish specific files for landing page
+          exclude_assets: '.github,tests,scripts,configs,Containerfile,Makefile,*.sh,*.md,!README.md'
+          keep_files: false
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+          commit_message: 'deploy: update GitHub Pages from ${{ github.sha }}'


### PR DESCRIPTION
## Summary

Automatically deploy `index.html` and `docs/` to the `gh-pages` branch when changes are pushed to `main`.

## Problem

The `gh-pages` branch was out of sync with `main` - the landing page at https://aviadshiber.github.io/kapsis/ was showing stale content.

## Solution

Add a GitHub Actions workflow that:
- Triggers on push to `main` when `index.html` or `docs/**` change
- Uses `peaceiris/actions-gh-pages` to deploy to `gh-pages` branch
- Supports manual trigger via `workflow_dispatch`

## Test plan

- [ ] Merge this PR
- [ ] Verify workflow runs successfully
- [ ] Check https://aviadshiber.github.io/kapsis/ shows updated content

🤖 Generated with [Claude Code](https://claude.com/claude-code)