### PR TITLE
fix: replace expired RELEASE_TOKEN PAT with GitHub App token in auto-release

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -10,8 +10,9 @@ name: Auto Release
 # Note: Since main is a protected branch, this workflow only creates tags.
 # Git tags are the source of truth for versioning.
 #
-# IMPORTANT: Uses RELEASE_TOKEN (PAT) to push tags so that the Release
+# IMPORTANT: Uses a GitHub App token to push tags so that the Release
 # workflow is triggered. GITHUB_TOKEN doesn't trigger other workflows.
+# GitHub App tokens work like PATs for triggering workflows but don't expire.
 
 on:
   # Triggered automatically when CI workflow completes on main
@@ -60,15 +61,20 @@ jobs:
       should_release: ${{ steps.check.outputs.should_release }}
       last_tag: ${{ steps.check.outputs.last_tag }}
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859  # v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           fetch-depth: 0
-          # Use RELEASE_TOKEN (PAT) so fetch succeeds in workflow_run context.
-          # GITHUB_TOKEN has insufficient permissions when triggered via workflow_run.
-          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          # Use GitHub App token — doesn't expire and works in workflow_run context
+          token: ${{ steps.app-token.outputs.token }}
           # For workflow_run, checkout the commit that triggered CI
-
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Check release conditions
@@ -122,13 +128,21 @@ jobs:
     needs: [check]
     if: needs.check.outputs.should_release == 'true'
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859  # v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           fetch-depth: 0
-          # Use PAT to push tags - this triggers the Release workflow
-          # GITHUB_TOKEN pushes don't trigger other workflows (prevents loops)
-          token: ${{ secrets.RELEASE_TOKEN }}
+          # Use GitHub App token to push tags — triggers the Release workflow.
+          # GITHUB_TOKEN pushes don't trigger other workflows (prevents loops).
+          # App tokens don't expire unlike PATs.
+          token: ${{ steps.app-token.outputs.token }}
           ref: main
 
       - name: Verify we're on the right commit


### PR DESCRIPTION
## Summary

- `RELEASE_TOKEN` (PAT, set December 2025) has expired — 90-day default lifetime puts expiry at ~March 28, 2026, coinciding with when auto-release started failing
- Previous fix (#229) switched to `RELEASE_TOKEN || GITHUB_TOKEN` but RELEASE_TOKEN is expired and GITHUB_TOKEN can't authenticate git fetch in `workflow_run` context
- **Root fix:** use `actions/create-github-app-token` (same pattern already used in `release.yml`) to generate fresh short-lived tokens from `RELEASE_APP_ID` + `RELEASE_APP_PRIVATE_KEY`

## Why App token is correct

- App tokens don't expire (generated fresh each run)
- Can trigger other workflows (required for tag push → `release.yml` → Homebrew tap + distribution updates)
- Already the established pattern in `release.yml`

## Changes

- `check` job: add `Generate GitHub App token` step before checkout
- `release` job: same — replaces `RELEASE_TOKEN` for checkout and tag push
- Updated header comment to reflect the change

## Test plan
- [ ] Merge → CI runs → auto-release triggers with app token → tag `v2.16.7` created
- [ ] `release.yml` fires → GitHub Release published
- [ ] Homebrew tap sync runs (triggered by release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)