### PR TITLE
docs: fix inaccuracies across user-facing documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,13 +12,13 @@
 - `scripts/` holds the core Bash entrypoints (agent launch, image build, cleanup); shared helpers live in `scripts/lib/`.
 - `configs/` contains example config files and agent profiles; profile definitions are under `configs/agents/`.
 - `tests/` is the shell-based test suite; the shared framework is `tests/lib/test-framework.sh`.
-- `docs/` and `specs/` hold documentation and task specs used by agents.
+- `docs/` holds extended documentation; `configs/specs/` holds task spec templates used by agents.
 - `assets/` stores static artifacts (e.g., logos); `maven/isolated-settings.xml` configures isolated Maven behavior in containers.
 
 ## Build, Test, and Development Commands
 - `./scripts/build-image.sh` builds the base Podman image used by Kapsis.
 - `./scripts/build-agent-image.sh <profile>` builds an agent-specific image (see `configs/agents/`).
-- `./scripts/launch-agent.sh <id> <project_path> --task "..."` launches an agent in a sandboxed container.
+- `./scripts/launch-agent.sh <project_path> --agent <name> --task "..."` launches an agent in a sandboxed container.
 - `./scripts/kapsis-status.sh` shows running agent status; add `--json` for machine output.
 - `./tests/run-all-tests.sh` runs the full test suite (requires Podman).
 - `./tests/run-all-tests.sh --quick` runs fast, non-container tests.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Essential context for AI assistants working on the Kapsis codebase.
 
 ## Project Overview
 
-Kapsis is a **hermetically isolated AI agent sandbox** (v2.7.0) for running multiple AI coding agents (Claude Code, Codex CLI, Aider, Gemini CLI) in parallel with complete isolation via Podman rootless containers, Copy-on-Write filesystems, and DNS-based network filtering.
+Kapsis is a **hermetically isolated AI agent sandbox** (v2.7.1) for running multiple AI coding agents (Claude Code, Codex CLI, Aider, Gemini CLI) in parallel with complete isolation via Podman rootless containers, Copy-on-Write filesystems, and DNS-based network filtering.
 
 ### Core Isolation Guarantees
 
@@ -29,6 +29,7 @@ kapsis/
 │   ├── entrypoint.sh           # Container startup script
 │   ├── worktree-manager.sh     # Git worktree creation and isolation
 │   ├── post-container-git.sh   # Post-exit commit/push operations
+│   ├── post-exit-git.sh        # Post-exit commit/push (host-side)
 │   ├── init-git-branch.sh      # Git branch initialization
 │   ├── kapsis-status.sh        # Query agent status
 │   ├── kapsis-cleanup.sh       # Reclaim disk space
@@ -37,9 +38,14 @@ kapsis/
 │   ├── configure-deps.sh       # Interactive dependency configuration
 │   ├── install.sh              # Distribution installer
 │   ├── switch-java.sh          # Java version switcher (in-container)
+│   ├── setup-github-protection.sh  # GitHub branch protection setup
+│   ├── setup-homebrew-tap-sync.sh  # Homebrew tap sync setup
+│   ├── setup-package-repos.sh  # Package repository setup
+│   ├── setup-release-app.sh    # Release app setup
 │   ├── lib/                    # Shared libraries (sourced, not executed)
 │   │   ├── logging.sh          # Centralized logging with file rotation
 │   │   ├── status.sh           # JSON status reporting to ~/.kapsis/status/
+│   │   ├── agent-types.sh      # Agent type definitions
 │   │   ├── constants.sh        # Central constants (paths, patterns, modes)
 │   │   ├── compat.sh           # Cross-platform macOS/Linux helpers
 │   │   ├── security.sh         # Security hardening & capability management
@@ -78,7 +84,7 @@ kapsis/
 ├── docs/                       # Extended documentation (14 guides)
 ├── security/                   # AppArmor & seccomp profiles
 ├── packaging/                  # Debian, Homebrew, RPM packages
