### PR TITLE
fix: warn when keyring_profile set without keyring_collection

### DIFF
--- a/scripts/launch-agent.sh
+++ b/scripts/launch-agent.sh
@@ -1375,6 +1375,8 @@ generate_env_vars() {
                         local kc_entry="${var_name}|${keyring_collection}|${keyring_profile:-}"
                         KEYRING_COLLECTIONS="${KEYRING_COLLECTIONS:+${KEYRING_COLLECTIONS},}${kc_entry}"
                         log_debug "Will use collection '$keyring_collection' for $var_name${keyring_profile:+ (profile: $keyring_profile)}"
+                    elif [[ -n "${keyring_profile:-}" ]]; then
+                        log_warn "keyring_profile for $var_name ignored — requires keyring_collection to be set"
                     fi
                 fi
 


### PR DESCRIPTION
## Summary

- Adds a `log_warn` when `keyring_profile` is set but `keyring_collection` is not, since the profile has no effect without a collection
- Follow-up from code review of #177

## Test plan

- [x] shellcheck clean (no new warnings)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)