### PR TITLE
fix: preserve SSH key permissions during filesystem.include staging

### DIFF
--- a/scripts/lib/compat.sh
+++ b/scripts/lib/compat.sh
@@ -34,6 +34,28 @@ get_file_size() {
 }
 
 #-------------------------------------------------------------------------------
+# get_file_mode <file>
+#
+# Returns file permission mode as octal string (e.g., "644", "600", "755").
+# Works on both macOS and Linux.
+# Returns empty string if file doesn't exist or on error.
+#-------------------------------------------------------------------------------
+get_file_mode() {
+    local file="$1"
+
+    if [[ ! -e "$file" ]]; then
+        echo ""
+        return 1
+    fi
+
+    if [[ "$_KAPSIS_OS" == "Darwin" ]]; then
+        stat -f "%Lp" "$file" 2>/dev/null || echo ""
+    else
+        stat -c "%a" "$file" 2>/dev/null || echo ""
+    fi
+}
+
+#-------------------------------------------------------------------------------
 # get_file_mtime <file>
 #
 # Returns file modification time as Unix epoch (seconds since 1970).


### PR DESCRIPTION
## Summary
- Use `cp -p` (permission-preserving copy) in `atomic-copy.sh` instead of plain `cp`
- Change `chmod -R u+w` to directory-only (`find -type d -exec chmod u+w`) to avoid corrupting restrictive file permissions like SSH keys (0600)
- Add `fix_ssh_permissions()` safety net in `entrypoint.sh` that explicitly enforces correct SSH modes (`0700` dir, `0600` keys, `0644` pubkeys) after staging
- Add `get_file_mode()` cross-platform helper to `compat.sh`
- Add 4 new permission preservation tests (all 21 atomic-copy tests pass, full quick suite green)

## Test plan
- [x] ShellCheck passes on all modified files
- [x] `tests/test-atomic-copy.sh` — 21/21 pass (including 4 new permission tests)
- [x] `tests/run-all-tests.sh --quick` — all suites pass with 0 failures
- [ ] Manual: add `~/.ssh` to `filesystem.include`, launch agent, verify `ls -la ~/.ssh/` inside container shows `0600` on keys

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)