### PR TITLE
fix: use RELEASE_TOKEN for checkout in auto-release workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -64,8 +64,11 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Use RELEASE_TOKEN (PAT) so fetch succeeds in workflow_run context.
+          # GITHUB_TOKEN has insufficient permissions when triggered via workflow_run.
+          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
           # For workflow_run, checkout the commit that triggered CI
+
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Check release conditions


### PR DESCRIPTION
## Summary

- `GITHUB_TOKEN` has insufficient permissions for git fetch when triggered via `workflow_run` event
- `RELEASE_TOKEN` (PAT) is already used for tag pushes later in the same workflow
- Using it for checkout too resolves the "terminal prompts disabled" auth failure that's been blocking auto-releases since March 29

## Test plan
- [ ] Merge this PR → CI runs → auto-release workflow triggers → verify it completes without auth error
- [ ] New tag v2.16.7 created and published

🤖 Generated with [Claude Code](https://claude.com/claude-code)