### PR TITLE
fix(security): sanitize secrets in debug logs

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -38,7 +38,18 @@ else
     log_success() { echo -e "${GREEN}[KAPSIS]${NC} $*"; }
     log_warn() { echo -e "${YELLOW}[KAPSIS]${NC} $*"; }
     log_error() { echo -e "\033[0;31m[KAPSIS]\033[0m $*" >&2; }
-    log_debug() { [[ -n "${KAPSIS_DEBUG:-}" ]] && echo -e "\033[0;90m[DEBUG]\033[0m $*"; }
+    # Fallback sanitize_secrets for when logging.sh is not available
+    # Security: Mask sensitive environment variables in log output
+    sanitize_secrets() {
+        echo "$*" | sed -E 's/(-e [A-Za-z0-9_]*(KEY|TOKEN|SECRET|PASSWORD|CREDENTIALS|AUTH|BEARER|API_KEY|PRIVATE)[A-Za-z0-9_]*)=[^ ]*/\1=***MASKED***/gi'
+    }
+    log_debug() {
+        if [[ -n "${KAPSIS_DEBUG:-}" ]]; then
+            local sanitized
+            sanitized=$(sanitize_secrets "$*")
+            echo -e "\033[0;90m[DEBUG]\033[0m $sanitized"
+        fi
+    }
 fi
 
 # Source status reporting library if available

--- a/scripts/lib/logging.sh
+++ b/scripts/lib/logging.sh
@@ -347,13 +347,68 @@ log_success() {
 }
 
 # =============================================================================
+# Secret Sanitization
+# =============================================================================
+
+# Patterns that indicate sensitive variable names (case-insensitive)
+# These patterns match environment variable names containing sensitive keywords
+_KAPSIS_SECRET_PATTERNS='(KEY|TOKEN|SECRET|PASSWORD|CREDENTIALS|AUTH|BEARER|API_KEY|PRIVATE)'
+
+# Sanitize secrets from a string for safe logging
+# This function masks values of variables that appear to contain secrets.
+# Usage: sanitize_secrets "string with -e MY_TOKEN=secret123"
+# Returns: "string with -e MY_TOKEN=***MASKED***"
+sanitize_secrets() {
+    local input="$*"
+
+    # Pattern 1: Mask -e VAR=value format (container env vars)
+    # Matches: -e SOME_TOKEN=value, -e API_KEY=value, etc.
+    local result
+    result=$(echo "$input" | sed -E "s/(-e [A-Za-z0-9_]*${_KAPSIS_SECRET_PATTERNS}[A-Za-z0-9_]*)=[^ ]*/\1=***MASKED***/gi")
+
+    # Pattern 2: Mask VAR=value at word boundary (general env var format)
+    # Matches: MY_SECRET=value, API_TOKEN=value at start or after space
+    result=$(echo "$result" | sed -E "s/(^|[[:space:]])([A-Za-z0-9_]*${_KAPSIS_SECRET_PATTERNS}[A-Za-z0-9_]*)=[^[:space:]]*/\1\2=***MASKED***/gi")
+
+    # Pattern 3: Mask common token formats (Bearer tokens, base64 tokens)
+    # Matches: Bearer xyz123..., authorization headers
+    result=$(echo "$result" | sed -E 's/(Bearer|Authorization:)[[:space:]]+[^[:space:]]+/\1 ***MASKED***/gi')
+
+    echo "$result"
+}
+
+# Check if a variable name looks like it contains a secret
+# Usage: if is_secret_var_name "MY_TOKEN"; then ...
+is_secret_var_name() {
+    local var_name="$1"
+    echo "$var_name" | grep -qiE "$_KAPSIS_SECRET_PATTERNS"
+}
+
+# Sanitize a variable value if the variable name suggests it's a secret
+# Usage: sanitize_var_value "VAR_NAME" "value"
+# Returns: "value" or "***MASKED***"
+sanitize_var_value() {
+    local var_name="$1"
+    local var_value="$2"
+
+    if is_secret_var_name "$var_name"; then
+        echo "***MASKED***"
+    else
+        echo "$var_value"
+    fi
+}
+
+# =============================================================================
 # Utility Functions
 # =============================================================================
 
 # Log a command before executing it (useful for debugging)
 # Security: Use "$@" instead of eval to prevent command injection
