### PR TITLE
fix: correct protoc version and upgrade Node.js to v22 LTS

### DIFF
--- a/configs/build-config.yaml
+++ b/configs/build-config.yaml
@@ -61,8 +61,8 @@ languages:
     enabled: true
     # Versions to install (first is primary)
     versions:
-      - "18.18.0"        # LTS
-    default_version: "18.18.0"
+      - "22.22.0"        # LTS
+    default_version: "22.22.0"
     # Package managers to install globally
     package_managers:
       pnpm: "9.15.3"
@@ -155,7 +155,7 @@ build_tools:
   #-----------------------------------------------------------------------------
   protoc:
     enabled: true
-    version: "25.1"
+    version: "3.25.1"
     # Pre-cache binaries for both architectures
     cache_binaries: true
     architectures:

--- a/configs/build-profiles/backend-go.yaml
+++ b/configs/build-profiles/backend-go.yaml
@@ -42,7 +42,7 @@ build_tools:
 
   protoc:
     enabled: true
-    version: "25.1"
+    version: "3.25.1"
 
 system_packages:
   development:

--- a/configs/build-profiles/backend-rust.yaml
+++ b/configs/build-profiles/backend-rust.yaml
@@ -45,7 +45,7 @@ build_tools:
 
   protoc:
     enabled: true
-    version: "25.1"
+    version: "3.25.1"
 
 system_packages:
   development:

--- a/configs/build-profiles/frontend.yaml
+++ b/configs/build-profiles/frontend.yaml
@@ -16,9 +16,9 @@ languages:
   nodejs:
     enabled: true
     versions:
+      - "22.22.0"
       - "20.10.0"
-      - "18.18.0"
-    default_version: "20.10.0"
+    default_version: "22.22.0"
     package_managers:
       pnpm: "9.15.3"
       yarn: "latest"

--- a/configs/build-profiles/full-stack.yaml
+++ b/configs/build-profiles/full-stack.yaml
@@ -22,8 +22,8 @@ languages:
   nodejs:
     enabled: true
     versions:
-      - "18.18.0"
-    default_version: "18.18.0"
+      - "22.22.0"
+    default_version: "22.22.0"
     package_managers:
       pnpm: "9.15.3"
 
@@ -54,7 +54,7 @@ build_tools:
 
   protoc:
     enabled: true
-    version: "25.1"
+    version: "3.25.1"
 
 system_packages:
   development:

--- a/configs/build-profiles/java-dev.yaml
+++ b/configs/build-profiles/java-dev.yaml
@@ -49,7 +49,7 @@ build_tools:
 
   protoc:
     enabled: true
-    version: "25.1"
+    version: "3.25.1"
 
 system_packages:
   development:

--- a/configs/build-profiles/java8-legacy.yaml
+++ b/configs/build-profiles/java8-legacy.yaml
@@ -46,7 +46,7 @@ build_tools:
 
   protoc:
     enabled: true
-    version: "25.1"
+    version: "3.25.1"
 
 system_packages:
   development:

--- a/configs/build-profiles/ml-python.yaml
+++ b/configs/build-profiles/ml-python.yaml
@@ -16,8 +16,8 @@ languages:
   nodejs:
     enabled: true
     versions:
-      - "18.18.0"
-    default_version: "18.18.0"
+      - "22.22.0"
+    default_version: "22.22.0"
     package_managers:
       pnpm: "9.15.3"
 


### PR DESCRIPTION
## Summary

- **Fix protoc version**: `25.1` → `3.25.1` across all build profiles. Maven classifier artifacts use the full `3.x.y` version format (`com.google.protobuf:protoc:exe:linux-x86_64:3.25.1`). The incorrect version caused protoc cache to fail silently during image builds.
- **Upgrade Node.js**: `18.18.0` (EOL since March 2025) → `22.22.0` (current active LTS) across all profiles. Frontend profile keeps `20.10.0` as secondary version.

## Files changed

| File | Protoc fix | Node.js upgrade |
|------|-----------|----------------|
| `configs/build-config.yaml` | ✅ | ✅ |
| `configs/build-profiles/full-stack.yaml` | ✅ | ✅ |
| `configs/build-profiles/ml-python.yaml` | — | ✅ |
| `configs/build-profiles/frontend.yaml` | — | ✅ |
| `configs/build-profiles/java-dev.yaml` | ✅ | — |
| `configs/build-profiles/java8-legacy.yaml` | ✅ | — |
| `configs/build-profiles/backend-go.yaml` | ✅ | — |
| `configs/build-profiles/backend-rust.yaml` | ✅ | — |

## Test plan

- [x] Verified protoc `3.25.1` exists on Maven Central for both `linux-x86_64` and `linux-aarch_64`
- [x] Verified Node.js `22.22.0` is the latest v22 LTS release
- [ ] Rebuild image with `--profile full-stack` and verify protoc binaries are cached
- [ ] Verify NVM installs Node.js 22.22.0 correctly in container

🤖 Generated with [Claude Code](https://claude.com/claude-code)