-├── .github/workflows/          # CI/CD (ci, auto-release, release, security, packages, deploy-pages)
+├── .github/workflows/          # CI/CD (ci, auto-release, release, security, packages, deploy-pages, sync-homebrew-tap)
 ├── Containerfile               # Multi-stage container image definition
 ├── setup.sh                    # Initial system setup & dependency validation
 └── quick-start.sh              # Simplified one-line agent launcher
@@ -102,6 +108,7 @@ kapsis/
 | Logging & testing | `CONTRIBUTING.md` |
 | Cleanup operations | `docs/CLEANUP.md` |
 | Test coverage analysis | `docs/TEST-COVERAGE-ANALYSIS.md` |
+| Security vulnerability scan | `docs/SECURITY-VULNERABILITY-SCAN.md` |
 | Agent profiles | `configs/agents/*.yaml` |
 | Security policy | `SECURITY.md` |
 | AI agent guidelines | `AGENTS.md` |

--- a/README.md
+++ b/README.md
@@ -130,9 +130,11 @@ Kapsis includes pre-built agent profiles that install the agent directly into th
 
 | Profile | Agent | Installation |
 |---------|-------|--------------|
-| `claude-cli` | Claude Code CLI | `npm install -g @anthropic-ai/claude-code` |
+| `claude-cli` | Claude Code CLI | Native installer (`curl -fsSL https://claude.ai/install.sh`) |
 | `claude-api` | Anthropic Python SDK | `pip install anthropic` |
 | `aider` | Aider AI Pair Programmer | `pip install aider-chat` |
+| `codex-cli` | OpenAI Codex CLI | `npm install -g @openai/codex` |
+| `gemini-cli` | Google Gemini CLI | `npm install -g @google/gemini-cli` |
 
 Profiles are defined in `configs/agents/`. Create custom profiles by copying an existing one.
 
@@ -314,10 +316,13 @@ Customize container images for your specific needs using build profiles:
 | Profile | Est. Size | Languages | Best For |
 |---------|-----------|-----------|----------|
 | `minimal` | ~500MB | None | Shell scripts, basic tasks |
-| `java-dev` | ~1.5GB | Java 17/8 | Taboola Java development |
+| `java-dev` | ~1.5GB | Java 17/8 | Java development |
+| `java8-legacy` | ~1.4GB | Java 8 | Legacy Java projects |
 | `full-stack` | ~2.1GB | Java, Node.js, Python | Multi-language projects |
+| `backend-go` | ~1.3GB | Go, Python | Go backend services |
 | `backend-rust` | ~1.4GB | Rust, Python | Rust backend services |
 | `frontend` | ~1.2GB | Node.js, Rust | Frontend/WebAssembly |
+| `ml-python` | ~1.8GB | Python, Node.js, Rust | Machine learning projects |
 
 ### Configure Dependencies
 
@@ -436,6 +441,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full logging configuration and te
 | [SECURITY-HARDENING.md](docs/SECURITY-HARDENING.md) | Container security design and hardening options |
 | [NETWORK-ISOLATION.md](docs/NETWORK-ISOLATION.md) | Network security and isolation configuration |
 | [GITHUB-SETUP.md](docs/GITHUB-SETUP.md) | GitHub integration and authentication |
+| [TEST-COVERAGE-ANALYSIS.md](docs/TEST-COVERAGE-ANALYSIS.md) | Test coverage analysis and recommendations |
+| [SECURITY-VULNERABILITY-SCAN.md](docs/SECURITY-VULNERABILITY-SCAN.md) | Security vulnerability scan report |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | Development guide, testing, and logging |
 
 ## Project Structure
@@ -471,6 +478,7 @@ kapsis/
 │   ├── configure-deps.sh        # Configure container dependencies
 │   ├── worktree-manager.sh      # Git worktree management
 │   ├── post-container-git.sh    # Post-container git operations
