### PR TITLE
fix(security): add NET_BIND_SERVICE to default capabilities

### DIFF
--- a/configs/aider.yaml
+++ b/configs/aider.yaml
@@ -24,6 +24,18 @@ resources:
   memory: 8g
   cpus: 4
 
+#===============================================================================
+# SECURITY - Container security hardening
+#===============================================================================
+security:
+  profile: standard
+
+  # Additional capabilities needed for specific features
+  capabilities:
+    add:
+      # Required for network.mode: filtered (dnsmasq binds to port 53)
+      - NET_BIND_SERVICE
+
 maven:
   mirror_url: "https://artifactory.example.org/artifactory/releases"
   block_remote_snapshots: true

--- a/configs/claude.yaml
+++ b/configs/claude.yaml
@@ -51,6 +51,12 @@ resources:
 security:
   profile: standard
 
+  # Additional capabilities needed for specific features
+  capabilities:
+    add:
+      # Required for network.mode: filtered (dnsmasq binds to port 53)
+      - NET_BIND_SERVICE
+
   # Enable seccomp filtering to block ptrace/mount/bpf syscalls
   # This adds kernel-level protection against container escape attempts
   seccomp:

--- a/configs/codex.yaml
+++ b/configs/codex.yaml
@@ -23,6 +23,18 @@ resources:
   memory: 8g
   cpus: 4
 
+#===============================================================================
+# SECURITY - Container security hardening
+#===============================================================================
+security:
+  profile: standard
+
+  # Additional capabilities needed for specific features
+  capabilities:
+    add:
+      # Required for network.mode: filtered (dnsmasq binds to port 53)
+      - NET_BIND_SERVICE
+
 maven:
   mirror_url: "https://artifactory.example.org/artifactory/releases"
   block_remote_snapshots: true

--- a/configs/interactive.yaml
+++ b/configs/interactive.yaml
@@ -28,6 +28,18 @@ resources:
   memory: 8g
   cpus: 4
 
+#===============================================================================
+# SECURITY - Container security hardening
+#===============================================================================
+security:
+  profile: standard
+
+  # Additional capabilities needed for specific features
+  capabilities:
+    add:
+      # Required for network.mode: filtered (dnsmasq binds to port 53)
+      - NET_BIND_SERVICE
+
 maven:
   mirror_url: "https://artifactory.example.org/artifactory/releases"
   block_remote_snapshots: true

--- a/docs/CONFIG-REFERENCE.md
+++ b/docs/CONFIG-REFERENCE.md
@@ -279,6 +279,15 @@ security:
     # Default: true for paranoid only
     required: false
 
+  # Container capabilities
+  # By default, Kapsis drops all capabilities and adds back a minimal set.
+  # Use this to add additional capabilities required by specific features.
+  capabilities:
+    # Additional capabilities to add to the container
+    # Common use case: NET_BIND_SERVICE for DNS filtering (dnsmasq on port 53)
+    add:
+      - NET_BIND_SERVICE  # Required for network.mode: filtered
+
 #===============================================================================
 # MAVEN ISOLATION
 #===============================================================================

--- a/scripts/launch-agent.sh
+++ b/scripts/launch-agent.sh
@@ -727,6 +727,20 @@ parse_config() {
         # Parse DNS logging setting
         NETWORK_LOG_DNS=$(yq eval '.network.log_dns_queries // "false"' "$CONFIG_FILE" 2>/dev/null || echo "false")
 
+        # Parse security capabilities from config
+        # These are added to KAPSIS_CAPS_ADD for the capability generation
+        local config_caps_add
+        config_caps_add=$(yq eval '.security.capabilities.add // [] | join(",")' "$CONFIG_FILE" 2>/dev/null || echo "")
+        if [[ -n "$config_caps_add" ]]; then
+            # Merge with existing KAPSIS_CAPS_ADD (env var takes precedence for overrides)
+            if [[ -n "${KAPSIS_CAPS_ADD:-}" ]]; then
+                KAPSIS_CAPS_ADD="${KAPSIS_CAPS_ADD},${config_caps_add}"
+            else
+                KAPSIS_CAPS_ADD="$config_caps_add"
+            fi
+            export KAPSIS_CAPS_ADD
+        fi
+
         # Parse security section (lower priority than env vars and CLI)
         # Only set if not already set by env var or CLI flag
         local cfg_security_profile

--- a/scripts/lib/security.sh
+++ b/scripts/lib/security.sh
@@ -80,6 +80,7 @@ KAPSIS_CAPS_MINIMAL=(
     "SETGID"         # Group ID changes
     "SETUID"         # User ID changes
     "SYS_NICE"       # Process priority (Maven/Gradle)
+    "NET_BIND_SERVICE"  # Bind to privileged ports (dnsmasq for DNS filtering)
 )
 
 # Generate capability arguments for podman


### PR DESCRIPTION
## Summary

DNS filtering (`network.mode: filtered`) requires dnsmasq to bind to port 53, which needs the `NET_BIND_SERVICE` capability. Previously, users had to manually add this capability via environment variable or config, causing "Failed to start dnsmasq" errors.

## Changes

- Add `NET_BIND_SERVICE` to `KAPSIS_CAPS_MINIMAL` array in `security.sh` (default capability)
- Add `security.capabilities.add` config parsing in `launch-agent.sh`
- Document `security.capabilities.add` option in `CONFIG-REFERENCE.md`
- Update all agent configs with security section including the capability

## Test plan

- [ ] Run kapsis with `network.mode: filtered` without any capability config
- [ ] Verify dnsmasq starts successfully
- [ ] Verify DNS filtering works (allowed domains resolve, blocked domains fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)