### PR TITLE
fix(test): use retry loop in kill test to fix CI flakiness

### DIFF
--- a/tests/test-liveness-monitor.sh
+++ b/tests/test-liveness-monitor.sh
@@ -417,7 +417,12 @@ test_liveness_kill_when_no_api_connection() {
                 _LIVENESS_API_SKIP_COUNT=0
                 _liveness_write_killed_status "test"
                 kill -SIGTERM "$test_pid" 2>/dev/null || true
-                sleep 1
+                # Wait up to 5s for process to die (CI environments can be slow)
+                local i
+                for i in 1 2 3 4 5; do
+                    kill -0 "$test_pid" 2>/dev/null || break
+                    sleep 1
+                done
             fi
         fi
 

--- a/tests/test-liveness-monitor.sh
+++ b/tests/test-liveness-monitor.sh
@@ -418,8 +418,8 @@ test_liveness_kill_when_no_api_connection() {
                 _liveness_write_killed_status "test"
                 kill -SIGTERM "$test_pid" 2>/dev/null || true
                 # Wait up to 5s for process to die (CI environments can be slow)
-                local i
-                for i in 1 2 3 4 5; do
+                local _wait
+                for _wait in 1 2 3 4 5; do
                     kill -0 "$test_pid" 2>/dev/null || break
                     sleep 1
                 done


### PR DESCRIPTION
## Summary
- `test_liveness_kill_when_no_api_connection` was using `sleep 1` after sending SIGTERM, then immediately checking if the process was dead
- On loaded CI runners this 1-second window was too short, causing a flaky failure
- Replaced with a retry loop that waits up to 5s for SIGTERM to take effect

## Test plan
- [ ] CI passes on this PR
- [ ] All 27 liveness monitor tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)