### PR TITLE
fix: help text shows correct command name for package manager installs

### DIFF
--- a/packaging/debian/debian/rules
+++ b/packaging/debian/debian/rules
@@ -48,31 +48,37 @@ override_dh_auto_install:
 	echo 'export KAPSIS_HOME="/usr/share/kapsis"' >> $(CURDIR)/debian/kapsis/usr/bin/kapsis
 	echo 'export KAPSIS_LIB="/usr/lib/kapsis/lib"' >> $(CURDIR)/debian/kapsis/usr/bin/kapsis
 	echo 'export KAPSIS_SCRIPTS="/usr/lib/kapsis/scripts"' >> $(CURDIR)/debian/kapsis/usr/bin/kapsis
+	echo 'export KAPSIS_CMD_NAME="kapsis"' >> $(CURDIR)/debian/kapsis/usr/bin/kapsis
 	echo 'exec /usr/lib/kapsis/scripts/launch-agent.sh "$$@"' >> $(CURDIR)/debian/kapsis/usr/bin/kapsis
 	chmod 755 $(CURDIR)/debian/kapsis/usr/bin/kapsis
 
 	echo '#!/bin/bash' > $(CURDIR)/debian/kapsis/usr/bin/kapsis-build
 	echo 'export KAPSIS_HOME="/usr/share/kapsis"' >> $(CURDIR)/debian/kapsis/usr/bin/kapsis-build
+	echo 'export KAPSIS_CMD_NAME="kapsis-build"' >> $(CURDIR)/debian/kapsis/usr/bin/kapsis-build
 	echo 'exec /usr/lib/kapsis/scripts/build-image.sh "$$@"' >> $(CURDIR)/debian/kapsis/usr/bin/kapsis-build
 	chmod 755 $(CURDIR)/debian/kapsis/usr/bin/kapsis-build
 
 	echo '#!/bin/bash' > $(CURDIR)/debian/kapsis/usr/bin/kapsis-cleanup
 	echo 'export KAPSIS_HOME="/usr/share/kapsis"' >> $(CURDIR)/debian/kapsis/usr/bin/kapsis-cleanup
+	echo 'export KAPSIS_CMD_NAME="kapsis-cleanup"' >> $(CURDIR)/debian/kapsis/usr/bin/kapsis-cleanup
 	echo 'exec /usr/lib/kapsis/scripts/kapsis-cleanup.sh "$$@"' >> $(CURDIR)/debian/kapsis/usr/bin/kapsis-cleanup
 	chmod 755 $(CURDIR)/debian/kapsis/usr/bin/kapsis-cleanup
 
 	echo '#!/bin/bash' > $(CURDIR)/debian/kapsis/usr/bin/kapsis-status
 	echo 'export KAPSIS_HOME="/usr/share/kapsis"' >> $(CURDIR)/debian/kapsis/usr/bin/kapsis-status
+	echo 'export KAPSIS_CMD_NAME="kapsis-status"' >> $(CURDIR)/debian/kapsis/usr/bin/kapsis-status
 	echo 'exec /usr/lib/kapsis/scripts/kapsis-status.sh "$$@"' >> $(CURDIR)/debian/kapsis/usr/bin/kapsis-status
 	chmod 755 $(CURDIR)/debian/kapsis/usr/bin/kapsis-status
 
 	echo '#!/bin/bash' > $(CURDIR)/debian/kapsis/usr/bin/kapsis-setup
 	echo 'export KAPSIS_HOME="/usr/share/kapsis"' >> $(CURDIR)/debian/kapsis/usr/bin/kapsis-setup
+	echo 'export KAPSIS_CMD_NAME="kapsis-setup"' >> $(CURDIR)/debian/kapsis/usr/bin/kapsis-setup
 	echo 'exec /usr/lib/kapsis/scripts/setup.sh "$$@"' >> $(CURDIR)/debian/kapsis/usr/bin/kapsis-setup
 	chmod 755 $(CURDIR)/debian/kapsis/usr/bin/kapsis-setup
 
 	echo '#!/bin/bash' > $(CURDIR)/debian/kapsis/usr/bin/kapsis-quick
 	echo 'export KAPSIS_HOME="/usr/share/kapsis"' >> $(CURDIR)/debian/kapsis/usr/bin/kapsis-quick