+│   ├── post-exit-git.sh         # Post-exit commit/push
 │   ├── merge-changes.sh         # Manual merge workflow
 │   ├── entrypoint.sh            # Container entrypoint
 │   ├── init-git-branch.sh       # Git branch initialization

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -133,7 +133,7 @@ This will install Kapsis to `~/.local` and add it to your PATH.
 
 ```bash
 # Install specific version (check releases page for latest: https://github.com/aviadshiber/kapsis/releases)
-KAPSIS_VERSION=0.7.6 curl -fsSL https://raw.githubusercontent.com/aviadshiber/kapsis/main/scripts/install.sh | bash
+KAPSIS_VERSION=2.7.1 curl -fsSL https://raw.githubusercontent.com/aviadshiber/kapsis/main/scripts/install.sh | bash
 
 # Install to custom location
 KAPSIS_PREFIX=/opt/kapsis curl -fsSL https://raw.githubusercontent.com/aviadshiber/kapsis/main/scripts/install.sh | bash
@@ -160,7 +160,7 @@ cd kapsis
 ```bash
 # Get latest version (or specify manually)
 VERSION=$(curl -s https://api.github.com/repos/aviadshiber/kapsis/releases/latest | grep -o '"tag_name": "v[^"]*' | cut -d'v' -f2)
-# Or specify manually: VERSION=0.7.6
+# Or specify manually: VERSION=2.7.1
 
 # Download release
 curl -LO "https://github.com/aviadshiber/kapsis/archive/refs/tags/v${VERSION}.tar.gz"
@@ -352,7 +352,7 @@ If you prefer not to install jq, you can set the version manually by checking th
 
 ```bash
 # Replace with the latest version from the releases page
-VERSION="0.7.6"  # Check https://github.com/aviadshiber/kapsis/releases for latest
+VERSION="2.7.1"  # Check https://github.com/aviadshiber/kapsis/releases for latest
 ```
 
 ## System Requirements

--- a/quick-start.sh
+++ b/quick-start.sh
@@ -6,17 +6,17 @@
 # Agent IDs are automatically generated (6-character UUID).
 #
 # Usage:
-#   ./quick-start.sh <project> <branch> [spec-file]
+#   ./quick-start.sh <agent-id> <project> <branch> [spec-file]
 #
 # Examples:
-#   ./quick-start.sh products feature/DEV-123
-#   ./quick-start.sh products feature/DEV-123 my-task.md
-#   ./quick-start.sh daredevil-ui feature/DEV-456 configs/specs/feature.md
+#   ./quick-start.sh 1 products feature/DEV-123
+#   ./quick-start.sh 1 products feature/DEV-123 my-task.md
+#   ./quick-start.sh 1 daredevil-ui feature/DEV-456 configs/specs/feature.md
 #
-# For parallel agents on same project (each gets unique auto-generated ID):
-#   ./quick-start.sh products feature/DEV-123-auth &
-#   ./quick-start.sh products feature/DEV-123-api &
-#   ./quick-start.sh products feature/DEV-123-tests &
+# For parallel agents on same project:
+#   ./quick-start.sh 1 products feature/DEV-123-auth &
+#   ./quick-start.sh 2 products feature/DEV-123-api &
+#   ./quick-start.sh 3 products feature/DEV-123-tests &
 #===============================================================================
 
 set -euo pipefail


### PR DESCRIPTION
- README: add missing agent profiles (codex-cli, gemini-cli), fix
  claude-cli install method (native installer, not npm), add missing
  build profiles (java8-legacy, backend-go, ml-python), add missing
  doc entries (TEST-COVERAGE-ANALYSIS, SECURITY-VULNERABILITY-SCAN),
  remove Taboola-specific reference from java-dev profile description
- CLAUDE.md: update version to v2.7.1, add missing scripts
  (post-exit-git, setup-*, agent-types.sh), add sync-homebrew-tap
  workflow, add SECURITY-VULNERABILITY-SCAN to docs map
- AGENTS.md: fix launch-agent.sh usage (no <id> param), fix specs
  path from specs/ to configs/specs/
- INSTALL.md: update hardcoded version examples from 0.7.6 to 2.7.1
- quick-start.sh: fix header comment to match actual usage (requires
  agent-id as first argument)

https://claude.ai/code/session_01MYjirULd3BVyBtNaEWjAfA