### PR TITLE
fix: kapsis --help returns exit code 0 (Unix convention)

### DIFF
--- a/scripts/launch-agent.sh
+++ b/scripts/launch-agent.sh
@@ -206,7 +206,10 @@ query_secret_store_with_fallbacks() {
 #===============================================================================
 # USAGE
 #===============================================================================
+# Usage: usage [exit_code]
+# Displays help text and exits with the given code (default: 0 for help, 1 for errors)
 usage() {
+    local exit_code="${1:-0}"
     cat << EOF
 Usage: $(basename "$0") <project-path> [options]
        $(basename "$0") --version
@@ -276,7 +279,7 @@ Examples:
   $(basename "$0") ~/project --interactive --branch experiment/explore
 
 EOF
-    exit 1
+    exit "$exit_code"
 }
 
 #===============================================================================
@@ -342,9 +345,14 @@ parse_args() {
     # Handle global flags first (version management - no project path required)
     handle_global_flags "$@"
 
-    # Handle help flags (before any argument requirement check)
-    if [[ $# -eq 0 ]] || [[ "$1" == "-h" ]] || [[ "$1" == "--help" ]]; then
-        usage
+    # No arguments is an error (exit 1 with usage)
+    if [[ $# -eq 0 ]]; then
+        usage 1
+    fi
+
+    # Handle help flags (exit 0 for explicit help request)
+    if [[ "$1" == "-h" ]] || [[ "$1" == "--help" ]]; then
+        usage 0
     fi
 
     # First argument is always the project path
@@ -415,7 +423,7 @@ parse_args() {
                 ;;
             *)
                 log_error "Unknown option: $1"
-                usage
+                usage 1
                 ;;
         esac
     done
@@ -459,7 +467,7 @@ validate_inputs() {
     # Validate task input
     if [[ -z "$TASK_INLINE" && -z "$SPEC_FILE" && "$INTERACTIVE" != "true" ]]; then
         log_error "Task input required: use --task, --spec, or --interactive"
-        usage
+        usage 1
     fi
 
     # Validate spec file exists

--- a/tests/test-input-validation.sh
+++ b/tests/test-input-validation.sh
@@ -167,25 +167,30 @@ test_unknown_option_error() {
 }
 
 test_help_flag() {
-    log_test "Testing --help shows usage"
+    log_test "Testing --help shows usage and exits 0"
 
     local output
     local exit_code=0
 
     output=$("$LAUNCH_SCRIPT" --help 2>&1) || exit_code=$?
 
-    # Help exits with 1 but shows usage
+    # Help should exit with 0 (success) per Unix convention
+    assert_equals 0 "$exit_code" "Should exit 0 for --help (Unix convention)"
     assert_contains "$output" "Usage" "Should show usage"
     assert_contains "$output" "Options" "Should show options section"
     assert_contains "$output" "Examples" "Should show examples"
 }
 
 test_short_help_flag() {
-    log_test "Testing -h shows usage"
+    log_test "Testing -h shows usage and exits 0"
 
     local output
-    output=$("$LAUNCH_SCRIPT" -h 2>&1) || true
+    local exit_code=0
 
+    output=$("$LAUNCH_SCRIPT" -h 2>&1) || exit_code=$?
+
+    # -h should also exit with 0 (success) per Unix convention
+    assert_equals 0 "$exit_code" "Should exit 0 for -h (Unix convention)"
     assert_contains "$output" "Usage" "Should show usage with -h"
 }
 


### PR DESCRIPTION
## Summary
- Fixed `kapsis --help` and `kapsis -h` to return exit code 0 (Unix convention)
- Error conditions (no args, unknown options, missing task) continue to return exit code 1
- Modified `usage()` function to accept optional exit code parameter

## Test plan
- [x] `./scripts/launch-agent.sh --help` returns exit code 0
- [x] `./scripts/launch-agent.sh -h` returns exit code 0
- [x] `./scripts/launch-agent.sh` (no args) returns exit code 1
- [x] All 13 input validation tests pass
- [x] shellcheck passes

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)