+	echo 'export KAPSIS_CMD_NAME="kapsis-quick"' >> $(CURDIR)/debian/kapsis/usr/bin/kapsis-quick
 	echo 'exec /usr/lib/kapsis/scripts/quick-start.sh "$$@"' >> $(CURDIR)/debian/kapsis/usr/bin/kapsis-quick
 	chmod 755 $(CURDIR)/debian/kapsis/usr/bin/kapsis-quick
 

--- a/packaging/homebrew/kapsis.rb
+++ b/packaging/homebrew/kapsis.rb
@@ -49,6 +49,7 @@ class Kapsis < Formula
         export KAPSIS_HOME="#{libexec}"
         export KAPSIS_LIB="#{libexec}/scripts/lib"
         export KAPSIS_SCRIPTS="#{libexec}/scripts"
+        export KAPSIS_CMD_NAME="#{cmd}"
         exec "#{libexec}/#{script}" "$@"
       EOS
     end
@@ -81,7 +82,7 @@ class Kapsis < Formula
   end
 
   test do
-    # Test that kapsis command works
-    assert_match "Usage:", shell_output("#{bin}/kapsis --help 2>&1", 1)
+    # Test that kapsis command works (--help returns exit code 0 per Unix convention)
+    assert_match "Usage:", shell_output("#{bin}/kapsis --help 2>&1", 0)
   end
 end

--- a/packaging/rpm/kapsis.spec
+++ b/packaging/rpm/kapsis.spec
@@ -81,6 +81,7 @@ cat > %{buildroot}%{_bindir}/kapsis << 'EOF'
 export KAPSIS_HOME="%{_datadir}/kapsis"
 export KAPSIS_LIB="%{_libexecdir}/kapsis/lib"
 export KAPSIS_SCRIPTS="%{_libexecdir}/kapsis/scripts"
+export KAPSIS_CMD_NAME="kapsis"
 exec %{_libexecdir}/kapsis/scripts/launch-agent.sh "$@"
 EOF
 chmod 755 %{buildroot}%{_bindir}/kapsis
@@ -88,6 +89,7 @@ chmod 755 %{buildroot}%{_bindir}/kapsis
 cat > %{buildroot}%{_bindir}/kapsis-build << 'EOF'
 #!/bin/bash
 export KAPSIS_HOME="%{_datadir}/kapsis"
+export KAPSIS_CMD_NAME="kapsis-build"
 exec %{_libexecdir}/kapsis/scripts/build-image.sh "$@"
 EOF
 chmod 755 %{buildroot}%{_bindir}/kapsis-build
@@ -95,6 +97,7 @@ chmod 755 %{buildroot}%{_bindir}/kapsis-build
 cat > %{buildroot}%{_bindir}/kapsis-cleanup << 'EOF'
 #!/bin/bash
 export KAPSIS_HOME="%{_datadir}/kapsis"
+export KAPSIS_CMD_NAME="kapsis-cleanup"
 exec %{_libexecdir}/kapsis/scripts/kapsis-cleanup.sh "$@"
 EOF
 chmod 755 %{buildroot}%{_bindir}/kapsis-cleanup
@@ -102,6 +105,7 @@ chmod 755 %{buildroot}%{_bindir}/kapsis-cleanup
 cat > %{buildroot}%{_bindir}/kapsis-status << 'EOF'
 #!/bin/bash
 export KAPSIS_HOME="%{_datadir}/kapsis"
+export KAPSIS_CMD_NAME="kapsis-status"
 exec %{_libexecdir}/kapsis/scripts/kapsis-status.sh "$@"
 EOF
 chmod 755 %{buildroot}%{_bindir}/kapsis-status
@@ -109,6 +113,7 @@ chmod 755 %{buildroot}%{_bindir}/kapsis-status
 cat > %{buildroot}%{_bindir}/kapsis-setup << 'EOF'
 #!/bin/bash
 export KAPSIS_HOME="%{_datadir}/kapsis"
+export KAPSIS_CMD_NAME="kapsis-setup"
 exec %{_libexecdir}/kapsis/scripts/setup.sh "$@"
 EOF
 chmod 755 %{buildroot}%{_bindir}/kapsis-setup
