### PR TITLE
feat: support hook and MCP server whitelisting in container config

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -472,6 +472,7 @@ COPY scripts/lib/progress-monitor.sh /opt/kapsis/lib/progress-monitor.sh
 COPY scripts/lib/progress-instructions.md /opt/kapsis/lib/progress-instructions.md
 COPY scripts/lib/status.py /opt/kapsis/lib/status.py
 COPY scripts/lib/inject-status-hooks.sh /opt/kapsis/lib/inject-status-hooks.sh
+COPY scripts/lib/filter-agent-config.sh /opt/kapsis/lib/filter-agent-config.sh
 COPY scripts/lib/dns-filter.sh /opt/kapsis/lib/dns-filter.sh
 
 # Create hooks directory and copy status tracking hooks

--- a/docs/CONFIG-REFERENCE.md
+++ b/docs/CONFIG-REFERENCE.md
@@ -618,6 +618,28 @@ ssh:
     # - git.company.com  # Enterprise host (run add-host first!)
 
 #===============================================================================
+# CLAUDE - Agent-specific config filtering (whitelist mode)
+#
+# Controls which host hooks and MCP servers are available in the container.
+# Only whitelisted entries are kept; everything else is removed.
+# Omit a section entirely to pass everything through (no filtering).
+#===============================================================================
+claude:
+  hooks:
+    # Whitelist hooks by substring match on the command field
+    # Only hooks whose command contains one of these substrings are kept
+    include:
+      - block-secrets          # Security hook
+      - claudeignore           # File ignore patterns
+
+  mcp_servers:
+    # Whitelist MCP servers by exact key name match
+    # Only servers whose JSON key exactly matches are kept
+    include:
+      - context7               # Documentation lookup
+      - atlassian              # Jira/Confluence
+
+#===============================================================================
 # CONTAINER IMAGE
 #===============================================================================
 image:

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1015,6 +1015,14 @@ main() {
     # This must happen before setup_environment so agent configs are available
     setup_staged_config_overlays
 
+    # Whitelist Claude agent config (hooks and MCP servers) based on YAML config
+    # Must happen after CoW (files writable) and before hook injection (settings.local.json)
+    local filter_lib="${KAPSIS_HOME:-/opt/kapsis}/lib/filter-agent-config.sh"
+    if [[ -f "$filter_lib" ]]; then
+        source "$filter_lib"
+        filter_claude_agent_config
+    fi
+
     # Inject credentials to files (agent-agnostic)
     # Reads KAPSIS_CREDENTIAL_FILES env var set by launch-agent.sh
     inject_credential_files

--- a/scripts/lib/filter-agent-config.sh
+++ b/scripts/lib/filter-agent-config.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+#===============================================================================
+# filter-agent-config.sh - Whitelist hooks and MCP servers in agent configs
+#
+# Filters Claude Code's settings.json (hooks) and .claude.json (MCP servers)
+# based on include lists from the YAML launch config. Only whitelisted entries
+# are kept; everything else is removed.
+#
+# This runs INSIDE the container after CoW overlay setup (files are writable)
+# but BEFORE Kapsis hook injection (settings.local.json), so there's no conflict.
+#
+# Environment:
+#   KAPSIS_CLAUDE_HOOKS_INCLUDE  - Comma-separated substrings to match hook commands
+#   KAPSIS_CLAUDE_MCP_INCLUDE    - Comma-separated exact MCP server names to keep
+#   KAPSIS_AGENT_TYPE            - Agent type (only runs for claude-related types)
+#
+# Usage: Called automatically by entrypoint.sh
+#        source filter-agent-config.sh && filter_claude_agent_config
+#===============================================================================
+
+# Source guard
+[[ -n "${_KAPSIS_FILTER_AGENT_CONFIG_LOADED:-}" ]] && return 0
+_KAPSIS_FILTER_AGENT_CONFIG_LOADED=1
+
+# Source logging if available
+if [[ -f "${KAPSIS_LIB:-/opt/kapsis/lib}/logging.sh" ]]; then
+    # shellcheck source=logging.sh
+    source "${KAPSIS_LIB:-/opt/kapsis/lib}/logging.sh"
+else
+    log_info() { echo "[INFO] $*"; }
+    log_warn() { echo "[WARN] $*" >&2; }
+    log_debug() { :; }
+    log_success() { echo "[OK] $*"; }
+fi
+
+#===============================================================================
+# Hook Whitelisting
+#
+# Filters ~/.claude/settings.json to keep only hooks whose command field
+# contains a substring from the include list.
+#
+# Hook structure in settings.json:
+#   {
+#     "hooks": {
+#       "PostToolUse": [
+#         { "matcher": "*", "hooks": [{"type": "command", "command": "..."}] }
+#       ],
+#       "Stop": [...]
+#     }
+#   }
+#===============================================================================
+
+filter_claude_hooks() {
+    local settings_file="${HOME}/.claude/settings.json"
+    local include_list="${KAPSIS_CLAUDE_HOOKS_INCLUDE:-}"
+
+    if [[ -z "$include_list" ]]; then
+        log_debug "No hook whitelist configured - all hooks pass through"
+        return 0
+    fi
+
+    if [[ ! -f "$settings_file" ]]; then
+        log_debug "No settings.json found - nothing to filter"
+        return 0
+    fi
+
+    if ! command -v jq &>/dev/null; then
+        log_warn "jq not found - cannot filter hooks"
+        return 1
+    fi
+
+    # Convert comma-separated list to JSON array for jq
+    local patterns_json
+    patterns_json=$(echo "$include_list" | tr ',' '\n' | jq -R . | jq -s .)
+
+    local tmp_file
+    tmp_file=$(mktemp)
+
+    # Keep only hooks where at least one command substring-matches the whitelist
+    if jq --argjson patterns "$patterns_json" '
+        if .hooks then
+            .hooks |= with_entries(
+                .value |= map(
+                    select(
+                        [.hooks[]?.command // ""] |
+                        any(. as $cmd |
+                            $patterns | any(. as $pat | $cmd | contains($pat))
+                        )
+                    )
+                )
+            )
+        else . end
+    ' "$settings_file" > "$tmp_file" 2>/dev/null; then
+        mv "$tmp_file" "$settings_file"
+        chmod 600 "$settings_file"
+        log_success "Hooks whitelisted (patterns: $include_list)"
+        return 0
+    else
+        rm -f "$tmp_file"
+        log_warn "Failed to filter hooks - JSON parsing error"
+        return 1
+    fi
+}
+
+#===============================================================================
+# MCP Server Whitelisting
+#
+# Filters ~/.claude.json to keep only MCP servers whose key name
+# exactly matches an entry in the include list.
+#
+# MCP structure in .claude.json:
+#   {
+#     "mcpServers": {
+#       "context7": { ... },
+#       "chrome-devtools": { ... }
+#     }
+#   }
+#===============================================================================
+
+filter_claude_mcp_servers() {
+    local config_file="${HOME}/.claude.json"
+    local include_list="${KAPSIS_CLAUDE_MCP_INCLUDE:-}"
+
+    if [[ -z "$include_list" ]]; then
+        log_debug "No MCP whitelist configured - all servers pass through"
+        return 0
+    fi
+
+    if [[ ! -f "$config_file" ]]; then
+        log_debug "No .claude.json found - nothing to filter"
+        return 0
+    fi
+
+    if ! command -v jq &>/dev/null; then
+        log_warn "jq not found - cannot filter MCP servers"
+        return 1
+    fi
+
+    # Convert comma-separated list to JSON array for jq
+    local servers_json
+    servers_json=$(echo "$include_list" | tr ',' '\n' | jq -R . | jq -s .)
+
+    local tmp_file
+    tmp_file=$(mktemp)
+
+    # Keep only MCP servers whose key matches the whitelist
+    if jq --argjson servers "$servers_json" '
+        if .mcpServers then
+            .mcpServers |= with_entries(
+                select(.key as $k | $servers | any(. == $k))
+            )
+        else . end
+    ' "$config_file" > "$tmp_file" 2>/dev/null; then
+        mv "$tmp_file" "$config_file"
+        chmod 600 "$config_file"
+        log_success "MCP servers whitelisted (servers: $include_list)"
+        return 0
+    else
+        rm -f "$tmp_file"
+        log_warn "Failed to filter MCP servers - JSON parsing error"
+        return 1
+    fi
+}
+
+#===============================================================================
+# Entry Point
+#===============================================================================
+
+filter_claude_agent_config() {
+    local agent_type="${KAPSIS_AGENT_TYPE:-}"
+
+    # Only filter for Claude-related agents
+    case "$agent_type" in
+        claude|claude-cli|claude-code) ;;
+        *)
+            log_debug "Agent type '$agent_type' - skipping Claude config filtering"
+            return 0
+            ;;
+    esac
+
+    # Check if any filtering is configured
+    if [[ -z "${KAPSIS_CLAUDE_HOOKS_INCLUDE:-}" ]] && [[ -z "${KAPSIS_CLAUDE_MCP_INCLUDE:-}" ]]; then
+        log_debug "No Claude config filtering configured"
+        return 0
+    fi
+
+    log_info "Applying Claude config whitelist filters..."
+
+    # Filter hooks (non-fatal)
+    filter_claude_hooks || log_warn "Hook filtering had errors (continuing)"
+
+    # Filter MCP servers (non-fatal)
+    filter_claude_mcp_servers || log_warn "MCP server filtering had errors (continuing)"
+
+    return 0
+}

