### PR TITLE
feat: support different local and remote branch names via --remote-branch

### DIFF
--- a/docs/CONFIG-REFERENCE.md
+++ b/docs/CONFIG-REFERENCE.md
@@ -1069,6 +1069,7 @@ Some config values can be overridden via command line:
 | `agent.command` | `--interactive` |
 | `image.name:image.tag` | `--image <name:tag>` |
 | `sandbox.upper_dir_base` | Set via environment |
+| (none) | `--remote-branch <name>` (remote branch name when different from local) |
 
 ## Network Isolation
 

--- a/docs/GIT-WORKFLOW.md
+++ b/docs/GIT-WORKFLOW.md
@@ -191,6 +191,27 @@ When your repository uses a specific tag or branch as the stable base (e.g., `st
 
 Without `--base-branch`, new branches are created from the current HEAD of the main repository, which may not be the intended base. This can cause PRs to show incorrect diffs.
 
+### Different Local and Remote Branch Names
+
+When the remote branch has a different name than your local branch (e.g., CI systems or naming conventions that differ), use `--remote-branch`:
+
+```bash
+# Local branch "my-feature" pushes to remote branch "claude/my-feature-abc123"
+./scripts/launch-agent.sh ~/project \
+    --branch my-feature \
+    --remote-branch claude/my-feature-abc123 \
+    --spec ./specs/task.md
+
+# Continue working on an existing remote branch with a different local name
+./scripts/launch-agent.sh ~/project \
+    --branch dev-work \
+    --remote-branch feature/DEV-456-api-refactor \
+    --push \
+    --spec ./specs/refactor.md
+```
+
+Without `--remote-branch`, the local branch name is used for both local and remote operations (default behavior).
+
 ### Continue Existing Branch
 
 ```bash

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -442,25 +442,30 @@ init_git_branch() {
     cd /workspace
 
     local remote="${KAPSIS_GIT_REMOTE:-origin}"
+    # Remote branch name defaults to local branch name when not specified
+    local remote_branch="${KAPSIS_REMOTE_BRANCH:-$KAPSIS_BRANCH}"
 
     # Fetch latest refs
     git fetch "$remote" --prune 2>/dev/null || log_warn "Could not fetch from $remote"
 
-    # Check if remote branch exists
-    if git ls-remote --exit-code --heads "$remote" "$KAPSIS_BRANCH" >/dev/null 2>&1; then
+    # Check if remote branch exists (use remote branch name for lookup)
+    if git ls-remote --exit-code --heads "$remote" "$remote_branch" >/dev/null 2>&1; then
         echo ""
         echo "┌────────────────────────────────────────────────────────────────┐"
         echo "│ CONTINUING FROM EXISTING REMOTE BRANCH                        │"
-        echo "│ Branch: $KAPSIS_BRANCH"
+        echo "│ Local Branch:  $KAPSIS_BRANCH"
+        if [[ "$remote_branch" != "$KAPSIS_BRANCH" ]]; then
+        echo "│ Remote Branch: $remote_branch"
+        fi
         echo "│ Remote: $remote"
         echo "└────────────────────────────────────────────────────────────────┘"
 
-        # Checkout tracking the remote branch
-        git checkout -b "$KAPSIS_BRANCH" "${remote}/${KAPSIS_BRANCH}" 2>/dev/null || \
+        # Checkout local branch tracking the remote branch
+        git checkout -b "$KAPSIS_BRANCH" "${remote}/${remote_branch}" 2>/dev/null || \
             git checkout "$KAPSIS_BRANCH"
 
         # Ensure we're up to date
-        git pull "$remote" "$KAPSIS_BRANCH" --ff-only 2>/dev/null || true
+        git pull "$remote" "$remote_branch" --ff-only 2>/dev/null || true
 
         echo ""
         log_info "Recent commits on this branch:"
@@ -473,7 +478,10 @@ init_git_branch() {
         echo ""
         echo "┌────────────────────────────────────────────────────────────────┐"
         echo "│ CREATING NEW BRANCH                                            │"
-        echo "│ Branch: $KAPSIS_BRANCH"
+        echo "│ Local Branch:  $KAPSIS_BRANCH"
+        if [[ "$remote_branch" != "$KAPSIS_BRANCH" ]]; then
+        echo "│ Remote Branch: $remote_branch"
+        fi
         echo "│ Base: $base_ref"
         echo "└────────────────────────────────────────────────────────────────┘"
 
@@ -518,10 +526,12 @@ post_exit_git() {
 
     # Check for unpushed commits (compare with remote tracking branch)
     local remote="${KAPSIS_GIT_REMOTE:-origin}"
-    if git rev-parse --verify "${remote}/${KAPSIS_BRANCH}" >/dev/null 2>&1; then
+    # Remote branch name defaults to local branch name when not specified
+    local remote_branch="${KAPSIS_REMOTE_BRANCH:-$KAPSIS_BRANCH}"
+    if git rev-parse --verify "${remote}/${remote_branch}" >/dev/null 2>&1; then
         # Remote branch exists - check if we're ahead
         local ahead
-        ahead=$(git rev-list --count "${remote}/${KAPSIS_BRANCH}..HEAD" 2>/dev/null || echo "0")
+        ahead=$(git rev-list --count "${remote}/${remote_branch}..HEAD" 2>/dev/null || echo "0")
         if [[ "$ahead" -gt 0 ]]; then
             has_unpushed=true
         fi
@@ -585,7 +595,8 @@ Branch: ${KAPSIS_BRANCH}"
         local local_commit
         local_commit=$(git rev-parse HEAD 2>/dev/null || echo "")
 
-        git push --set-upstream "$remote" "$KAPSIS_BRANCH" || {
+        # Use refspec to push local branch to (potentially different) remote branch
+        git push --set-upstream "$remote" "${KAPSIS_BRANCH}:${remote_branch}" || {
             log_warn "Push failed. Changes are committed locally."
             if type status_set_push_info &>/dev/null; then
                 status_set_push_info "failed" "$local_commit" ""
@@ -595,14 +606,14 @@ Branch: ${KAPSIS_BRANCH}"
 
         # Verify push succeeded by comparing local and remote HEAD
         echo ""
-        log_info "Verifying push to ${remote}/${KAPSIS_BRANCH}..."
+        log_info "Verifying push to ${remote}/${remote_branch}..."
 
         # Fetch latest from remote to ensure we have current state
-        git fetch "$remote" "$KAPSIS_BRANCH" --quiet 2>/dev/null || true
+        git fetch "$remote" "$remote_branch" --quiet 2>/dev/null || true
 
         # Get remote HEAD commit after fetch
         local remote_commit
-        remote_commit=$(git rev-parse "${remote}/${KAPSIS_BRANCH}" 2>/dev/null || echo "")
+        remote_commit=$(git rev-parse "${remote}/${remote_branch}" 2>/dev/null || echo "")
 
         # Compare commits
         if [[ "$local_commit" == "$remote_commit" ]]; then
@@ -634,7 +645,7 @@ Branch: ${KAPSIS_BRANCH}"
 
         echo ""
         if [[ -n "$remote_url" ]]; then
-            pr_url=$(generate_pr_url "$remote_url" "$KAPSIS_BRANCH")
+            pr_url=$(generate_pr_url "$remote_url" "$remote_branch")
             pr_term=$(get_pr_term "$remote_url")
             if [[ -n "$pr_url" ]]; then
                 log_success "Create/View ${pr_term}: ${pr_url}"
@@ -649,7 +660,7 @@ Branch: ${KAPSIS_BRANCH}"
     else
         echo ""
         log_success "Changes committed locally (use --push to enable auto-push)"
-        echo "To push later: git push ${KAPSIS_GIT_REMOTE:-origin} ${KAPSIS_BRANCH}"
+        echo "To push later: git push ${KAPSIS_GIT_REMOTE:-origin} ${KAPSIS_BRANCH}:${remote_branch}"
         # Record that push was skipped with the local commit
         local local_commit
         local_commit=$(git rev-parse HEAD 2>/dev/null || echo "")

--- a/scripts/lib/status.sh
+++ b/scripts/lib/status.sh
@@ -258,18 +258,20 @@ status_set_push_info() {
 # Arguments:
 #   $1 - Worktree path
 #   $2 - Remote name
-#   $3 - Branch name
+#   $3 - Local branch name
+#   $4 - Remote branch name (optional, defaults to local branch name)
 status_set_push_fallback() {
     local worktree_path="$1"
     local remote="${2:-origin}"
     local branch="$3"
+    local remote_branch="${4:-$branch}"
 
     if [[ -z "$worktree_path" || -z "$branch" ]]; then
         _KAPSIS_PUSH_FALLBACK_CMD=""
         return
     fi
 
-    _KAPSIS_PUSH_FALLBACK_CMD="cd ${worktree_path} && git push -u ${remote} ${branch}"
+    _KAPSIS_PUSH_FALLBACK_CMD="cd ${worktree_path} && git push -u ${remote} ${branch}:${remote_branch}"
 
     # Output machine-parseable marker for agent grep
     echo ""


### PR DESCRIPTION
Add --remote-branch CLI option that allows the local branch name to differ
from the remote branch name when pushing. This enables workflows where
CI systems or naming conventions require different branch names on the remote.

Key changes:
- New --remote-branch flag in launch-agent.sh
- KAPSIS_REMOTE_BRANCH env var passed to container
- All git operations (fetch, checkout, push, verify) use remote branch name
  for remote operations and local branch name for local operations
- Push uses refspec syntax (local:remote) for name mapping
- Fallback commands and PR URLs use the remote branch name
- Fully backward compatible: defaults to local branch name when not specified

https://claude.ai/code/session_01Jvi4VsmrRLAFmdbvfJauBr