### PR TITLE
fix: use allowlist validation for keyring fields

### DIFF
--- a/scripts/launch-agent.sh
+++ b/scripts/launch-agent.sh
@@ -1358,16 +1358,17 @@ generate_env_vars() {
                     log_debug "Will inject $var_name to container secret store"
 
                     # Track keyring collection for 99designs/keyring compat (Issue #170)
+                    # Allowlist validation: only safe characters for D-Bus paths/labels
                     if [[ -n "${keyring_collection:-}" ]]; then
-                        if [[ "$keyring_collection" == *"|"* || "$keyring_collection" == *","* ]]; then
-                            log_warn "keyring_collection for $var_name contains invalid characters (|,) — ignoring"
+                        if [[ "$keyring_collection" =~ [^a-zA-Z0-9/.@:_-] ]]; then
+                            log_warn "keyring_collection for $var_name contains invalid characters — ignoring"
                             keyring_collection=""
                         fi
                     fi
                     # Validate keyring_profile (Issue #176)
                     if [[ -n "${keyring_profile:-}" ]]; then
-                        if [[ "$keyring_profile" == *"|"* || "$keyring_profile" == *","* ]]; then
-                            log_warn "keyring_profile for $var_name contains invalid characters (|,) — ignoring"
+                        if [[ "$keyring_profile" =~ [^a-zA-Z0-9/.@:_-] ]]; then
+                            log_warn "keyring_profile for $var_name contains invalid characters — ignoring"
                             keyring_profile=""
                         fi
                     fi

--- a/tests/test-secret-store-injection.sh
+++ b/tests/test-secret-store-injection.sh
@@ -352,6 +352,25 @@ test_keyring_profile_validation() {
         "launch-agent.sh should validate keyring_profile"
 }
 
+test_keyring_field_allowlist_validation() {
+    log_test "Testing keyring fields use allowlist validation (not blocklist)"
+
+    local launch_script="$KAPSIS_ROOT/scripts/launch-agent.sh"
+    local content
+    content=$(cat "$launch_script")
+
+    # Should use regex allowlist pattern [^a-zA-Z0-9/.@:_-]
+    assert_contains "$content" '[^a-zA-Z0-9/.@:_-]' \
+        "Should use allowlist regex for character validation"
+
+    # Should NOT use old blocklist pattern *"|"*
+    if [[ "$content" == *'== *"|"*'* ]]; then
+        log_fail "Should not use blocklist pattern *\"|\"* — use allowlist regex instead"
+        return 1
+    fi
+    log_pass "No blocklist patterns found — using allowlist validation"
+}
+
 test_entrypoint_has_keyring_profile_support() {
     log_test "Testing entrypoint.sh has keyring_profile support"
 
@@ -424,6 +443,9 @@ main() {
     run_test test_keyring_profile_overrides_account
     run_test test_keyring_profile_validation
     run_test test_entrypoint_has_keyring_profile_support
+
+    # Security hardening
+    run_test test_keyring_field_allowlist_validation
 
     # Cleanup
     cleanup_test_project


### PR DESCRIPTION
## Summary

- Switch `keyring_collection` and `keyring_profile` validation from blocklist (`|`,`,`) to allowlist regex (`[a-zA-Z0-9/.@:_-]`)
- Prevents injection of newlines, control characters, shell metacharacters, and other unsafe values into D-Bus paths/labels
- Add test verifying allowlist pattern is used and old blocklist pattern is absent

## Context

Security scan of the #176 keyring_profile changes identified that blocklist validation only rejects two specific characters but accepts everything else (including newlines, control chars, backticks, semicolons). Allowlist validation is the safer approach — only permit known-safe characters for D-Bus collection labels and profile keys.

## Test plan

- [x] shellcheck passes
- [x] All 19 secret store injection tests pass (including new `test_keyring_field_allowlist_validation`)
- [x] All quick tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)