+# Security: Sanitize potential secrets from logged output
 log_cmd() {
-    log_debug "Executing: $*"
+    local sanitized
+    sanitized=$(sanitize_secrets "$*")
+    log_debug "Executing: $sanitized"
     "$@"
     local rc=$?
     if [[ $rc -ne 0 ]]; then
@@ -363,9 +418,12 @@ log_cmd() {
 }
 
 # Log entry into a function
+# Security: Sanitize potential secrets from function arguments
 log_enter() {
     local func="${FUNCNAME[1]:-unknown}"
-    log_debug ">>> Entering ${func}() with args: $*"
+    local sanitized_args
+    sanitized_args=$(sanitize_secrets "$*")
+    log_debug ">>> Entering ${func}() with args: $sanitized_args"
 }
 
 # Log exit from a function
@@ -376,10 +434,13 @@ log_exit() {
 }
 
 # Log a variable's value
+# Security: Mask values of variables with sensitive names
 log_var() {
     local var_name="$1"
     local var_value="${!var_name:-<unset>}"
-    log_debug "${var_name}=${var_value}"
+    local sanitized_value
+    sanitized_value=$(sanitize_var_value "$var_name" "$var_value")
+    log_debug "${var_name}=${sanitized_value}"
 }
 
 # Log multiple variables

--- a/tests/test-logging.sh
+++ b/tests/test-logging.sh
@@ -702,6 +702,209 @@ test_legacy_log_functions() {
 }
 
 #===============================================================================
+# SECRET SANITIZATION TESTS
+#===============================================================================
+
+test_sanitize_secrets_masks_env_vars() {
+    log_test "sanitize_secrets: masks -e VAR=value format"
+
+    local result
+    result=$(run_logging_test '
+        local input="podman run -e API_KEY=secret123 -e NORMAL_VAR=ok -e MY_TOKEN=abc"
+        sanitize_secrets "$input"
+    ')
+
+    # Should mask API_KEY and MY_TOKEN but not NORMAL_VAR
+    assert_contains "$result" "API_KEY=***MASKED***" "API_KEY should be masked"
+    assert_contains "$result" "MY_TOKEN=***MASKED***" "MY_TOKEN should be masked"
+    assert_contains "$result" "NORMAL_VAR=ok" "NORMAL_VAR should NOT be masked"
+}
+
+test_sanitize_secrets_masks_secret_patterns() {
+    log_test "sanitize_secrets: masks various secret patterns"
+
+    local patterns=(
+        "-e MY_SECRET=hidden"
+        "-e DB_PASSWORD=pass123"
+        "-e CREDENTIALS_FILE=/path"
+        "-e AUTH_TOKEN=xyz"
+        "-e BEARER_TOKEN=abc"
+        "-e PRIVATE_KEY=key"
+    )
+
+    for pattern in "${patterns[@]}"; do
+        local result
+        result=$(run_logging_test "
+            sanitize_secrets '$pattern'
+        ")
+
+        # All of these should be masked
+        if [[ "$result" == *"=***MASKED***"* ]]; then
+            log_pass "Pattern '$pattern' was correctly masked"
+        else
+            log_fail "Pattern '$pattern' should be masked but got: $result"
+            return 1
+        fi
+    done
+}
+
+test_sanitize_secrets_case_insensitive() {
+    log_test "sanitize_secrets: case insensitive matching"
+
+    local result
+    result=$(run_logging_test '
+        local input="-e api_key=lower -e API_KEY=upper -e Api_Key=mixed"
+        sanitize_secrets "$input"
+    ')
+
+    # Count masked values - should be 3
+    local masked_count
+    masked_count=$(echo "$result" | grep -o '=\*\*\*MASKED\*\*\*' | wc -l | tr -d ' ')
+
+    assert_equals "3" "$masked_count" "All case variants should be masked"
+}
+
+test_sanitize_secrets_preserves_safe_vars() {
+    log_test "sanitize_secrets: preserves non-sensitive variables"
+
+    local result
+    result=$(run_logging_test '
+        local input="-e HOME=/home/user -e PATH=/bin -e KAPSIS_PROJECT=myproject"
+        sanitize_secrets "$input"
+    ')
+
+    assert_contains "$result" "HOME=/home/user" "HOME should NOT be masked"
+    assert_contains "$result" "PATH=/bin" "PATH should NOT be masked"
+    assert_contains "$result" "KAPSIS_PROJECT=myproject" "KAPSIS_PROJECT should NOT be masked"
+}
+
+test_is_secret_var_name() {
+    log_test "is_secret_var_name: correctly identifies secret names"
+
+    (
+        unset _KAPSIS_LOGGING_LOADED
+        export KAPSIS_LOG_DIR="$TEST_LOG_DIR"
+        export KAPSIS_LOG_CONSOLE="false"
+        source "$KAPSIS_ROOT/scripts/lib/logging.sh"
+        log_init "secret-name-test"
+
+        # Should return true (0) for secret names
+        is_secret_var_name "API_KEY" || exit 1
+        is_secret_var_name "MY_TOKEN" || exit 2
+        is_secret_var_name "DB_PASSWORD" || exit 3
+        is_secret_var_name "AUTH_SECRET" || exit 4
+
+        # Should return false (1) for safe names
+        is_secret_var_name "HOME" && exit 5
+        is_secret_var_name "PATH" && exit 6
+        is_secret_var_name "KAPSIS_PROJECT" && exit 7
+
+        exit 0
+    )
+    local result=$?
+
+    case $result in
+        0) log_pass "is_secret_var_name works correctly" ;;
+        1) log_fail "API_KEY should be detected as secret"; return 1 ;;
+        2) log_fail "MY_TOKEN should be detected as secret"; return 1 ;;
+        3) log_fail "DB_PASSWORD should be detected as secret"; return 1 ;;
+        4) log_fail "AUTH_SECRET should be detected as secret"; return 1 ;;
+        5) log_fail "HOME should NOT be detected as secret"; return 1 ;;
+        6) log_fail "PATH should NOT be detected as secret"; return 1 ;;
+        7) log_fail "KAPSIS_PROJECT should NOT be detected as secret"; return 1 ;;
+        *) log_fail "Unexpected exit code: $result"; return 1 ;;
+    esac
+}
+
+test_sanitize_var_value_masks_secrets() {
+    log_test "sanitize_var_value: masks values for secret variable names"
+
+    local result
+    result=$(run_logging_test '
+        echo "$(sanitize_var_value "API_KEY" "super-secret-value")"
+    ')
+
+    assert_equals "***MASKED***" "$result" "Secret variable value should be masked"
+}
+
+test_sanitize_var_value_preserves_safe() {
+    log_test "sanitize_var_value: preserves values for non-secret names"
+
+    local result
+    result=$(run_logging_test '
+        echo "$(sanitize_var_value "HOME" "/home/user")"
+    ')
+
+    assert_equals "/home/user" "$result" "Non-secret variable value should NOT be masked"
+}
+
+test_log_var_masks_secrets() {
+    log_test "log_var: masks values of variables with secret names"
+
+    local log_file="$TEST_LOG_DIR/kapsis-var-secret.log"
+
+    (
+        unset _KAPSIS_LOGGING_LOADED
+        export KAPSIS_LOG_DIR="$TEST_LOG_DIR"
+        export KAPSIS_LOG_CONSOLE="false"
+        export KAPSIS_LOG_LEVEL="DEBUG"
+        source "$KAPSIS_ROOT/scripts/lib/logging.sh"
+        log_init "var-secret"
+
+        # shellcheck disable=SC2034  # Variable used by log_var
+        API_KEY="super-secret-value"
+        log_var API_KEY
+    )
+
+    assert_file_contains "$log_file" "API_KEY=***MASKED***" "Secret variable should be masked in log_var"
+    assert_file_not_contains "$log_file" "super-secret-value" "Actual secret value should NOT appear"
+}
+
+test_log_cmd_sanitizes_command() {
+    log_test "log_cmd: sanitizes secrets in logged commands"
+
+    local log_file="$TEST_LOG_DIR/kapsis-cmd-secret.log"
+
+    (
+        unset _KAPSIS_LOGGING_LOADED
+        export KAPSIS_LOG_DIR="$TEST_LOG_DIR"
+        export KAPSIS_LOG_CONSOLE="false"
+        export KAPSIS_LOG_LEVEL="DEBUG"
+        source "$KAPSIS_ROOT/scripts/lib/logging.sh"
+        log_init "cmd-secret"
+
+        # Run a command that includes what looks like a secret
+        log_cmd echo "-e API_KEY=secret123 test" >/dev/null 2>&1 || true
+    )
+
+    assert_file_not_contains "$log_file" "secret123" "Secret value should NOT appear in command log"
+    assert_file_contains "$log_file" "API_KEY=***MASKED***" "Secret should be masked in command log"
+}
+
+test_log_enter_sanitizes_args() {
+    log_test "log_enter: sanitizes secrets in function arguments"
+
+    local log_file="$TEST_LOG_DIR/kapsis-enter-secret.log"
+
+    (
+        unset _KAPSIS_LOGGING_LOADED
+        export KAPSIS_LOG_DIR="$TEST_LOG_DIR"
+        export KAPSIS_LOG_CONSOLE="false"
+        export KAPSIS_LOG_LEVEL="DEBUG"
+        source "$KAPSIS_ROOT/scripts/lib/logging.sh"
+        log_init "enter-secret"
+
+        my_secret_function() {
+            log_enter "-e API_TOKEN=mysecret123"
+        }
+        my_secret_function
+    )
+
+    assert_file_not_contains "$log_file" "mysecret123" "Secret should NOT appear in log_enter"
+    assert_file_contains "$log_file" "API_TOKEN=***MASKED***" "Secret should be masked in log_enter"
+}
+
+#===============================================================================
 # LOG TAIL TEST
 #===============================================================================
 
@@ -795,6 +998,18 @@ main() {
 
     # Tail test
     run_test test_log_tail
+
+    # Secret sanitization tests
+    run_test test_sanitize_secrets_masks_env_vars
+    run_test test_sanitize_secrets_masks_secret_patterns
+    run_test test_sanitize_secrets_case_insensitive
+    run_test test_sanitize_secrets_preserves_safe_vars
+    run_test test_is_secret_var_name
+    run_test test_sanitize_var_value_masks_secrets
+    run_test test_sanitize_var_value_preserves_safe
+    run_test test_log_var_masks_secrets
+    run_test test_log_cmd_sanitizes_command
+    run_test test_log_enter_sanitizes_args
 
     # Summary
     print_summary


### PR DESCRIPTION
## Summary

- Fix security issue where debug logs were exposing sensitive environment variables (API keys, tokens, passwords) when `KAPSIS_DEBUG` was enabled
- Add comprehensive `sanitize_secrets()` function to mask sensitive values in log output
- Update `log_cmd()`, `log_enter()`, and `log_var()` to automatically sanitize their output
- Add fallback sanitization in entrypoint.sh when logging.sh is not available

## Changes

| File | Change |
|------|--------|
| `scripts/lib/logging.sh` | Add secret sanitization functions and update logging utilities |
| `scripts/launch-agent.sh` | Fix container command debug log to use sanitization |
| `scripts/entrypoint.sh` | Add fallback sanitization when logging.sh unavailable |
| `tests/test-logging.sh` | Add 10 new tests for secret sanitization |

## Patterns Masked

Variables containing these keywords (case-insensitive) are now masked:
- `KEY`, `TOKEN`, `SECRET`, `PASSWORD`, `CREDENTIALS`
- `AUTH`, `BEARER`, `API_KEY`, `PRIVATE`

## Example

**Before:**
```
[DEBUG] Container command: podman run -e API_KEY=supersecret123 -e GITHUB_TOKEN=ghp_abc ...
```

**After:**
```
[DEBUG] Container command: podman run -e API_KEY=***MASKED*** -e GITHUB_TOKEN=***MASKED*** ...
```

## Test plan

- [x] All 39 logging tests pass (including 10 new secret sanitization tests)
- [x] Verified `sanitize_secrets()` correctly masks sensitive patterns
- [x] Verified non-sensitive variables are preserved
- [ ] Manual test with `KAPSIS_DEBUG=1` to verify no secrets leak

🤖 Generated with [Claude Code](https://claude.ai/code)