### PR TITLE
fix: replace heredoc with echo commands in protoc cache section

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -168,6 +168,32 @@ RUN mkdir -p /tmp/ge-cache && cd /tmp/ge-cache && \
     rm -rf /tmp/ge-cache
 
 #===============================================================================
+# PRE-CACHE PROTOC BINARIES FOR JAVA BUILDS
+#===============================================================================
+# The protobuf-maven-plugin downloads platform-specific protoc binaries.
+# Pre-caching ensures builds work in DNS-filtered network mode.
+ARG PROTOC_VERSION=25.1
+
+RUN mkdir -p /tmp/protoc-cache && cd /tmp/protoc-cache && \
+    # Create minimal pom to resolve protoc binaries
+    echo '<?xml version="1.0" encoding="UTF-8"?>' > pom.xml && \
+    echo '<project><modelVersion>4.0.0</modelVersion>' >> pom.xml && \
+    echo '<groupId>kapsis</groupId><artifactId>protoc-cache</artifactId><version>1.0</version>' >> pom.xml && \
+    echo '<dependencies>' >> pom.xml && \
+    echo "  <dependency><groupId>com.google.protobuf</groupId><artifactId>protoc</artifactId><version>${PROTOC_VERSION}</version><classifier>linux-x86_64</classifier><type>exe</type></dependency>" >> pom.xml && \
+    echo "  <dependency><groupId>com.google.protobuf</groupId><artifactId>protoc</artifactId><version>${PROTOC_VERSION}</version><classifier>linux-aarch_64</classifier><type>exe</type></dependency>" >> pom.xml && \
+    echo '</dependencies></project>' >> pom.xml && \
+    # Download to global location that will be copied to user's .m2 later
+    source "$SDKMAN_DIR/bin/sdkman-init.sh" && \
+    mvn -B dependency:resolve -Dmaven.repo.local=/opt/kapsis/m2-cache \
+        -DincludeScope=runtime 2>/dev/null || true && \
+    find /opt/kapsis/m2-cache -name "_remote.repositories" -delete && \
+    rm -rf /tmp/protoc-cache
+
+# Make protoc binaries executable
+RUN find /opt/kapsis/m2-cache -name "protoc-*" -type f -exec chmod +x {} \;
+
+#===============================================================================
 # NON-ROOT USER SETUP
 #===============================================================================
 ARG USER_ID=1000


### PR DESCRIPTION
The heredoc syntax with '&& \' continuation doesn't work in Dockerfile
RUN commands. Convert to use echo commands (same pattern as GE extension
section) to fix the "Syntax error: end of file unexpected" build failure.

Fixes PR #127 test issue.

https://claude.ai/code/session_01BNhAMMiS5Esh8ynBwHpjQ5