--- a/tests/test-filter-agent-config.sh
+++ b/tests/test-filter-agent-config.sh
@@ -1,0 +1,480 @@
+#!/usr/bin/env bash
+#===============================================================================
+# Tests for Claude Agent Config Filtering (Hook & MCP Server Whitelisting)
+#
+# Run: ./tests/test-filter-agent-config.sh
+#===============================================================================
+
+set -euo pipefail
+
+# Load test framework
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/test-framework.sh"
+
+# Script location
+LIB_DIR="$KAPSIS_ROOT/scripts/lib"
+
+# Temp directory for test fixtures
+TEST_HOME=""
+
+setup_test_home() {
+    TEST_HOME=$(mktemp -d)
+    mkdir -p "$TEST_HOME/.claude"
+}
+
+cleanup_test_home() {
+    [[ -n "$TEST_HOME" ]] && rm -rf "$TEST_HOME"
+    TEST_HOME=""
+    # Clean up env vars
+    unset KAPSIS_CLAUDE_HOOKS_INCLUDE 2>/dev/null || true
+    unset KAPSIS_CLAUDE_MCP_INCLUDE 2>/dev/null || true
+    unset KAPSIS_AGENT_TYPE 2>/dev/null || true
+}
+
+#===============================================================================
+# Test: Hook Filtering
+#===============================================================================
+
+test_hook_include_filters_correctly() {
+    setup_test_home
+
+    # Create settings.json with multiple hooks
+    cat > "$TEST_HOME/.claude/settings.json" << 'EOF'
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [{"type": "command", "command": "/usr/local/bin/block-secrets.sh", "timeout": 5}]
+      },
+      {
+        "matcher": "*",
+        "hooks": [{"type": "command", "command": "/tmp/claude-island-state.py --socket /tmp/claude-island.sock", "timeout": 3}]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [{"type": "command", "command": "/usr/local/bin/claudeignore-cleanup.sh"}]
+      }
+    ]
+  }
+}
+EOF
+
+    # Whitelist only block-secrets and claudeignore
+    export HOME="$TEST_HOME"
+    export KAPSIS_CLAUDE_HOOKS_INCLUDE="block-secrets,claudeignore"
+
+    source "$LIB_DIR/filter-agent-config.sh"
+    filter_claude_hooks
+
+    # Verify: block-secrets kept, claude-island-state removed, claudeignore kept
+    local result
+    result=$(cat "$TEST_HOME/.claude/settings.json")
+
+    assert_contains "$result" "block-secrets" "block-secrets hook should be kept"
+    assert_not_contains "$result" "claude-island-state" "claude-island-state hook should be removed"
+    assert_contains "$result" "claudeignore" "claudeignore hook should be kept"
+
+    cleanup_test_home
+}
+
+test_hook_include_empty_means_no_filter() {
+    setup_test_home
+
+    cat > "$TEST_HOME/.claude/settings.json" << 'EOF'
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [{"type": "command", "command": "/usr/local/bin/some-hook.sh"}]
+      }
+    ]
+  }
+}
+EOF
+
+    export HOME="$TEST_HOME"
+    export KAPSIS_CLAUDE_HOOKS_INCLUDE=""
+
+    # Reset source guard to re-source
+    unset _KAPSIS_FILTER_AGENT_CONFIG_LOADED
+    source "$LIB_DIR/filter-agent-config.sh"
+    filter_claude_hooks
+
+    local result
+    result=$(cat "$TEST_HOME/.claude/settings.json")
+    assert_contains "$result" "some-hook" "All hooks should pass through when include is empty"
+
+    cleanup_test_home
+}
+
+test_hook_include_no_settings_file() {
+    setup_test_home
+
+    export HOME="$TEST_HOME"
+    export KAPSIS_CLAUDE_HOOKS_INCLUDE="block-secrets"
+
+    unset _KAPSIS_FILTER_AGENT_CONFIG_LOADED
+    source "$LIB_DIR/filter-agent-config.sh"
+
+    # Should not fail when settings.json doesn't exist
+    filter_claude_hooks
+    local exit_code=$?
+    assert_equals "0" "$exit_code" "Should return 0 when no settings.json"
+
+    cleanup_test_home
+}
+
+test_hook_include_no_hooks_key() {
+    setup_test_home
+
+    cat > "$TEST_HOME/.claude/settings.json" << 'EOF'
+{
+  "permissions": {
+    "allow": ["Read", "Write"]
+  }
+}
+EOF
+
+    export HOME="$TEST_HOME"
+    export KAPSIS_CLAUDE_HOOKS_INCLUDE="block-secrets"
+
+    unset _KAPSIS_FILTER_AGENT_CONFIG_LOADED
+    source "$LIB_DIR/filter-agent-config.sh"
+    filter_claude_hooks
+
+    local result
+    result=$(cat "$TEST_HOME/.claude/settings.json")
+    assert_contains "$result" "permissions" "Non-hook content should be preserved"
+    assert_not_contains "$result" "hooks" "No hooks key should be added"
+
+    cleanup_test_home
+}
+
+test_hook_include_removes_all_when_none_match() {
+    setup_test_home
+
+    cat > "$TEST_HOME/.claude/settings.json" << 'EOF'
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [{"type": "command", "command": "/tmp/claude-island-state.py"}]
+      }
+    ]
+  }
+}
+EOF
+
+    export HOME="$TEST_HOME"
+    export KAPSIS_CLAUDE_HOOKS_INCLUDE="nonexistent-hook"
+
+    unset _KAPSIS_FILTER_AGENT_CONFIG_LOADED
+    source "$LIB_DIR/filter-agent-config.sh"
+    filter_claude_hooks
+
+    local result
+    result=$(cat "$TEST_HOME/.claude/settings.json")
+    assert_not_contains "$result" "claude-island-state" "Non-matching hook should be removed"
+
+    cleanup_test_home
+}
+
+test_hook_include_multiple_event_types() {
+    setup_test_home
+
+    cat > "$TEST_HOME/.claude/settings.json" << 'EOF'
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [{"type": "command", "command": "/bin/block-secrets"}]
+      },
+      {
+        "matcher": "*",
+        "hooks": [{"type": "command", "command": "/bin/unwanted-hook"}]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [{"type": "command", "command": "/bin/validate-bash"}]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [{"type": "command", "command": "/bin/cleanup-secrets"}]
+      }
+    ]
+  }
+}
+EOF
+
+    export HOME="$TEST_HOME"
+    export KAPSIS_CLAUDE_HOOKS_INCLUDE="block-secrets,validate-bash,cleanup-secrets"
+
+    unset _KAPSIS_FILTER_AGENT_CONFIG_LOADED
+    source "$LIB_DIR/filter-agent-config.sh"
+    filter_claude_hooks
+
+    local result
+    result=$(cat "$TEST_HOME/.claude/settings.json")
+    assert_contains "$result" "block-secrets" "block-secrets in PostToolUse should be kept"
+    assert_not_contains "$result" "unwanted-hook" "unwanted-hook in PostToolUse should be removed"
+    assert_contains "$result" "validate-bash" "validate-bash in PreToolUse should be kept"
+    assert_contains "$result" "cleanup-secrets" "cleanup-secrets in Stop should be kept"
+
+    cleanup_test_home
+}
+
+#===============================================================================
+# Test: MCP Server Filtering
+#===============================================================================
+
+test_mcp_include_filters_correctly() {
+    setup_test_home
+
+    cat > "$TEST_HOME/.claude.json" << 'EOF'
+{
+  "mcpServers": {
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp"]
+    },
+    "chrome-devtools": {
+      "command": "npx",
+      "args": ["chrome-devtools-mcp"]
+    },
+    "atlassian": {
+      "command": "npx",
+      "args": ["@anthropic/atlassian-mcp"]
+    },
+    "playwright": {
+      "command": "npx",
+      "args": ["@anthropic/playwright-mcp"]
+    }
+  }
+}
+EOF
+
+    export HOME="$TEST_HOME"
+    export KAPSIS_CLAUDE_MCP_INCLUDE="context7,atlassian"
+
+    unset _KAPSIS_FILTER_AGENT_CONFIG_LOADED
+    source "$LIB_DIR/filter-agent-config.sh"
+    filter_claude_mcp_servers
+
+    local result
+    result=$(cat "$TEST_HOME/.claude.json")
+    assert_contains "$result" "context7" "context7 should be kept"
+    assert_contains "$result" "atlassian" "atlassian should be kept"
+    assert_not_contains "$result" "chrome-devtools" "chrome-devtools should be removed"
+    assert_not_contains "$result" "playwright" "playwright should be removed"
+
+    cleanup_test_home
+}
+
+test_mcp_include_empty_means_no_filter() {
+    setup_test_home
+
+    cat > "$TEST_HOME/.claude.json" << 'EOF'
+{
+  "mcpServers": {
+    "context7": {"command": "npx"},
+    "chrome-devtools": {"command": "npx"}
+  }
+}
+EOF
+
+    export HOME="$TEST_HOME"
+    export KAPSIS_CLAUDE_MCP_INCLUDE=""
+
+    unset _KAPSIS_FILTER_AGENT_CONFIG_LOADED
+    source "$LIB_DIR/filter-agent-config.sh"
+    filter_claude_mcp_servers
+
+    local result
+    result=$(cat "$TEST_HOME/.claude.json")
+    assert_contains "$result" "context7" "context7 should pass through"
+    assert_contains "$result" "chrome-devtools" "chrome-devtools should pass through"
+
+    cleanup_test_home
+}
+
+test_mcp_include_no_config_file() {
+    setup_test_home
+
+    export HOME="$TEST_HOME"
+    export KAPSIS_CLAUDE_MCP_INCLUDE="context7"
+
+    unset _KAPSIS_FILTER_AGENT_CONFIG_LOADED
+    source "$LIB_DIR/filter-agent-config.sh"
+
+    filter_claude_mcp_servers
+    local exit_code=$?
+    assert_equals "0" "$exit_code" "Should return 0 when no .claude.json"
+
+    cleanup_test_home
+}
+
+test_mcp_include_no_mcpservers_key() {
+    setup_test_home
+
+    cat > "$TEST_HOME/.claude.json" << 'EOF'
+{
+  "projects": {}
+}
+EOF
+
+    export HOME="$TEST_HOME"
+    export KAPSIS_CLAUDE_MCP_INCLUDE="context7"
+
+    unset _KAPSIS_FILTER_AGENT_CONFIG_LOADED
+    source "$LIB_DIR/filter-agent-config.sh"
+    filter_claude_mcp_servers
+
+    local result
+    result=$(cat "$TEST_HOME/.claude.json")
+    assert_contains "$result" "projects" "Non-MCP content should be preserved"
+
+    cleanup_test_home
+}
+
+test_mcp_include_exact_match_only() {
+    setup_test_home
+
+    cat > "$TEST_HOME/.claude.json" << 'EOF'
+{
+  "mcpServers": {
+    "context7": {"command": "npx"},
+    "context7-extended": {"command": "npx"}
+  }
+}
+EOF
+
+    export HOME="$TEST_HOME"
+    export KAPSIS_CLAUDE_MCP_INCLUDE="context7"
+
+    unset _KAPSIS_FILTER_AGENT_CONFIG_LOADED
+    source "$LIB_DIR/filter-agent-config.sh"
+    filter_claude_mcp_servers
+
+    local result
+    result=$(cat "$TEST_HOME/.claude.json")
+    assert_contains "$result" "context7" "Exact match context7 should be kept"
+    assert_not_contains "$result" "context7-extended" "context7-extended should NOT match (exact match only)"
+
+    cleanup_test_home
+}
+
+#===============================================================================
+# Test: Entry Point (filter_claude_agent_config)
+#===============================================================================
+
+test_entry_point_skips_non_claude_agents() {
+    setup_test_home
+
+    export HOME="$TEST_HOME"
+    export KAPSIS_AGENT_TYPE="codex-cli"
+    export KAPSIS_CLAUDE_HOOKS_INCLUDE="block-secrets"
+
+    unset _KAPSIS_FILTER_AGENT_CONFIG_LOADED
+    source "$LIB_DIR/filter-agent-config.sh"
+    filter_claude_agent_config
+
+    # Should return successfully without doing anything
+    local exit_code=$?
+    assert_equals "0" "$exit_code" "Should skip non-Claude agents"
+
+    cleanup_test_home
+}
+
+test_entry_point_skips_when_no_filters() {
+    setup_test_home
+
+    export HOME="$TEST_HOME"
+    export KAPSIS_AGENT_TYPE="claude-cli"
+    unset KAPSIS_CLAUDE_HOOKS_INCLUDE 2>/dev/null || true
+    unset KAPSIS_CLAUDE_MCP_INCLUDE 2>/dev/null || true
+
+    unset _KAPSIS_FILTER_AGENT_CONFIG_LOADED
+    source "$LIB_DIR/filter-agent-config.sh"
+    filter_claude_agent_config
+
+    local exit_code=$?
+    assert_equals "0" "$exit_code" "Should skip when no filters configured"
+
+    cleanup_test_home
+}
+
+test_entry_point_runs_for_claude_variants() {
+    # Test that all Claude agent type variants are recognized
+    for agent_type in claude claude-cli claude-code; do
+        setup_test_home
+
+        cat > "$TEST_HOME/.claude/settings.json" << 'EOF'
+{
+  "hooks": {
+    "PostToolUse": [
+      {"matcher": "*", "hooks": [{"type": "command", "command": "/bin/keep-me"}]},
+      {"matcher": "*", "hooks": [{"type": "command", "command": "/bin/remove-me"}]}
+    ]
+  }
+}
+EOF
+
+        export HOME="$TEST_HOME"
+        export KAPSIS_AGENT_TYPE="$agent_type"
+        export KAPSIS_CLAUDE_HOOKS_INCLUDE="keep-me"
+
+        unset _KAPSIS_FILTER_AGENT_CONFIG_LOADED
+        source "$LIB_DIR/filter-agent-config.sh"
+        filter_claude_agent_config
+
+        local result
+        result=$(cat "$TEST_HOME/.claude/settings.json")
+        assert_contains "$result" "keep-me" "[$agent_type] Matching hook should be kept"
+        assert_not_contains "$result" "remove-me" "[$agent_type] Non-matching hook should be removed"
+
+        cleanup_test_home
+    done
+}
+
+#===============================================================================
+# Test Runner
+#===============================================================================
+
+run_tests() {
+    print_test_header "Claude Agent Config Filtering Test Suite"
+
+    log_info "=== Hook Whitelisting ==="
+    run_test test_hook_include_filters_correctly
+    run_test test_hook_include_empty_means_no_filter
+    run_test test_hook_include_no_settings_file
+    run_test test_hook_include_no_hooks_key
+    run_test test_hook_include_removes_all_when_none_match
+    run_test test_hook_include_multiple_event_types
+
+    log_info "=== MCP Server Whitelisting ==="
+    run_test test_mcp_include_filters_correctly
+    run_test test_mcp_include_empty_means_no_filter
+    run_test test_mcp_include_no_config_file
+    run_test test_mcp_include_no_mcpservers_key
+    run_test test_mcp_include_exact_match_only
+
+    log_info "=== Entry Point ==="
+    run_test test_entry_point_skips_non_claude_agents
+    run_test test_entry_point_skips_when_no_filters
+    run_test test_entry_point_runs_for_claude_variants
+
+    print_summary
+}
+
+# Run if executed directly
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    run_tests
+fi


