### PR TITLE
fix: include gist-instructions.md in container image and add missing K8s env vars (#202)

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -485,6 +485,7 @@ COPY scripts/lib/status.sh /opt/kapsis/lib/status.sh
 COPY scripts/lib/agent-types.sh /opt/kapsis/lib/agent-types.sh
 COPY scripts/lib/progress-monitor.sh /opt/kapsis/lib/progress-monitor.sh
 COPY scripts/lib/progress-instructions.md /opt/kapsis/lib/progress-instructions.md
+COPY scripts/lib/gist-instructions.md /opt/kapsis/lib/gist-instructions.md
 COPY scripts/lib/status.py /opt/kapsis/lib/status.py
 COPY scripts/lib/inject-status-hooks.sh /opt/kapsis/lib/inject-status-hooks.sh
 COPY scripts/lib/filter-agent-config.sh /opt/kapsis/lib/filter-agent-config.sh

--- a/scripts/lib/inject-status-hooks.sh
+++ b/scripts/lib/inject-status-hooks.sh
@@ -241,9 +241,11 @@ inject_gist_instructions() {
 
     # Only inject if gist instructions file exists
     if [[ ! -f "$gist_instructions" ]]; then
-        log_debug "Gist instructions not found: $gist_instructions"
+        log_warn "Gist instructions file not found: $gist_instructions — gist feature will not work"
         return 0
     fi
+
+    log_info "Injecting gist instructions (workspace: $workspace)"
 
     local marker="Kapsis Activity Gist"
     local injected=false

--- a/scripts/lib/inject-status-hooks.sh
+++ b/scripts/lib/inject-status-hooks.sh
@@ -237,7 +237,10 @@ inject_gist_instructions() {
     local gist_instructions="${KAPSIS_LIB:-/opt/kapsis/lib}/gist-instructions.md"
 
     # Create .kapsis directory in workspace (where gist.txt will be written)
-    mkdir -p "$kapsis_dir"
+    if ! mkdir -p "$kapsis_dir" 2>/dev/null; then
+        log_warn "Could not create $kapsis_dir -- skipping gist injection"
+        return 0
+    fi
 
     # Only inject if gist instructions file exists
     if [[ ! -f "$gist_instructions" ]]; then

--- a/scripts/lib/inject-status-hooks.sh
+++ b/scripts/lib/inject-status-hooks.sh
@@ -241,7 +241,7 @@ inject_gist_instructions() {
 
     # Only inject if gist instructions file exists
     if [[ ! -f "$gist_instructions" ]]; then
-        log_warn "Gist instructions file not found: $gist_instructions — gist feature will not work"
+        log_warn "Gist instructions file not found: $gist_instructions -- gist feature will not work"
         return 0
     fi
 

--- a/scripts/lib/k8s-config.sh
+++ b/scripts/lib/k8s-config.sh
@@ -52,7 +52,7 @@ _yaml_escape() {
     s="${s//$'\n'/\\n}"     # newline -> \n
     s="${s//$'\t'/\\t}"     # tab -> \t
     s="${s//$'\r'/\\r}"     # CR -> \r
-    echo "$s"
+    printf '%s\n' "$s"
 }
 
 # Generate YAML env: block from a bash array variable name

--- a/scripts/lib/k8s-config.sh
+++ b/scripts/lib/k8s-config.sh
@@ -151,11 +151,11 @@ YAML
       - name: KAPSIS_AGENT_TYPE
         value: "${AGENT_NAME}"
       - name: KAPSIS_STATUS_PROJECT
-        value: "${KAPSIS_STATUS_PROJECT:-}"
+        value: "$(_yaml_escape "${KAPSIS_STATUS_PROJECT:-}")"
       - name: KAPSIS_STATUS_AGENT_ID
         value: "${AGENT_ID}"
       - name: KAPSIS_STATUS_BRANCH
-        value: "${BRANCH:-}"
+        value: "$(_yaml_escape "${BRANCH:-}")"
       - name: KAPSIS_INJECT_GIST
         value: "${INJECT_GIST:-false}"
 YAML

--- a/scripts/lib/k8s-config.sh
+++ b/scripts/lib/k8s-config.sh
@@ -150,6 +150,14 @@ YAML
         value: "${AGENT_ID}"
       - name: KAPSIS_AGENT_TYPE
         value: "${AGENT_NAME}"
+      - name: KAPSIS_STATUS_PROJECT
+        value: "${KAPSIS_STATUS_PROJECT:-}"
+      - name: KAPSIS_STATUS_AGENT_ID
+        value: "${AGENT_ID}"
+      - name: KAPSIS_STATUS_BRANCH
+        value: "${BRANCH:-}"
+      - name: KAPSIS_INJECT_GIST
+        value: "${INJECT_GIST:-false}"
 YAML
 
     # Audit environment variables (if enabled)

--- a/tests/test-k8s-config-translation.sh
+++ b/tests/test-k8s-config-translation.sh
@@ -333,6 +333,21 @@ test_yaml_escape_tab() {
     assert_contains "$result" '\t' "Should escape tab to \\t"
 }
 
+test_yaml_escape_echo_flag_values() {
+    log_test "Testing _yaml_escape handles values starting with -n, -e, -E"
+
+    local result_n result_e result_E
+
+    # Values starting with -n, -e, -E could be misinterpreted by echo
+    result_n=$(_run_translator "printf '%s' \"\$(_yaml_escape '-nfoo')\"")
+    result_e=$(_run_translator "printf '%s' \"\$(_yaml_escape '-efoo')\"")
+    result_E=$(_run_translator "printf '%s' \"\$(_yaml_escape '-Efoo')\"")
+
+    assert_equals "-nfoo" "$result_n" "Should preserve -n prefix (not interpret as echo flag)"
+    assert_equals "-efoo" "$result_e" "Should preserve -e prefix (not interpret as echo flag)"
+    assert_equals "-Efoo" "$result_E" "Should preserve -E prefix (not interpret as echo flag)"
+}
+
 test_generate_cr_branch_special_chars_valid_yaml() {
     log_test "Testing CR with special branch name produces valid YAML"
 
@@ -465,6 +480,7 @@ main() {
     run_test test_generate_cr_empty_globals_does_not_crash
     run_test test_yaml_escape_newline_tab
     run_test test_yaml_escape_tab
+    run_test test_yaml_escape_echo_flag_values
     run_test test_generate_cr_branch_special_chars_valid_yaml
     run_test test_generate_env_yaml_cr_integration
 

--- a/tests/test-k8s-config-translation.sh
+++ b/tests/test-k8s-config-translation.sh
@@ -389,6 +389,34 @@ test_generate_env_yaml_cr_integration() {
     assert_contains "$result" "ANOTHER" "Should contain second extra env var"
 }
 
+test_generate_cr_contains_status_env_vars() {
+    log_test "Testing generated CR contains status and gist env vars"
+
+    local result
+    result=$(_run_translator '
+        AGENT_ID="test123"
+        IMAGE_NAME="kapsis-sandbox:latest"
+        AGENT_NAME="claude-cli"
+        RESOURCE_MEMORY="8g"
+        RESOURCE_CPUS="4"
+        BRANCH="feature/test"
+        TASK_INLINE="test task"
+        INLINE_SPEC_FILE=""
+        NETWORK_MODE="filtered"
+        SECURITY_PROFILE="standard"
+        AGENT_COMMAND="claude --task test"
+        KAPSIS_STATUS_PROJECT="my-project"
+        INJECT_GIST="true"
+        generate_agent_request_cr
+    ')
+
+    assert_contains "$result" "KAPSIS_STATUS_PROJECT" "Should contain KAPSIS_STATUS_PROJECT"
+    assert_contains "$result" "my-project" "Should contain project name value"
+    assert_contains "$result" "KAPSIS_STATUS_AGENT_ID" "Should contain KAPSIS_STATUS_AGENT_ID"
+    assert_contains "$result" "KAPSIS_STATUS_BRANCH" "Should contain KAPSIS_STATUS_BRANCH"
+    assert_contains "$result" "KAPSIS_INJECT_GIST" "Should contain KAPSIS_INJECT_GIST"
+}
+
 test_generate_cr_empty_globals_does_not_crash() {
     log_test "Testing CR generation with empty globals does not crash"
 
@@ -433,6 +461,7 @@ main() {
     run_test test_translate_memory_empty_string
     run_test test_translate_memory_uppercase
     run_test test_generate_cr_special_chars_valid_yaml
+    run_test test_generate_cr_contains_status_env_vars
     run_test test_generate_cr_empty_globals_does_not_crash
     run_test test_yaml_escape_newline_tab
     run_test test_yaml_escape_tab

--- a/tests/test-status-hooks.sh
+++ b/tests/test-status-hooks.sh
@@ -752,6 +752,39 @@ test_inject_gist_explicit_false() {
     cleanup_inject_test_env
 }
 
+test_inject_gist_readonly_workspace() {
+    setup_inject_test_env
+    export KAPSIS_STATUS_AGENT_ID="test-gist-7"
+    export KAPSIS_INJECT_GIST="true"
+
+    # Create workspace and make .kapsis creation fail by using a read-only dir
+    local workspace
+    workspace=$(mktemp -d)
+    export KAPSIS_WORKSPACE="$workspace"
+    echo "# Project" > "$workspace/CLAUDE.md"
+
+    # Pre-create .kapsis as a file (not dir) to make mkdir -p fail
+    touch "$workspace/.kapsis"
+    chmod 000 "$workspace/.kapsis"
+
+    # Run injection — should warn and skip gracefully (not crash)
+    source "$LIB_DIR/inject-status-hooks.sh"
+    local exit_code
+    inject_gist_instructions >/dev/null 2>&1
+    exit_code=$?
+
+    assert_equals "0" "$exit_code" "Should exit 0 when mkdir fails (graceful skip)"
+
+    # Verify CLAUDE.md was NOT modified (injection was skipped)
+    local content
+    content=$(cat "$workspace/CLAUDE.md")
+    assert_equals "# Project" "$content" "CLAUDE.md should be unchanged when workspace is read-only"
+
+    chmod 755 "$workspace/.kapsis" 2>/dev/null || true
+    rm -rf "$workspace"
+    cleanup_inject_test_env
+}
+
 test_inject_hook_path_uses_kapsis_home() {
     setup_inject_test_env
     export KAPSIS_STATUS_AGENT_ID="test-agent-10"
@@ -911,6 +944,7 @@ run_tests() {
     run_test test_inject_gist_missing_instructions_file
     run_test test_inject_gist_no_markdown_files
     run_test test_inject_gist_explicit_false
+    run_test test_inject_gist_readonly_workspace
 
     log_info "=== Agent Type Inference ==="
     run_test test_agent_type_inference_from_image_name

--- a/tests/test-status-hooks.sh
+++ b/tests/test-status-hooks.sh
@@ -698,6 +698,57 @@ test_inject_gist_missing_instructions_file() {
     cleanup_inject_test_env
 }
 
+test_inject_gist_no_markdown_files() {
+    setup_inject_test_env
+    export KAPSIS_STATUS_AGENT_ID="test-gist-5"
+    export KAPSIS_INJECT_GIST="true"
+
+    # Create workspace WITHOUT CLAUDE.md or AGENTS.md
+    local workspace
+    workspace=$(mktemp -d)
+    export KAPSIS_WORKSPACE="$workspace"
+
+    # Run injection
+    source "$LIB_DIR/inject-status-hooks.sh"
+    inject_gist_instructions >/dev/null 2>&1
+
+    # Verify .kapsis directory was created
+    assert_true "[[ -d '$workspace/.kapsis' ]]" ".kapsis directory should be created"
+
+    # Verify .kapsis/README.md fallback was created (only injection target)
+    assert_file_exists "$workspace/.kapsis/README.md" ".kapsis/README.md fallback should exist"
+    assert_contains "$(cat "$workspace/.kapsis/README.md")" "Kapsis Activity Gist" "README.md should contain gist instructions"
+
+    rm -rf "$workspace"
+    cleanup_inject_test_env
+}
+
+test_inject_gist_explicit_false() {
+    setup_inject_test_env
+    export KAPSIS_STATUS_AGENT_ID="test-gist-6"
+    export KAPSIS_INJECT_GIST="false"
+
+    local workspace
+    workspace=$(mktemp -d)
+    export KAPSIS_WORKSPACE="$workspace"
+    echo "# Project" > "$workspace/CLAUDE.md"
+
+    # Run injection (explicitly disabled)
+    source "$LIB_DIR/inject-status-hooks.sh"
+    inject_gist_instructions >/dev/null 2>&1
+
+    # Verify .kapsis directory was NOT created
+    assert_false "[[ -d '$workspace/.kapsis' ]]" ".kapsis directory should not be created when explicitly false"
+
+    # Verify CLAUDE.md was NOT modified
+    local content
+    content=$(cat "$workspace/CLAUDE.md")
+    assert_equals "# Project" "$content" "CLAUDE.md should be unchanged when gist explicitly false"
+
+    rm -rf "$workspace"
+    cleanup_inject_test_env
+}
+
 test_inject_hook_path_uses_kapsis_home() {
     setup_inject_test_env
     export KAPSIS_STATUS_AGENT_ID="test-agent-10"
@@ -855,6 +906,8 @@ run_tests() {
     run_test test_inject_gist_when_disabled
     run_test test_inject_gist_idempotent
     run_test test_inject_gist_missing_instructions_file
+    run_test test_inject_gist_no_markdown_files
+    run_test test_inject_gist_explicit_false
 
     log_info "=== Agent Type Inference ==="
     run_test test_agent_type_inference_from_image_name

--- a/tests/test-status-hooks.sh
+++ b/tests/test-status-hooks.sh
@@ -582,6 +582,122 @@ test_inject_skips_without_agent_id() {
     cleanup_inject_test_env
 }
 
+#===============================================================================
+# Test: Gist Injection (inject_gist_instructions)
+#===============================================================================
+
+test_inject_gist_when_enabled() {
+    setup_inject_test_env
+    export KAPSIS_STATUS_AGENT_ID="test-gist-1"
+    export KAPSIS_INJECT_GIST="true"
+
+    # Create a mock workspace with CLAUDE.md and AGENTS.md
+    local workspace
+    workspace=$(mktemp -d)
+    export KAPSIS_WORKSPACE="$workspace"
+    echo "# Project" > "$workspace/CLAUDE.md"
+    echo "# Agents" > "$workspace/AGENTS.md"
+
+    # Run injection
+    source "$LIB_DIR/inject-status-hooks.sh"
+    inject_gist_instructions >/dev/null 2>&1
+
+    # Verify .kapsis directory was created
+    assert_true "[[ -d '$workspace/.kapsis' ]]" ".kapsis directory should be created"
+
+    # Verify CLAUDE.md has gist instructions
+    assert_contains "$(cat "$workspace/CLAUDE.md")" "Kapsis Activity Gist" "CLAUDE.md should contain gist instructions"
+
+    # Verify AGENTS.md has gist instructions
+    assert_contains "$(cat "$workspace/AGENTS.md")" "Kapsis Activity Gist" "AGENTS.md should contain gist instructions"
+
+    # Verify .kapsis/README.md fallback was created
+    assert_file_exists "$workspace/.kapsis/README.md" ".kapsis/README.md should be created as fallback"
+
+    rm -rf "$workspace"
+    cleanup_inject_test_env
+}
+
+test_inject_gist_when_disabled() {
+    setup_inject_test_env
+    export KAPSIS_STATUS_AGENT_ID="test-gist-2"
+    unset KAPSIS_INJECT_GIST
+
+    local workspace
+    workspace=$(mktemp -d)
+    export KAPSIS_WORKSPACE="$workspace"
+    echo "# Project" > "$workspace/CLAUDE.md"
+
+    # Run injection (default: disabled)
+    source "$LIB_DIR/inject-status-hooks.sh"
+    inject_gist_instructions >/dev/null 2>&1
+
+    # Verify .kapsis directory was NOT created
+    assert_false "[[ -d '$workspace/.kapsis' ]]" ".kapsis directory should not be created when disabled"
+
+    # Verify CLAUDE.md was NOT modified
+    local content
+    content=$(cat "$workspace/CLAUDE.md")
+    assert_equals "# Project" "$content" "CLAUDE.md should be unchanged when gist disabled"
+
+    rm -rf "$workspace"
+    cleanup_inject_test_env
+}
+
+test_inject_gist_idempotent() {
+    setup_inject_test_env
+    export KAPSIS_STATUS_AGENT_ID="test-gist-3"
+    export KAPSIS_INJECT_GIST="true"
+
+    local workspace
+    workspace=$(mktemp -d)
+    export KAPSIS_WORKSPACE="$workspace"
+    echo "# Project" > "$workspace/CLAUDE.md"
+
+    # Run injection twice
+    source "$LIB_DIR/inject-status-hooks.sh"
+    inject_gist_instructions >/dev/null 2>&1
+    inject_gist_instructions >/dev/null 2>&1
+
+    # Verify gist instructions appear only once in CLAUDE.md
+    local gist_count
+    gist_count=$(grep -c "Kapsis Activity Gist" "$workspace/CLAUDE.md" || echo "0")
+    assert_equals "1" "$gist_count" "Gist instructions should appear exactly once after double injection"
+
+    rm -rf "$workspace"
+    cleanup_inject_test_env
+}
+
+test_inject_gist_missing_instructions_file() {
+    setup_inject_test_env
+    export KAPSIS_STATUS_AGENT_ID="test-gist-4"
+    export KAPSIS_INJECT_GIST="true"
+
+    local workspace
+    workspace=$(mktemp -d)
+    export KAPSIS_WORKSPACE="$workspace"
+    # Point to a non-existent lib directory
+    export KAPSIS_LIB="/tmp/nonexistent-kapsis-lib"
+
+    echo "# Project" > "$workspace/CLAUDE.md"
+
+    # Run injection — should warn but not fail
+    source "$LIB_DIR/inject-status-hooks.sh"
+    local stderr_output
+    stderr_output=$(inject_gist_instructions 2>&1 >/dev/null)
+
+    # Verify .kapsis directory IS created (happens before instructions check)
+    assert_true "[[ -d '$workspace/.kapsis' ]]" ".kapsis directory should still be created"
+
+    # Verify CLAUDE.md was NOT modified (no instructions to inject)
+    local content
+    content=$(cat "$workspace/CLAUDE.md")
+    assert_equals "# Project" "$content" "CLAUDE.md should be unchanged when instructions missing"
+
+    rm -rf "$workspace"
+    cleanup_inject_test_env
+}
+
 test_inject_hook_path_uses_kapsis_home() {
     setup_inject_test_env
     export KAPSIS_STATUS_AGENT_ID="test-agent-10"
@@ -733,6 +849,12 @@ run_tests() {
     run_test test_inject_gemini_idempotent
     run_test test_inject_skips_without_agent_id
     run_test test_inject_hook_path_uses_kapsis_home
+
+    log_info "=== Gist Injection ==="
+    run_test test_inject_gist_when_enabled
+    run_test test_inject_gist_when_disabled
+    run_test test_inject_gist_idempotent
+    run_test test_inject_gist_missing_instructions_file
 
     log_info "=== Agent Type Inference ==="
     run_test test_agent_type_inference_from_image_name

--- a/tests/test-status-hooks.sh
+++ b/tests/test-status-hooks.sh
@@ -686,6 +686,9 @@ test_inject_gist_missing_instructions_file() {
     local stderr_output
     stderr_output=$(inject_gist_instructions 2>&1 >/dev/null)
 
+    # Verify warning was logged about missing file
+    assert_contains "$stderr_output" "not found" "Should warn about missing gist instructions file"
+
     # Verify .kapsis directory IS created (happens before instructions check)
     assert_true "[[ -d '$workspace/.kapsis' ]]" ".kapsis directory should still be created"
 


### PR DESCRIPTION
The gist feature (inject_gist: true) was silently broken because
gist-instructions.md was never copied into the container image. The
inject_gist_instructions() function found the file missing and returned
early without injecting anything.

Also adds missing KAPSIS_STATUS_PROJECT, KAPSIS_STATUS_AGENT_ID,
KAPSIS_STATUS_BRANCH, and KAPSIS_INJECT_GIST env vars to the K8s
backend CR generation, and upgrades the missing-file log from debug
to warn so users can diagnose the issue.

https://claude.ai/code/session_015Mb7CbNVwZLHqoQWh4vwnM