### PR TITLE
fix(network): add artifactory-build to DNS allowlist

### DIFF
--- a/configs/network-allowlist.yaml
+++ b/configs/network-allowlist.yaml
@@ -126,6 +126,7 @@ network:
     # Custom/corporate hosts (add your internal registries here)
     custom:
       - artifactory.taboolasyndication.com
+      - artifactory-build.taboolasyndication.com
       - ci.taboolasyndication.com
 
   # DNS servers to use for resolving allowed domains


### PR DESCRIPTION
## Summary

- Add `artifactory-build.taboolasyndication.com` to the default network allowlist

## Problem

Issue #114 reported that Maven validation fails inside Kapsis containers. Investigation revealed:

1. Default network mode is `filtered` (DNS-based allowlist)
2. `aviad-claude.yaml` uses `artifactory-build.taboolasyndication.com` as Maven mirror
3. The default `network-allowlist.yaml` only had `artifactory.taboolasyndication.com`
4. DNS resolution for the Artifactory server returned NXDOMAIN, causing Maven to fail

## Solution

Add the missing domain to the default allowlist so Maven can resolve the Artifactory server.

## Test plan

- [x] YAML validation passes (`yq eval '.network.allowlist.custom'`)
- [ ] Run Kapsis with `--network-mode=filtered` and verify Maven can resolve `artifactory-build.taboolasyndication.com`

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)