### PR DESCRIPTION
## Summary

- Adds native YAML config to **whitelist** which Claude Code hooks and MCP servers are available inside Kapsis containers
- New `claude:` config section with include-only (whitelist) semantics — only explicitly listed entries survive
- Replaces fragile workaround of manually writing filtered `settings.json` and `cp`-ing in entrypoint

## Config Example

```yaml
claude:
  hooks:
    include:
      - block-secrets      # substring match on hook command
      - claudeignore
  mcp_servers:
    include:
      - context7           # exact match on MCP server key
      - atlassian
```

## How It Works

1. **Host** (`launch-agent.sh`): parses `claude.hooks.include` and `claude.mcp_servers.include` from YAML, passes as `KAPSIS_CLAUDE_HOOKS_INCLUDE` / `KAPSIS_CLAUDE_MCP_INCLUDE` env vars
2. **Container** (`entrypoint.sh`): after CoW overlay setup (files writable), sources `filter-agent-config.sh` and filters `settings.json` (hooks) and `.claude.json` (MCP servers)
3. Kapsis status hooks in `settings.local.json` are **unaffected** (separate file)

Omitting the `claude:` section entirely passes everything through — fully backward compatible.

## Files Changed

| File | Description |
|------|-------------|
| `scripts/lib/filter-agent-config.sh` | **New** — core jq-based whitelist filtering |
| `scripts/launch-agent.sh` | Parse `claude.*` YAML keys, pass as env vars |
| `scripts/entrypoint.sh` | Call `filter_claude_agent_config()` after CoW |
| `Containerfile` | COPY new library into image |
| `tests/test-filter-agent-config.sh` | **New** — 14 unit tests |
| `docs/CONFIG-REFERENCE.md` | Document new config section |

## Test plan

- [x] Shellcheck passes on all new/modified scripts
- [x] 14/14 new unit tests pass (`tests/test-filter-agent-config.sh`)
- [x] Full quick test suite: 378+ tests, 0 failures
- [ ] Manual integration: launch with `claude.mcp_servers.include: [context7]`, verify container `.claude.json` only has `context7`

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)