### PR TITLE
feat: keyring_collection for 99designs/keyring compat (#170)

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -150,11 +150,14 @@ RUN if [ "$ENABLE_OVERLAY" = "true" ]; then \
 
 # Secret store (gnome-keyring + secret-tool for Secret Service D-Bus API)
 # Enables CLI tools using keyring libraries to store/retrieve secrets natively
+# python3-secretstorage: 99designs/keyring compat (Issue #170) — stores with
+# 'profile' attribute in named collections for Go CLI tools (bkt, gh)
 RUN if [ "$ENABLE_SECRET_STORE" = "true" ]; then \
         apt-get update && apt-get install -y --no-install-recommends \
             dbus \
             gnome-keyring \
-            libsecret-tools && \
+            libsecret-tools \
+            python3-secretstorage && \
         rm -rf /var/lib/apt/lists/*; \
     fi
 
@@ -502,14 +505,16 @@ COPY scripts/entrypoint.sh /opt/kapsis/entrypoint.sh
 COPY scripts/init-git-branch.sh /opt/kapsis/init-git-branch.sh
 COPY scripts/post-exit-git.sh /opt/kapsis/post-exit-git.sh
 COPY scripts/switch-java.sh /opt/kapsis/switch-java.sh
+COPY scripts/kapsis-ss-inject.py /opt/kapsis/kapsis-ss-inject
 
 # Create agents directory for custom agent wrapper scripts
 RUN mkdir -p /opt/kapsis/agents && chown ${USER_ID}:${GROUP_ID} /opt/kapsis/agents
 
 # Make all scripts executable and readable
-RUN chmod 755 /opt/kapsis/*.sh /opt/kapsis/lib/*.sh /opt/kapsis/lib/status.py && \
+RUN chmod 755 /opt/kapsis/*.sh /opt/kapsis/kapsis-ss-inject /opt/kapsis/lib/*.sh /opt/kapsis/lib/status.py && \
     chmod 755 /opt/kapsis/hooks/*.sh /opt/kapsis/hooks/agent-adapters/*.sh && \
-    chmod 644 /opt/kapsis/maven/settings.xml /opt/kapsis/lib/progress-instructions.md
+    chmod 644 /opt/kapsis/maven/settings.xml /opt/kapsis/lib/progress-instructions.md && \
+    ln -sf /opt/kapsis/kapsis-ss-inject /usr/local/bin/kapsis-ss-inject
 
 #===============================================================================
 # ENVIRONMENT CONFIGURATION

--- a/docs/CONFIG-REFERENCE.md
+++ b/docs/CONFIG-REFERENCE.md
@@ -191,6 +191,13 @@ environment:
   #              Can be combined with inject_to — file injection happens first,
   #              then secret store injection (both receive the secret value).
   #   mode: (optional) File permissions for inject_to_file (default: 0600)
+  #   keyring_collection: (optional) D-Bus Secret Service collection label
+  #              Required for Go tools using 99designs/keyring (bkt, etc.)
+  #              When set, secrets are stored with the 'profile' attribute
+  #              in a named collection, making them discoverable by
+  #              99designs/keyring's SecretService backend.
+  #              Without this, secrets use standard service/account attributes
+  #              in the default collection (works with secret-tool).
   keychain:
     # Example: Token stored in container secret store (default behavior)
     BITBUCKET_TOKEN:
@@ -212,6 +219,12 @@ environment:
     JIRA_TOKEN:
       service: "my-jira-token"
       account: ["primary@example.com", "fallback@example.com", "${USER}@example.com"]
+
+    # Example: Token for Go CLI tools using 99designs/keyring (bkt, etc.)
+    BKT_CREDENTIAL:
+      service: "bkt"
+      account: "host/git.taboolasyndication.com/token"
+      keyring_collection: "bkt"  # Store in 'bkt' collection with profile attribute
 
   # Variables to pass from host to container
   # Values are taken from host environment
@@ -841,6 +854,12 @@ environment:
       inject_to: "secret_store"            # Store in keyring (also the default)
       inject_to_file: "~/.agent/creds"     # Additionally write to this file in container
       mode: "0600"                         # Optional: file permissions (default: 0600)
+
+    # Go keyring tool (99designs/keyring) — named collection with profile attribute
+    BKT_CREDENTIAL:
+      service: "bkt"                       # macOS keychain service name
+      account: "host/example.com/token"    # Used as the keyring key
+      keyring_collection: "bkt"            # Store in 'bkt' D-Bus collection
 ```
 
 ### Secret Store Injection (Default)
@@ -859,6 +878,34 @@ By default, keychain secrets are stored in the container's Linux Secret Service 
 **Combining `inject_to_file` and `inject_to`:** These are orthogonal — both can be specified on the same entry. File injection writes the secret to disk first, then secret store injection stores it in the keyring and unsets the env var. The file and the keyring entry both receive the secret value.
 
 To globally use environment variables instead: set `environment.inject_to: "env"` in your config.
+
+### Go Keyring Compatibility (`keyring_collection`)
+
+Go CLI tools using [99designs/keyring](https://github.com/99designs/keyring) (e.g., `bkt`) search for secrets differently than `secret-tool`:
+
+- **`secret-tool`** stores with `service`/`account` attributes in the default "login" collection
+- **99designs/keyring** searches by a `profile` attribute in a collection matching its `ServiceName`
+
+The `keyring_collection` field bridges this gap. When set, Kapsis stores the secret with the correct `profile` attribute in a named D-Bus collection, making it discoverable by 99designs/keyring's SecretService backend.
+
+```yaml
+environment:
+  keychain:
+    BKT_CREDENTIAL:
+      service: "bkt"                                    # macOS keychain service name
+      account: "host/git.taboolasyndication.com/token"  # keychain account / keyring key
+      keyring_collection: "bkt"                         # D-Bus collection label
+```
+
+**How it works:**
+1. The secret is retrieved from macOS Keychain using `service` + `account`
+2. Inside the container, `kapsis-ss-inject` (Python helper) creates the named collection if needed
+3. The secret is stored with `{"profile": "<account>"}` attribute — matching what 99designs/keyring expects
+4. Go tools find the secret via their standard keyring lookup
+
+**Without `keyring_collection`:** Secrets are stored using `secret-tool` with `service`/`account` attributes (the default behavior, works with `secret-tool lookup` and libsecret-based tools).
+
+**Requirements:** `python3-secretstorage` must be installed in the container image (included when `ENABLE_SECRET_STORE=true`).
 
 ### Account Fallback
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -205,6 +205,18 @@ inject_secret_store() {
         }
     fi
 
+    # Parse keyring collection mappings for 99designs/keyring compat (Issue #170)
+    # Format: VAR_NAME|collection_label (comma-separated)
+    declare -A keyring_collections
+    if [[ -n "${KAPSIS_KEYRING_COLLECTIONS:-}" ]]; then
+        IFS=',' read -ra kc_pairs <<< "$KAPSIS_KEYRING_COLLECTIONS"
+        for pair in "${kc_pairs[@]}"; do
+            IFS='|' read -r kc_var kc_coll <<< "$pair"
+            [[ -n "$kc_var" && -n "$kc_coll" ]] && keyring_collections["$kc_var"]="$kc_coll"
+        done
+        unset KAPSIS_KEYRING_COLLECTIONS
+    fi
+
     log_info "Injecting secrets into container secret store..."
 
     IFS=',' read -ra entries <<< "$KAPSIS_SECRET_STORE_ENTRIES"
@@ -217,16 +229,40 @@ inject_secret_store() {
         local value="${!var_name:-}"
         [[ -z "$value" ]] && continue
 
-        # Store in Secret Service via secret-tool
-        # Use printf to avoid echo interpreting -n/-e flags in secret values
-        if printf '%s' "$value" | secret-tool store --label="$var_name" \
-            service "$service" account "${account:-kapsis}" 2>/dev/null; then
-            log_debug "Stored $var_name in secret store (service: $service)"
+        local collection="${keyring_collections[$var_name]:-}"
+        local stored=false
+
+        # 99designs/keyring compat: store with 'profile' attribute in named collection
+        # go-libsecret searches by profile=KEY in a collection matching ServiceName
+        if [[ -n "$collection" ]]; then
+            if command -v kapsis-ss-inject &>/dev/null; then
+                if printf '%s' "$value" | kapsis-ss-inject "$collection" "${account:-$var_name}" 2>/dev/null; then
+                    log_debug "Stored $var_name in collection '$collection' (99designs/keyring compat)"
+                    stored=true
+                else
+                    log_warn "kapsis-ss-inject failed for $var_name — falling back to secret-tool (99designs/keyring tools will NOT find this secret)"
+                fi
+            else
+                log_warn "kapsis-ss-inject not found — falling back to secret-tool for $var_name (99designs/keyring tools will NOT find this secret)"
+            fi
+        fi
+
+        # Standard path: secret-tool with service/account attributes
+        if [[ "$stored" != "true" ]]; then
+            # Use printf to avoid echo interpreting -n/-e flags in secret values
+            if printf '%s' "$value" | secret-tool store --label="$var_name" \
+                service "$service" account "${account:-kapsis}" 2>/dev/null; then
+                log_debug "Stored $var_name in secret store (service: $service)"
+                stored=true
+            else
+                log_warn "Failed to store $var_name in secret store — keeping as env var"
+            fi
+        fi
+
+        if [[ "$stored" == "true" ]]; then
             # Unset env var — secret is now only in the keyring
             unset "$var_name"
             ((injected++)) || true
-        else
-            log_warn "Failed to store $var_name in secret store — keeping as env var"
         fi
     done
 

--- a/scripts/kapsis-ss-inject.py
+++ b/scripts/kapsis-ss-inject.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Store a secret in Secret Service with 99designs/keyring-compatible attributes.
+
+99designs/keyring (used by Go CLI tools like bkt) searches for items using a
+hardcoded 'profile' attribute in a named collection. This script stores secrets
+in that exact format, making them discoverable by those tools.
+
+Usage: kapsis-ss-inject COLLECTION_LABEL KEY < secret_value
+
+Arguments:
+    COLLECTION_LABEL  D-Bus Secret Service collection label (e.g., "bkt")
+    KEY               Item key / profile attribute value
+
+The secret value is read from stdin.
+
+Requires: python3-secretstorage (apt install python3-secretstorage)
+
+See: https://github.com/aviadshiber/kapsis/issues/170
+"""
+import sys
+
+try:
+    import secretstorage
+except ImportError:
+    print("error: python3-secretstorage not installed", file=sys.stderr)
+    print("Install with: apt install python3-secretstorage", file=sys.stderr)
+    sys.exit(1)
+
+
+def main():
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} COLLECTION_LABEL KEY", file=sys.stderr)
+        sys.exit(1)
+
+    collection_label, key = sys.argv[1], sys.argv[2]
+    secret = sys.stdin.buffer.read()
+
+    if not secret:
+        print("error: no data on stdin", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        conn = secretstorage.dbus_init()
+
+        # Find existing collection by label, or create it
+        target = None
+        for c in secretstorage.get_all_collections(conn):
+            if c.get_label() == collection_label:
+                target = c
+                break
+
+        if target is None:
+            target = secretstorage.create_collection(conn, collection_label)
+
+        if target.is_locked():
+            target.unlock()
+
+        # Store with 'profile' attribute — this is what 99designs/keyring
+        # (via go-libsecret) uses for SearchItems lookups
+        target.create_item(key, {"profile": key}, secret, replace=True)
+    except Exception as e:
+        print(f"error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/launch-agent.sh
+++ b/scripts/launch-agent.sh
@@ -1289,10 +1289,12 @@ generate_env_vars() {
     local CREDENTIAL_FILES=""
     # Track secrets that should be stored in container's Linux secret store
     local SECRET_STORE_ENTRIES=""
+    # Track keyring collection mappings for 99designs/keyring compat (Issue #170)
+    local KEYRING_COLLECTIONS=""
 
     if [[ -n "$ENV_KEYCHAIN" ]]; then
         log_info "Resolving secrets from system keychain..."
-        while IFS='|' read -r var_name service account inject_to_file file_mode inject_to; do
+        while IFS='|' read -r var_name service account inject_to_file file_mode inject_to keyring_collection; do
             [[ -z "$var_name" || -z "$service" ]] && continue
 
             # Expand variables in account (e.g., ${USER})
@@ -1353,6 +1355,19 @@ generate_env_vars() {
                         SECRET_STORE_ENTRIES="${ss_entry}"
                     fi
                     log_debug "Will inject $var_name to container secret store"
+
+                    # Track keyring collection for 99designs/keyring compat (Issue #170)
+                    if [[ -n "${keyring_collection:-}" ]]; then
+                        if [[ "$keyring_collection" == *"|"* || "$keyring_collection" == *","* ]]; then
+                            log_warn "keyring_collection for $var_name contains invalid characters (|,) — ignoring"
+                            keyring_collection=""
+                        fi
+                    fi
+                    if [[ -n "${keyring_collection:-}" ]]; then
+                        local kc_entry="${var_name}|${keyring_collection}"
+                        KEYRING_COLLECTIONS="${KEYRING_COLLECTIONS:+${KEYRING_COLLECTIONS},}${kc_entry}"
+                        log_debug "Will use collection '$keyring_collection' for $var_name"
+                    fi
                 fi
 
                 # Track file injection if specified (orthogonal to inject_to)
@@ -1381,6 +1396,11 @@ generate_env_vars() {
     # Secrets with inject_to: "secret_store" will be moved from env vars to Linux keyring
     if [[ -n "$SECRET_STORE_ENTRIES" ]]; then
         ENV_VARS+=("-e" "KAPSIS_SECRET_STORE_ENTRIES=${SECRET_STORE_ENTRIES}")
+    fi
+
+    # Pass keyring collection mappings for 99designs/keyring compat (Issue #170)
+    if [[ -n "$KEYRING_COLLECTIONS" ]]; then
+        ENV_VARS+=("-e" "KAPSIS_KEYRING_COLLECTIONS=${KEYRING_COLLECTIONS}")
     fi
 
     # Set explicit environment variables (non-secrets)

--- a/scripts/lib/constants.sh
+++ b/scripts/lib/constants.sh
@@ -115,6 +115,10 @@ readonly KAPSIS_GIT_EXCLUDE_PATTERNS="# Kapsis internal files
 # Controls how keychain secrets are injected into containers.
 # "secret_store" = Linux Secret Service (gnome-keyring) — preferred, default
 # "env" = environment variable (legacy, less secure)
+#
+# keyring_collection: (optional) D-Bus collection label for 99designs/keyring
+# compat (Issue #170). When set, secrets are stored with the 'profile' attribute
+# in a named collection, making them discoverable by Go CLI tools (bkt, gh).
 #===============================================================================
 
 # Valid inject_to values for keychain entries
@@ -125,10 +129,10 @@ readonly KAPSIS_SECRET_STORE_DEFAULT_INJECT_TO="secret_store"
 
 # YQ expression for parsing keychain config with inject_to support.
 # Used by scripts/launch-agent.sh and tests/lib/test-framework.sh.
-# Output format: VAR_NAME|service|account|inject_to_file|mode|inject_to
+# Output format: VAR_NAME|service|account|inject_to_file|mode|inject_to|keyring_collection
 # Requires KAPSIS_INJECT_DEFAULT env var to be set before calling yq.
 # shellcheck disable=SC2016
-readonly KAPSIS_YQ_KEYCHAIN_EXPR='.environment.keychain // {} | to_entries | .[] | .value.account |= (select(kind == "seq") | join(",")) // .value.account | .key + "|" + .value.service + "|" + (.value.account // "") + "|" + (.value.inject_to_file // "") + "|" + (.value.mode // "0600") + "|" + (.value.inject_to // strenv(KAPSIS_INJECT_DEFAULT))'
+readonly KAPSIS_YQ_KEYCHAIN_EXPR='.environment.keychain // {} | to_entries | .[] | .value.account |= (select(kind == "seq") | join(",")) // .value.account | .key + "|" + .value.service + "|" + (.value.account // "") + "|" + (.value.inject_to_file // "") + "|" + (.value.mode // "0600") + "|" + (.value.inject_to // strenv(KAPSIS_INJECT_DEFAULT)) + "|" + (.value.keyring_collection // "")'
 
 #===============================================================================
 # FILE SANITIZATION CONSTANTS

--- a/tests/lib/test-framework.sh
+++ b/tests/lib/test-framework.sh
@@ -538,7 +538,7 @@ assert_matches() {
 #   config_file      - Path to YAML config file
 #   inject_default   - Default inject_to value (default: parsed from config or "secret_store")
 #
-# Output format per line: VAR_NAME|service|account|inject_to_file|mode|inject_to
+# Output format per line: VAR_NAME|service|account|inject_to_file|mode|inject_to|keyring_collection
 parse_keychain_config() {
     local config_file="$1"
     local inject_default="${2:-}"

--- a/tests/test-secret-store-injection.sh
+++ b/tests/test-secret-store-injection.sh
@@ -201,6 +201,127 @@ test_yq_expr_shared_between_launch_and_tests() {
 }
 
 #===============================================================================
+# KEYRING COLLECTION TESTS (Issue #170)
+#===============================================================================
+
+test_yq_expr_includes_keyring_collection() {
+    log_test "Testing YQ expression includes keyring_collection as 7th field"
+
+    if ! command -v yq &> /dev/null; then
+        log_skip "yq not available"
+        return 0
+    fi
+
+    local test_config="$TEST_PROJECT/.kapsis-keyring-coll-test.yaml"
+    cat > "$test_config" << 'EOF'
+agent:
+  command: "echo test"
+environment:
+  keychain:
+    BKT_TOKEN:
+      service: "bkt"
+      account: "host/example.com/token"
+      inject_to: "secret_store"
+      keyring_collection: "bkt"
+    PLAIN_TOKEN:
+      service: "plain-svc"
+      inject_to: "secret_store"
+EOF
+
+    local parsed
+    parsed=$(parse_keychain_config "$test_config")
+
+    rm -f "$test_config"
+
+    assert_contains "$parsed" "BKT_TOKEN|bkt|host/example.com/token||0600|secret_store|bkt" \
+        "keyring_collection should be parsed as 7th field"
+    assert_contains "$parsed" "PLAIN_TOKEN|plain-svc|||0600|secret_store|" \
+        "missing keyring_collection should be empty 7th field"
+}
+
+test_keyring_collection_in_launch_script() {
+    log_test "Testing launch-agent.sh tracks KAPSIS_KEYRING_COLLECTIONS"
+
+    local launch_script="$KAPSIS_ROOT/scripts/launch-agent.sh"
+
+    assert_contains "$(cat "$launch_script")" "KAPSIS_KEYRING_COLLECTIONS" \
+        "launch-agent.sh should reference KAPSIS_KEYRING_COLLECTIONS"
+    assert_contains "$(cat "$launch_script")" "keyring_collection" \
+        "launch-agent.sh should read keyring_collection field"
+}
+
+test_entrypoint_has_keyring_compat() {
+    log_test "Testing entrypoint.sh has 99designs/keyring compat logic"
+
+    local entrypoint_script="$KAPSIS_ROOT/scripts/entrypoint.sh"
+
+    assert_contains "$(cat "$entrypoint_script")" "kapsis-ss-inject" \
+        "entrypoint.sh should call kapsis-ss-inject helper"
+    assert_contains "$(cat "$entrypoint_script")" "keyring_collections" \
+        "entrypoint.sh should parse keyring_collections map"
+    assert_contains "$(cat "$entrypoint_script")" "99designs/keyring compat" \
+        "entrypoint.sh should document 99designs/keyring compatibility"
+}
+
+test_keyring_collection_coexists_with_inject_to() {
+    log_test "Testing keyring_collection works alongside inject_to: secret_store"
+
+    if ! command -v yq &> /dev/null; then
+        log_skip "yq not available"
+        return 0
+    fi
+
+    local test_config="$TEST_PROJECT/.kapsis-keyring-coexist-test.yaml"
+    cat > "$test_config" << 'EOF'
+agent:
+  command: "echo test"
+environment:
+  keychain:
+    BKT_CRED:
+      service: "bkt"
+      account: "host/example.com/token"
+      inject_to: "secret_store"
+      inject_to_file: "~/.config/bkt/token"
+      keyring_collection: "bkt"
+EOF
+
+    local parsed
+    parsed=$(parse_keychain_config "$test_config")
+
+    rm -f "$test_config"
+
+    # All fields should coexist in the pipe output
+    assert_contains "$parsed" "BKT_CRED|bkt|host/example.com/token|~/.config/bkt/token|0600|secret_store|bkt" \
+        "keyring_collection should coexist with inject_to_file and inject_to"
+}
+
+test_kapsis_ss_inject_script_exists() {
+    log_test "Testing kapsis-ss-inject.py script exists and is valid Python"
+
+    local script="$KAPSIS_ROOT/scripts/kapsis-ss-inject.py"
+
+    assert_file_exists "$script" "kapsis-ss-inject.py should exist"
+
+    if command -v python3 &>/dev/null; then
+        python3 -m py_compile "$script" 2>/dev/null
+        assert_equals "0" "$?" "kapsis-ss-inject.py should be valid Python"
+    else
+        log_skip "python3 not available for syntax check"
+    fi
+}
+
+test_containerfile_includes_secretstorage() {
+    log_test "Testing Containerfile installs python3-secretstorage"
+
+    local containerfile="$KAPSIS_ROOT/Containerfile"
+
+    assert_contains "$(cat "$containerfile")" "python3-secretstorage" \
+        "Containerfile should install python3-secretstorage"
+    assert_contains "$(cat "$containerfile")" "kapsis-ss-inject" \
+        "Containerfile should copy kapsis-ss-inject script"
+}
+
+#===============================================================================
 # MAIN
 #===============================================================================
 
@@ -222,6 +343,14 @@ main() {
     run_test test_credential_files_preserves_env_for_secret_store
     run_test test_inject_to_validation_in_launch_script
     run_test test_yq_expr_shared_between_launch_and_tests
+
+    # Keyring collection tests (Issue #170)
+    run_test test_yq_expr_includes_keyring_collection
+    run_test test_keyring_collection_in_launch_script
+    run_test test_entrypoint_has_keyring_compat
+    run_test test_keyring_collection_coexists_with_inject_to
+    run_test test_kapsis_ss_inject_script_exists
+    run_test test_containerfile_includes_secretstorage
 
     # Cleanup
     cleanup_test_project


### PR DESCRIPTION
## Summary

- Adds `keyring_collection` config field that stores secrets with 99designs/keyring-compatible `profile` attribute in a named D-Bus collection
- Creates `kapsis-ss-inject` Python helper using `secretstorage` library for precise Secret Service control
- Fixes root cause: `secret-tool` uses `service`/`account` attributes in default collection, while 99designs/keyring searches by `profile` attribute in a named collection

Closes #170

## Changes

| File | Change |
|------|--------|
| `scripts/kapsis-ss-inject.py` | New Python helper for 99designs/keyring-compatible secret storage |
| `Containerfile` | Added `python3-secretstorage` dep, COPY + symlink for helper |
| `scripts/lib/constants.sh` | Extended YQ expression to 7 fields (added `keyring_collection`) |
| `scripts/launch-agent.sh` | Reads 7th field, tracks/passes `KAPSIS_KEYRING_COLLECTIONS` |
| `scripts/entrypoint.sh` | Branches in `inject_secret_store()` when collection is set |
| `tests/test-secret-store-injection.sh` | 6 new tests (15 total) |
| `docs/CONFIG-REFERENCE.md` | Documented `keyring_collection` with examples |

## Config usage

```yaml
environment:
  keychain:
    BKT_CREDENTIAL:
      service: "bkt"
      account: "host/git.taboolasyndication.com/token"
      keyring_collection: "bkt"  # Store in 'bkt' D-Bus collection
```

## Test plan

- [x] ShellCheck clean on all modified scripts
- [x] All 15 secret store tests pass
- [x] Full quick test suite: 42/42 scripts pass, 0 failures
- [ ] Integration: build with `--profile full-stack`, launch with `keyring_collection` config, verify bkt finds credential

🤖 Generated with [Claude Code](https://claude.com/claude-code)