@@ -116,6 +121,7 @@ chmod 755 %{buildroot}%{_bindir}/kapsis-setup
 cat > %{buildroot}%{_bindir}/kapsis-quick << 'EOF'
 #!/bin/bash
 export KAPSIS_HOME="%{_datadir}/kapsis"
+export KAPSIS_CMD_NAME="kapsis-quick"
 exec %{_libexecdir}/kapsis/scripts/quick-start.sh "$@"
 EOF
 chmod 755 %{buildroot}%{_bindir}/kapsis-quick

--- a/quick-start.sh
+++ b/quick-start.sh
@@ -34,8 +34,9 @@ CYAN='\033[0;36m'
 NC='\033[0m'
 
 usage() {
+    local cmd_name="${KAPSIS_CMD_NAME:-$0}"
     echo ""
-    echo "Usage: $0 <agent-id> <project> <branch> [spec-file]"
+    echo "Usage: $cmd_name <agent-id> <project> <branch> [spec-file]"
     echo ""
     echo "Arguments:"
     echo "  agent-id   Unique identifier (1, 2, 3, etc.)"
@@ -44,9 +45,9 @@ usage() {
     echo "  spec-file  Optional: Task specification file (default: prompt)"
     echo ""
     echo "Examples:"
-    echo "  $0 1 my-project feature/ABC-123"
-    echo "  $0 1 ~/git/my-project feature/ABC-123 task.md"
-    echo "  $0 2 /path/to/repo feature/DEV-456"
+    echo "  $cmd_name 1 my-project feature/ABC-123"
+    echo "  $cmd_name 1 ~/git/my-project feature/ABC-123 task.md"
+    echo "  $cmd_name 2 /path/to/repo feature/DEV-456"
     echo ""
     echo "Project resolution:"
     echo "  my-app     -> ~/git/my-app (simple names resolve to ~/git/)"

--- a/scripts/kapsis-cleanup.sh
+++ b/scripts/kapsis-cleanup.sh
@@ -60,8 +60,9 @@ TOTAL_SIZE_FREED=0
 ITEMS_CLEANED=0
 
 usage() {
+    local cmd_name="${KAPSIS_CMD_NAME:-$(basename "$0")}"
     cat <<EOF
-Usage: $(basename "$0") [OPTIONS]
+Usage: $cmd_name [OPTIONS]
 
 Reclaim disk space by cleaning up after Kapsis agent work.
 
@@ -89,19 +90,19 @@ WHAT GETS CLEANED:
 
 EXAMPLES:
     # See what would be cleaned
-    $(basename "$0") --dry-run
+    $cmd_name --dry-run
 
     # Clean everything for project 'products'
-    $(basename "$0") --project products --force
+    $cmd_name --project products --force
 
     # Full cleanup including volumes
-    $(basename "$0") --all --volumes
+    $cmd_name --all --volumes
 
     # Clean specific agent
-    $(basename "$0") --agent products 1
+    $cmd_name --agent products 1
 
     # Clear SSH host key cache (after key rotation)
-    $(basename "$0") --ssh-cache
+    $cmd_name --ssh-cache
 EOF
 }
 

--- a/scripts/kapsis-status.sh
+++ b/scripts/kapsis-status.sh
@@ -39,8 +39,9 @@ NC='\033[0m'
 # HELP
 #===============================================================================
 usage() {
+    local cmd_name="${KAPSIS_CMD_NAME:-$(basename "$0")}"
     cat << EOF
-Usage: $(basename "$0") [options] [project] [agent-id]
+Usage: $cmd_name [options] [project] [agent-id]
 
 Query and monitor Kapsis agent status.
 
@@ -55,11 +56,11 @@ Arguments:
   agent-id        Agent ID (optional, requires project)
 
 Examples:
-  $(basename "$0")                    # List all agents
-  $(basename "$0") products 1         # Show specific agent
-  $(basename "$0") --watch            # Live monitoring
-  $(basename "$0") --json             # JSON output for scripting
-  $(basename "$0") --cleanup          # Remove old status files
+  $cmd_name                    # List all agents
+  $cmd_name products 1         # Show specific agent
+  $cmd_name --watch            # Live monitoring
+  $cmd_name --json             # JSON output for scripting
+  $cmd_name --cleanup          # Remove old status files
 
 Status Files Location: $KAPSIS_STATUS_DIR
 EOF

--- a/scripts/launch-agent.sh
+++ b/scripts/launch-agent.sh
@@ -210,12 +210,13 @@ query_secret_store_with_fallbacks() {
 # Displays help text and exits with the given code (default: 0 for help, 1 for errors)
 usage() {
     local exit_code="${1:-0}"
+    local cmd_name="${KAPSIS_CMD_NAME:-$(basename "$0")}"
     cat << EOF
-Usage: $(basename "$0") <project-path> [options]
-       $(basename "$0") --version
-       $(basename "$0") --check-upgrade
-       $(basename "$0") --upgrade [VERSION] [--dry-run]
-       $(basename "$0") --downgrade [VERSION] [--dry-run]
+Usage: $cmd_name <project-path> [options]
+       $cmd_name --version
+       $cmd_name --check-upgrade
+       $cmd_name --upgrade [VERSION] [--dry-run]
+       $cmd_name --downgrade [VERSION] [--dry-run]
 
 Launch an AI coding agent in an isolated Podman container.
 
@@ -260,24 +261,24 @@ Task Input (one required unless --interactive):
 
 Examples:
   # Simple task (agent ID auto-generated)
-  $(basename "$0") ~/project --task "fix failing tests in UserService"
+  $cmd_name ~/project --task "fix failing tests in UserService"
 
   # Complex task with spec file
-  $(basename "$0") ~/project --spec ./specs/user-preferences.md
+  $cmd_name ~/project --spec ./specs/user-preferences.md
 
   # With git branch workflow (creates or continues)
-  $(basename "$0") ~/project --branch feature/DEV-123 --spec ./task.md
+  $cmd_name ~/project --branch feature/DEV-123 --spec ./task.md
 
   # Continue a previous session (use same agent ID)
-  $(basename "$0") ~/project --agent-id a3f2b1 --branch feature/DEV-123 --task "continue"
+  $cmd_name ~/project --agent-id a3f2b1 --branch feature/DEV-123 --task "continue"
 
   # Multiple agents in parallel (each gets unique auto-ID)
-  $(basename "$0") ~/project --branch feature/DEV-123-api --spec ./api.md &
-  $(basename "$0") ~/project --branch feature/DEV-123-ui --spec ./ui.md &
+  $cmd_name ~/project --branch feature/DEV-123-api --spec ./api.md &
+  $cmd_name ~/project --branch feature/DEV-123-ui --spec ./ui.md &
   wait
 
   # Interactive exploration
-  $(basename "$0") ~/project --interactive --branch experiment/explore
+  $cmd_name ~/project --interactive --branch experiment/explore
 
 EOF
     exit "$exit_code"

--- a/setup.sh
+++ b/setup.sh
@@ -730,7 +730,8 @@ run_validation() {
 #===============================================================================
 
 show_usage() {
-    echo "Usage: $0 [OPTIONS]"
+    local cmd_name="${KAPSIS_CMD_NAME:-$0}"
+    echo "Usage: $cmd_name [OPTIONS]"
     echo ""
     echo "Options:"
     echo "  --check      Check dependencies only (no changes)"
@@ -742,9 +743,9 @@ show_usage() {
     echo "  --help       Show this help message"
     echo ""
     echo "Examples:"
-    echo "  $0 --check              # Just check what's needed"
-    echo "  $0 --all                # Full automated setup"
-    echo "  $0 --install --build    # Install deps and build image"
+    echo "  $cmd_name --check              # Just check what's needed"
+    echo "  $cmd_name --all                # Full automated setup"
+    echo "  $cmd_name --install --build    # Install deps and build image"
 }
 
 main() {


### PR DESCRIPTION
When installed via package manager (Homebrew, apt, dnf), the help text
now correctly shows the wrapper command name (e.g., 'kapsis') instead
of the underlying script name (e.g., 'launch-agent.sh').

Changes:
- Add KAPSIS_CMD_NAME env var support to usage functions in all scripts
- Update Homebrew, Debian, and RPM wrappers to export KAPSIS_CMD_NAME
- Fix Homebrew test to expect exit code 0 for --help (per Unix convention)

The usage functions now use: ${KAPSIS_CMD_NAME:-$(basename "$0")}
This falls back to the script basename when run directly.