### PR TITLE
fix(ci): map schedule event to manual for differential-shellcheck

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -31,6 +31,9 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           severity: warning
+          # Map schedule/workflow_dispatch events to 'manual' since the action
+          # only supports: merge_group, pull_request, push, manual
+          triggering-event: ${{ github.event_name == 'schedule' && 'manual' || github.event_name == 'workflow_dispatch' && 'manual' || github.event_name }}
 
   container-scan:
     name: Container Vulnerability Scan


### PR DESCRIPTION
## Summary
- Fix ShellCheck SARIF workflow failure when triggered by `schedule` or `workflow_dispatch` events
- The `differential-shellcheck` action only supports: `merge_group`, `pull_request`, `push`, `manual`
- Map unsupported events to `manual` to allow full (non-differential) scans

## Root Cause
The action was failing with:
```
Value of required variable INPUT_TRIGGERING_EVENT isn't set or contains unsupported value.
Supported values are: (merge_group | pull_request | push | manual).
```

When the workflow runs on schedule (weekly cron), GitHub sets `github.event_name` to `schedule`, which the action doesn't recognize.

## Test plan
- [x] Verify the fix by reviewing the conditional expression logic
- [ ] Wait for next scheduled run (Sunday 00:00 UTC) or trigger manually via workflow_dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)