### PR TITLE
fix(java): use fallback chain for Java version switching

### DIFF
--- a/scripts/switch-java.sh
+++ b/scripts/switch-java.sh
@@ -24,23 +24,29 @@ fi
 
 case "$VERSION" in
     8|1.8)
-        sdk use java 8.0.392-tem
+        # Try zulu first (used in full-stack/java8-legacy profiles), then tem as fallback
+        sdk use java 8.0.422-zulu 2>/dev/null || sdk use java 8.0.392-tem 2>/dev/null || {
+            echo "Java 8 not installed."
+            exit 1
+        }
         ;;
     11)
-        sdk use java 11.0.21-tem 2>/dev/null || {
-            echo "Java 11 not installed. Installing..."
-            sdk install java 11.0.21-tem
-            sdk use java 11.0.21-tem
+        sdk use java 11.0.21-tem 2>/dev/null || sdk use java 11.0.25-zulu 2>/dev/null || {
+            echo "Java 11 not installed."
+            exit 1
         }
         ;;
     17)
-        sdk use java 17.0.9-tem
+        # Try zulu first (used in full-stack profile), then tem as fallback
+        sdk use java 17.0.14-zulu 2>/dev/null || sdk use java 17.0.9-tem 2>/dev/null || {
+            echo "Java 17 not installed."
+            exit 1
+        }
         ;;
     21)
-        sdk use java 21.0.1-tem 2>/dev/null || {
-            echo "Java 21 not installed. Installing..."
-            sdk install java 21.0.1-tem
-            sdk use java 21.0.1-tem
+        sdk use java 21.0.6-zulu 2>/dev/null || sdk use java 21.0.1-tem 2>/dev/null || {
+            echo "Java 21 not installed."
+            exit 1
         }
         ;;
     *)


### PR DESCRIPTION
## Summary
- Fix switch-java.sh to try zulu distributions first (the Kapsis default)
- Fall back to tem (Temurin) if zulu is not available
- Remove auto-install behavior in favor of fail-fast approach

## Problem
The script was hardcoded with Temurin versions that don't match what's installed in Kapsis container images (which use zulu distributions).

## Test plan
- [x] Tested Java 8 switching in container with full-stack profile
- [ ] Run `./tests/run-all-tests.sh --quick`

🤖 Generated with [Claude Code](https://claude.com/claude-code)