### PR TITLE
fix: use set -e safe arithmetic in DNS scripts

### DIFF
--- a/scripts/lib/dns-filter.sh
+++ b/scripts/lib/dns-filter.sh
@@ -195,7 +195,7 @@ EOF
             done
 
             log_debug "Pinned: $pin_domain -> $pin_ips"
-            ((pinned_count++))
+            pinned_count=$((pinned_count + 1))
         done < "$pinned_file"
 
         log_success "Loaded $pinned_count pinned domain(s) from host resolution"
@@ -272,7 +272,7 @@ EOF
                         echo "server=/${domain}/${primary_dns}" >> "$config_file"
                         log_debug "Added domain: $domain"
                     fi
-                    ((domain_count++))
+                    domain_count=$((domain_count + 1))
                 else
                     log_warn "Skipping invalid domain: $domain"
                 fi
@@ -308,7 +308,7 @@ EOF
                 else
                     echo "server=/${domain}/${primary_dns}" >> "$config_file"
                 fi
-                ((domain_count++))
+                domain_count=$((domain_count + 1))
             fi
         done
     fi
@@ -618,10 +618,10 @@ protect_dns_files() {
     if [[ -f /etc/resolv.conf ]]; then
         if chmod 444 /etc/resolv.conf 2>/dev/null; then
             log_debug "Protected /etc/resolv.conf (read-only)"
-            ((protected++))
+            protected=$((protected + 1))
         else
             log_warn "Cannot protect /etc/resolv.conf - may require root"
-            ((failed++))
+            failed=$((failed + 1))
         fi
     fi
 
@@ -629,10 +629,10 @@ protect_dns_files() {
     if [[ -f /etc/hosts ]]; then
         if chmod 444 /etc/hosts 2>/dev/null; then
             log_debug "Protected /etc/hosts (read-only)"
-            ((protected++))
+            protected=$((protected + 1))
         else
             log_warn "Cannot protect /etc/hosts - may require root"
-            ((failed++))
+            failed=$((failed + 1))
         fi
     fi
 
@@ -640,10 +640,10 @@ protect_dns_files() {
     if [[ -f "${KAPSIS_DNS_PID_FILE}" ]]; then
         if chmod 400 "${KAPSIS_DNS_PID_FILE}" 2>/dev/null; then
             log_debug "Protected ${KAPSIS_DNS_PID_FILE} (owner read-only)"
-            ((protected++))
+            protected=$((protected + 1))
         else
             log_warn "Cannot protect ${KAPSIS_DNS_PID_FILE}"
-            ((failed++))
+            failed=$((failed + 1))
         fi
     fi
 
@@ -651,10 +651,10 @@ protect_dns_files() {
     if [[ -f "${KAPSIS_DNS_CONFIG_FILE}" ]]; then
         if chmod 400 "${KAPSIS_DNS_CONFIG_FILE}" 2>/dev/null; then
             log_debug "Protected ${KAPSIS_DNS_CONFIG_FILE} (owner read-only)"
-            ((protected++))
+            protected=$((protected + 1))
         else
             log_warn "Cannot protect ${KAPSIS_DNS_CONFIG_FILE}"
-            ((failed++))
+            failed=$((failed + 1))
         fi
     fi
 

--- a/scripts/lib/dns-pin.sh
+++ b/scripts/lib/dns-pin.sh
@@ -88,14 +88,14 @@ resolve_allowlist_domains() {
         if [[ "$domain" == "*."* ]]; then
             log_warn "SECURITY: Wildcard '$domain' cannot be IP-pinned - vulnerable to DNS manipulation"
             log_warn "  Consider using concrete subdomains instead of wildcards for better security"
-            ((wildcard_count++))
+            wildcard_count=$((wildcard_count + 1))
             continue
         fi
 
         # Skip if already an IP address (just echo it back)
         if [[ "$domain" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "$domain $domain"
-            ((resolved_count++))
+            resolved_count=$((resolved_count + 1))
             continue
         fi
 
@@ -109,10 +109,10 @@ resolve_allowlist_domains() {
             ip_list=$(echo "$ips" | tr '\n' ' ' | sed 's/ $//')
             echo "$domain $ip_list"
             log_debug "Resolved $domain -> $ip_list"
-            ((resolved_count++))
+            resolved_count=$((resolved_count + 1))
         else
             log_warn "Failed to resolve domain: $domain"
-            ((failed_count++))
+            failed_count=$((failed_count + 1))
         fi
     done
 
@@ -331,7 +331,7 @@ validate_pinned_file() {
     while IFS= read -r line; do
         if ! validate_pinned_entry "$line"; then
             log_warn "Invalid pinned DNS entry: $line"
-            ((invalid_count++))
+            invalid_count=$((invalid_count + 1))
         fi
     done < "$pinned_file"
 


### PR DESCRIPTION
## Summary
- Replace `((var++))` with `var=$((var + 1))` in `dns-filter.sh` and `dns-pin.sh`
- Fixes silent container crash when running with `set -euo pipefail` (the entrypoint default)

## Root Cause
When a counter variable starts at 0, `((0++))` evaluates to 0 (the pre-increment value), which bash interprets as exit code 1 (falsy). Under `set -e`, this silently terminates the script.

**Critical failure path:** `protect_dns_files()` tries to `chmod /etc/resolv.conf`, fails (non-root user in container), then `((failed++))` with `failed=0` crashes the entire entrypoint. The container exits with code 1 before the agent command ever runs, with no error message.

## Files Changed
- `scripts/lib/dns-filter.sh` - 7 instances fixed (protect_dns_files counters, pinned_count, domain_count)
- `scripts/lib/dns-pin.sh` - 5 instances fixed (wildcard_count, resolved_count, failed_count, invalid_count)

## Test plan
- [x] Rebuilt `kapsis-claude-cli` and `kapsis-slack-bot` images with fix
- [x] Ran kapsis with DNS filtering enabled (`mode: filtered`) - container now reaches "KAPSIS SANDBOX READY" and exits 0
- [x] Before fix: container silently crashed with exit 1 after "Cannot protect /etc/resolv.conf"
- [x] After fix: "DNS files protected (3 file(s) set to read-only)" message appears and execution continues

🤖 Generated with [Claude Code](https://claude.com/claude-code)