### PR TITLE
feat: inject_file_template for formatted credential files (#241)

### DIFF
--- a/agent-sandbox.yaml.template
+++ b/agent-sandbox.yaml.template
@@ -148,6 +148,20 @@ environment:
     #   inject_to_file: "~/.config/my-agent/credentials.json"
     #   mode: "0600"
     #
+    # Formatted credential file with template (Issue #241):
+    # Use inject_file_template to embed the secret inside a structured config file.
+    # {{VALUE}} is replaced with the secret value at container startup.
+    # GH_TOKEN:
+    #   service: "gh:github.com"
+    #   account: "your-github-username"
+    #   inject_to_file: "~/.config/gh/hosts.yml"
+    #   inject_file_template: |
+    #     github.com:
+    #       oauth_token: {{VALUE}}
+    #       user: your-github-username
+    #       git_protocol: https
+    #   mode: "0600"
+    #
     # Example: Token with account name
     # GIT_TOKEN:
     #   service: "my-git-token"

--- a/docs/CONFIG-REFERENCE.md
+++ b/docs/CONFIG-REFERENCE.md
@@ -1062,7 +1062,7 @@ By default, keychain secrets are stored in the container's Linux Secret Service 
 
 **Validation:** Unrecognized `inject_to` values (e.g., typos like `"keyring"`) produce a warning and default to `"env"`.
 
-**Combining `inject_to_file` and `inject_to`:** These are orthogonal — both can be specified on the same entry. File injection writes the secret to disk first, then secret store injection stores it in the keyring and unsets the env var. The file and the keyring entry both receive the secret value.
+**Combining `inject_to_file` and `inject_to`:** These are orthogonal — both can be specified on the same entry. File injection writes the secret to disk first, then secret store injection stores it in the keyring and unsets the env var. The file and the keyring entry both receive the secret value. When `inject_file_template` is also specified, the secret is embedded inside the template before writing to the file.
 
 To globally use environment variables instead: set `environment.inject_to: "env"` in your config.
 
@@ -1200,6 +1200,41 @@ environment:
 3. For each entry with `inject_to_file`, the credential is written to that file path
 4. The environment variable is then **unset** (so child processes can't read it)
 5. The agent reads credentials from the file as expected
+
+### Formatted Files with `inject_file_template`
+
+Some CLI tools require credentials embedded inside a structured config file rather than as a raw value. The `inject_file_template` field lets you define the file format inline, with `{{VALUE}}` as the placeholder for the secret:
+
+```yaml
+environment:
+  keychain:
+    GH_TOKEN:
+      service: "gh:github.com"
+      account: "aviadshiber"
+      inject_to: "secret_store"
+      inject_to_file: "~/.config/gh/hosts.yml"
+      inject_file_template: |
+        github.com:
+          oauth_token: {{VALUE}}
+          user: aviadshiber
+          git_protocol: https
+      mode: "0600"
+```
+
+**How it works:**
+1. At launch, the template is base64-encoded and passed to the container via an env var
+2. The entrypoint decodes the template and replaces every `{{VALUE}}` with the secret
+3. The result is written to the `inject_to_file` path with the specified `mode`
+4. No trailing newline is added — the template controls whitespace (use YAML `|` block scalar for a trailing newline)
+
+**Validation rules:**
+- `inject_to_file` is required when `inject_file_template` is set
+- The template must contain at least one `{{VALUE}}` placeholder
+- Maximum 5 `{{VALUE}}` placeholders per template
+- Maximum 64 KB template size (pre-encoding)
+- NUL bytes are rejected
+
+**Without `inject_file_template`:** The raw secret value is written to the file (existing behavior, unchanged).
 
 ### Priority Order
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -152,10 +152,12 @@ inject_credential_files() {
         local tmpl_b64="${!tmpl_var:-}"
 
         if [[ -n "$tmpl_b64" ]]; then
-            # SECURITY INVARIANT: Template substitution MUST use bash parameter
-            # expansion only. NEVER use sed, envsubst, eval, or any mechanism
-            # that interprets the secret value. This prevents secret-content
-            # injection attacks.
+            # SECURITY INVARIANT: Template substitution MUST use the split-and-
+            # rejoin method below. NEVER use sed, envsubst, eval, or bash's
+            # ${var//pat/rep} for this — sed and awk treat & as a backreference,
+            # and bash 5.2+ patsub_replacement also treats & in the replacement
+            # as the matched pattern. The split-and-rejoin approach treats the
+            # secret value as a completely opaque string.
             local template
             if ! template=$(printf '%s' "$tmpl_b64" | base64 -d 2>/dev/null); then
                 umask "$old_umask"
@@ -163,8 +165,16 @@ inject_credential_files() {
                 continue
             fi
 
-            # Substitute all {{VALUE}} placeholders with the secret
-            local content="${template//\{\{VALUE\}\}/$value}"
+            # Substitute all {{VALUE}} placeholders with the secret value.
+            # Uses prefix/suffix stripping to split on {{VALUE}} and rejoin
+            # with the secret — no metacharacter interpretation in any bash version.
+            local content=""
+            local remaining="$template"
+            while [[ "$remaining" == *'{{VALUE}}'* ]]; do
+                content+="${remaining%%\{\{VALUE\}\}*}${value}"
+                remaining="${remaining#*\{\{VALUE\}\}}"
+            done
+            content+="$remaining"
 
             # Write templated content (no trailing newline — template controls whitespace)
             if ! printf '%s' "$content" > "$file_path" 2>/dev/null; then

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -161,6 +161,7 @@ inject_credential_files() {
             local template
             if ! template=$(printf '%s' "$tmpl_b64" | base64 -d 2>/dev/null); then
                 umask "$old_umask"
+                unset "$tmpl_var"
                 log_error "Failed to decode template for $var_name — skipping"
                 continue
             fi
@@ -179,6 +180,7 @@ inject_credential_files() {
             # Write templated content (no trailing newline — template controls whitespace)
             if ! printf '%s' "$content" > "$file_path" 2>/dev/null; then
                 umask "$old_umask"
+                unset "$tmpl_var"
                 log_error "Failed to write templated credential to $file_path"
                 continue
             fi

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -143,7 +143,9 @@ inject_credential_files() {
         umask 0077
 
         # Write the credential to file (protected by umask)
-        if ! echo "$value" > "$file_path" 2>/dev/null; then
+        # Use printf instead of echo: echo interprets flags (-n, -e, -E) and
+        # backslash sequences, which corrupts secrets starting with those chars.
+        if ! printf '%s\n' "$value" > "$file_path" 2>/dev/null; then
             umask "$old_umask"
             log_error "Failed to write credential to $file_path"
             continue

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -107,6 +107,11 @@ fi
 #
 # Format: VAR_NAME|file_path|mode (comma-separated for multiple)
 # Example: CLAUDE_OAUTH|~/.claude/.credentials.json|0600,OPENAI_KEY|~/.config/openai/key|0600
+#
+# Template support (Issue #241):
+#   If KAPSIS_TMPL_<VAR_NAME> env var exists, it contains a base64-encoded
+#   template. The template's {{VALUE}} placeholders are replaced with the
+#   secret, and the result is written to the file instead of the raw value.
 #===============================================================================
 inject_credential_files() {
     if [[ -z "${KAPSIS_CREDENTIAL_FILES:-}" ]]; then
@@ -142,13 +147,45 @@ inject_credential_files() {
         old_umask=$(umask)
         umask 0077
 
-        # Write the credential to file (protected by umask)
-        # Use printf instead of echo: echo interprets flags (-n, -e, -E) and
-        # backslash sequences, which corrupts secrets starting with those chars.
-        if ! printf '%s\n' "$value" > "$file_path" 2>/dev/null; then
-            umask "$old_umask"
-            log_error "Failed to write credential to $file_path"
-            continue
+        # Check for template (Issue #241)
+        local tmpl_var="KAPSIS_TMPL_${var_name}"
+        local tmpl_b64="${!tmpl_var:-}"
+
+        if [[ -n "$tmpl_b64" ]]; then
+            # SECURITY INVARIANT: Template substitution MUST use bash parameter
+            # expansion only. NEVER use sed, envsubst, eval, or any mechanism
+            # that interprets the secret value. This prevents secret-content
+            # injection attacks.
+            local template
+            if ! template=$(printf '%s' "$tmpl_b64" | base64 -d 2>/dev/null); then
+                umask "$old_umask"
+                log_error "Failed to decode template for $var_name — skipping"
+                continue
+            fi
+
+            # Substitute all {{VALUE}} placeholders with the secret
+            local content="${template//\{\{VALUE\}\}/$value}"
+
+            # Write templated content (no trailing newline — template controls whitespace)
+            if ! printf '%s' "$content" > "$file_path" 2>/dev/null; then
+                umask "$old_umask"
+                log_error "Failed to write templated credential to $file_path"
+                continue
+            fi
+            log_debug "Injected $var_name to $file_path via template (mode: ${file_mode:-0600})"
+
+            # Clean up template intermediate variables
+            unset "$tmpl_var"
+        else
+            # Write raw credential to file (protected by umask)
+            # Use printf instead of echo: echo interprets flags (-n, -e, -E) and
+            # backslash sequences, which corrupts secrets starting with those chars.
+            if ! printf '%s\n' "$value" > "$file_path" 2>/dev/null; then
+                umask "$old_umask"
+                log_error "Failed to write credential to $file_path"
+                continue
+            fi
+            log_debug "Injected $var_name to $file_path (mode: ${file_mode:-0600})"
         fi
 
         # Restore original umask
@@ -156,7 +193,6 @@ inject_credential_files() {
 
         # Explicitly set final permissions for clarity
         chmod "${file_mode:-0600}" "$file_path" 2>/dev/null || true
-        log_debug "Injected $var_name to $file_path (mode: ${file_mode:-0600})"
 
         # Unset the env var so it's not visible to child processes
         # BUT: if this secret is also targeted for secret store injection,
@@ -167,6 +203,10 @@ inject_credential_files() {
             unset "$var_name"
         fi
     done
+
+    # Clean up metadata env var to prevent leaking file paths and template
+    # structure to the agent process (design review finding)
+    unset KAPSIS_CREDENTIAL_FILES
 
     log_success "Credential files injected"
 }

--- a/scripts/launch-agent.sh
+++ b/scripts/launch-agent.sh
@@ -1424,7 +1424,8 @@ generate_env_vars() {
 
     if [[ -n "$ENV_KEYCHAIN" ]]; then
         log_info "Resolving secrets from system keychain..."
-        while IFS='|' read -r var_name service account inject_to_file file_mode inject_to keyring_collection keyring_profile git_credential_for; do
+        # shellcheck disable=SC2034  # inject_file_template_b64 used in template validation block below
+        while IFS='|' read -r var_name service account inject_to_file file_mode inject_to keyring_collection keyring_profile git_credential_for inject_file_template_b64; do
             [[ -z "$var_name" || -z "$service" ]] && continue
 
             # Expand variables in account (e.g., ${USER})
@@ -1530,6 +1531,62 @@ generate_env_vars() {
                         CREDENTIAL_FILES="${var_name}|${inject_to_file}|${file_mode:-0600}"
                     fi
                     log_debug "Will inject $var_name to file: $inject_to_file"
+                fi
+
+                # Validate and pass inject_file_template if specified (Issue #241)
+                if [[ -n "${inject_file_template_b64:-}" ]]; then
+                    # Template requires inject_to_file — fail-loud if absent
+                    if [[ -z "$inject_to_file" ]]; then
+                        log_error "inject_file_template for $var_name requires inject_to_file to be set"
+                        exit 1
+                    fi
+
+                    # Decode template for validation (yq already base64-encoded it)
+                    local template_raw
+                    if ! template_raw=$(echo "$inject_file_template_b64" | base64 -d 2>/dev/null); then
+                        log_error "Failed to decode inject_file_template for $var_name"
+                        exit 1
+                    fi
+
+                    # Skip empty templates (field is base64("") when not specified)
+                    if [[ -n "$template_raw" ]]; then
+                        # Reject NUL bytes (would truncate shell strings)
+                        if [[ "$template_raw" == *$'\0'* ]]; then
+                            log_error "inject_file_template for $var_name contains NUL bytes"
+                            exit 1
+                        fi
+
+                        # Enforce 64 KB pre-encoding size cap
+                        local template_len=${#template_raw}
+                        if (( template_len > 65536 )); then
+                            log_error "inject_file_template for $var_name exceeds 64 KB limit (${template_len} bytes)"
+                            exit 1
+                        fi
+
+                        # Require {{VALUE}} marker — a template without one is always a misconfiguration
+                        if [[ "$template_raw" != *'{{VALUE}}'* ]]; then
+                            log_error "inject_file_template for $var_name missing required {{VALUE}} placeholder"
+                            exit 1
+                        fi
+
+                        # Cap {{VALUE}} marker count to prevent heap amplification
+                        local marker_count
+                        marker_count=$(grep -o '{{VALUE}}' <<< "$template_raw" | wc -l)
+                        if (( marker_count > 5 )); then
+                            log_error "inject_file_template for $var_name has $marker_count {{VALUE}} markers (max 5)"
+                            exit 1
+                        fi
+
+                        # Warn if secret value itself contains {{VALUE}} (safe for single-pass
+                        # bash parameter expansion, but surprising if mechanism ever changes)
+                        if [[ "$value" == *'{{VALUE}}'* ]]; then
+                            log_warn "Secret value for $var_name contains literal '{{VALUE}}' — substitution is single-pass"
+                        fi
+
+                        # Pass template to container via env-file (avoids ARG_MAX limits)
+                        SECRET_ENV_VARS+=("KAPSIS_TMPL_${var_name}=${inject_file_template_b64}")
+                        log_debug "Will apply template for $var_name (${template_len} bytes)"
+                    fi
                 fi
             else
                 log_warn "Secret not found: $service (for $var_name)"
@@ -2235,7 +2292,7 @@ main() {
         echo ""
         # Sanitize secrets as defense-in-depth (secrets normally go via --env-file,
         # but fallback path may add them as inline -e flags)
-        echo "$(sanitize_secrets "${CONTAINER_CMD[*]}")"
+        sanitize_secrets "${CONTAINER_CMD[*]}"
 
         # Show secrets env-file info if secrets were configured
         if [[ ${#SECRET_ENV_VARS[@]} -gt 0 ]]; then

--- a/scripts/launch-agent.sh
+++ b/scripts/launch-agent.sh
@@ -1543,7 +1543,7 @@ generate_env_vars() {
 
                     # Decode template for validation (yq already base64-encoded it)
                     local template_raw
-                    if ! template_raw=$(echo "$inject_file_template_b64" | base64 -d 2>/dev/null); then
+                    if ! template_raw=$(printf '%s' "$inject_file_template_b64" | base64 -d 2>/dev/null); then
                         log_error "Failed to decode inject_file_template for $var_name"
                         exit 1
                     fi
@@ -1570,8 +1570,12 @@ generate_env_vars() {
                         fi
 
                         # Cap {{VALUE}} marker count to prevent heap amplification
-                        local marker_count
-                        marker_count=$(grep -o '{{VALUE}}' <<< "$template_raw" | wc -l)
+                        local marker_count=0
+                        local _marker_tmp="$template_raw"
+                        while [[ "$_marker_tmp" == *'{{VALUE}}'* ]]; do
+                            _marker_tmp="${_marker_tmp#*\{\{VALUE\}\}}"
+                            ((marker_count++)) || true
+                        done
                         if (( marker_count > 5 )); then
                             log_error "inject_file_template for $var_name has $marker_count {{VALUE}} markers (max 5)"
                             exit 1

--- a/scripts/lib/constants.sh
+++ b/scripts/lib/constants.sh
@@ -181,10 +181,12 @@ readonly KAPSIS_SECRET_STORE_DEFAULT_INJECT_TO="secret_store"
 
 # YQ expression for parsing keychain config with inject_to support.
 # Used by scripts/launch-agent.sh and tests/lib/test-framework.sh.
-# Output format: VAR_NAME|service|account|inject_to_file|mode|inject_to|keyring_collection|keyring_profile|git_credential_for
+# Output format: VAR_NAME|service|account|inject_to_file|mode|inject_to|keyring_collection|keyring_profile|git_credential_for|inject_file_template_b64
+# Field 10 (inject_file_template_b64) is the inject_file_template value base64-encoded via @base64.
+# Empty string when not specified. Used by launch-agent.sh to populate KAPSIS_TMPL_* env vars.
 # Requires KAPSIS_INJECT_DEFAULT env var to be set before calling yq.
 # shellcheck disable=SC2016
-readonly KAPSIS_YQ_KEYCHAIN_EXPR='.environment.keychain // {} | to_entries | .[] | .value.account |= (select(kind == "seq") | join(",")) // .value.account | .key + "|" + .value.service + "|" + (.value.account // "") + "|" + (.value.inject_to_file // "") + "|" + (.value.mode // "0600") + "|" + (.value.inject_to // strenv(KAPSIS_INJECT_DEFAULT)) + "|" + (.value.keyring_collection // "") + "|" + (.value.keyring_profile // "") + "|" + (.value.git_credential_for // "")'
+readonly KAPSIS_YQ_KEYCHAIN_EXPR='.environment.keychain // {} | to_entries | .[] | .value.account |= (select(kind == "seq") | join(",")) // .value.account | .key + "|" + .value.service + "|" + (.value.account // "") + "|" + (.value.inject_to_file // "") + "|" + (.value.mode // "0600") + "|" + (.value.inject_to // strenv(KAPSIS_INJECT_DEFAULT)) + "|" + (.value.keyring_collection // "") + "|" + (.value.keyring_profile // "") + "|" + (.value.git_credential_for // "") + "|" + ((.value.inject_file_template // "") | @base64)'
 
 #===============================================================================
 # FILE SANITIZATION CONSTANTS

--- a/tests/lib/test-framework.sh
+++ b/tests/lib/test-framework.sh
@@ -542,7 +542,7 @@ assert_matches() {
 #   config_file      - Path to YAML config file
 #   inject_default   - Default inject_to value (default: parsed from config or "secret_store")
 #
-# Output format per line: VAR_NAME|service|account|inject_to_file|mode|inject_to|keyring_collection|keyring_profile|git_credential_for
+# Output format per line: VAR_NAME|service|account|inject_to_file|mode|inject_to|keyring_collection|keyring_profile|git_credential_for|inject_file_template_b64
 parse_keychain_config() {
     local config_file="$1"
     local inject_default="${2:-}"

--- a/tests/test-credential-file-template.sh
+++ b/tests/test-credential-file-template.sh
@@ -238,9 +238,11 @@ test_template_env_vars_unset_after_injection() {
     # KAPSIS_TMPL_* should be unset
     assert_equals "" "${KAPSIS_TMPL_UNSET_TOKEN:-}" \
         "KAPSIS_TMPL_UNSET_TOKEN should be unset after injection"
+    # Secret env var itself should be unset (prevents leak to agent process)
+    assert_equals "" "${UNSET_TOKEN:-}" \
+        "Secret env var UNSET_TOKEN should be unset after injection"
 
     rm -rf "$output_dir"
-    unset UNSET_TOKEN 2>/dev/null || true
 }
 
 test_template_multiple_value_markers() {
@@ -292,14 +294,44 @@ test_template_bad_base64_skipped() {
     inject_credential_files 2>/dev/null || true
 
     # File should NOT be created (decode failed → skipped)
-    if [[ -f "$output_file" ]]; then
-        log_fail "Bad base64 should not produce a file"
-    else
-        log_pass "Bad base64 correctly skipped — no file created"
-    fi
+    assert_file_not_exists "$output_file" "Bad base64 should not produce a file"
 
     rm -rf "$output_dir"
     unset BAD_TOKEN KAPSIS_TMPL_BAD_TOKEN KAPSIS_CREDENTIAL_FILES 2>/dev/null || true
+}
+
+test_template_without_value_marker_writes_verbatim() {
+    log_test "Testing template without {{VALUE}} writes template verbatim (entrypoint bypass)"
+
+    # When launch-agent.sh is bypassed (e.g., direct container invocation),
+    # a template without {{VALUE}} should write the template content as-is.
+    # The split-and-rejoin loop never iterates, so content = remaining = template.
+    _setup_entrypoint_env
+
+    local output_dir="$TEST_PROJECT/.kapsis-tmpl-nomarker-$$"
+    mkdir -p "$output_dir"
+    local output_file="$output_dir/config.yml"
+
+    local template
+    template=$(printf 'static_key: some-fixed-value\n')
+    local template_b64
+    template_b64=$(printf '%s' "$template" | base64)
+
+    export NOMARKER_TOKEN="secret-unused"
+    export KAPSIS_TMPL_NOMARKER_TOKEN="$template_b64"
+    export KAPSIS_CREDENTIAL_FILES="NOMARKER_TOKEN|${output_file}|0600"
+
+    inject_credential_files
+
+    local content
+    content=$(cat "$output_file")
+    assert_contains "$content" "static_key: some-fixed-value" \
+        "Template without {{VALUE}} should write template content verbatim"
+    assert_not_contains "$content" "secret-unused" \
+        "Secret should not appear when template has no {{VALUE}} marker"
+
+    rm -rf "$output_dir"
+    unset NOMARKER_TOKEN KAPSIS_TMPL_NOMARKER_TOKEN KAPSIS_CREDENTIAL_FILES 2>/dev/null || true
 }
 
 #===============================================================================
@@ -309,19 +341,21 @@ test_template_bad_base64_skipped() {
 test_template_validation_in_launch_script() {
     log_test "Testing inject_file_template validation logic exists in launch-agent.sh"
 
+    # Structural guards — ensures the code paths are not accidentally deleted.
+    # Uses grep -q directly on file to avoid loading entire script into shell arg.
     local launch_script="$KAPSIS_ROOT/scripts/launch-agent.sh"
 
-    assert_contains "$(cat "$launch_script")" "KAPSIS_TMPL_" \
+    assert_true "grep -q 'KAPSIS_TMPL_' '$launch_script'" \
         "launch-agent.sh should reference KAPSIS_TMPL_ env vars"
-    assert_contains "$(cat "$launch_script")" "inject_file_template" \
+    assert_true "grep -q 'inject_file_template' '$launch_script'" \
         "launch-agent.sh should reference inject_file_template"
-    assert_contains "$(cat "$launch_script")" "missing required {{VALUE}}" \
+    assert_true "grep -q 'missing required {{VALUE}}' '$launch_script'" \
         "launch-agent.sh should validate {{VALUE}} marker"
-    assert_contains "$(cat "$launch_script")" "exceeds 64 KB limit" \
+    assert_true "grep -q 'exceeds 64 KB limit' '$launch_script'" \
         "launch-agent.sh should enforce size limit"
-    assert_contains "$(cat "$launch_script")" "contains NUL bytes" \
+    assert_true "grep -q 'contains NUL bytes' '$launch_script'" \
         "launch-agent.sh should reject NUL bytes"
-    assert_contains "$(cat "$launch_script")" "markers (max 5)" \
+    assert_true "grep -q 'markers (max 5)' '$launch_script'" \
         "launch-agent.sh should cap marker count"
 }
 
@@ -330,9 +364,9 @@ test_entrypoint_has_security_invariant() {
 
     local entrypoint="$KAPSIS_ROOT/scripts/entrypoint.sh"
 
-    assert_contains "$(cat "$entrypoint")" "SECURITY INVARIANT" \
+    assert_true "grep -q 'SECURITY INVARIANT' '$entrypoint'" \
         "entrypoint.sh should have SECURITY INVARIANT comment"
-    assert_contains "$(cat "$entrypoint")" "NEVER use sed, envsubst, eval" \
+    assert_true "grep -q 'NEVER use sed, envsubst, eval' '$entrypoint'" \
         "SECURITY INVARIANT should prohibit sed/envsubst/eval"
 }
 
@@ -341,7 +375,7 @@ test_entrypoint_unsets_credential_files() {
 
     local entrypoint="$KAPSIS_ROOT/scripts/entrypoint.sh"
 
-    assert_contains "$(cat "$entrypoint")" "unset KAPSIS_CREDENTIAL_FILES" \
+    assert_true "grep -q 'unset KAPSIS_CREDENTIAL_FILES' '$entrypoint'" \
         "entrypoint.sh should unset KAPSIS_CREDENTIAL_FILES"
 }
 
@@ -362,6 +396,7 @@ main() {
     run_test test_template_env_vars_unset_after_injection
     run_test test_template_multiple_value_markers
     run_test test_template_bad_base64_skipped
+    run_test test_template_without_value_marker_writes_verbatim
 
     # Launch-agent validation tests (file content checks)
     run_test test_template_validation_in_launch_script

--- a/tests/test-credential-file-template.sh
+++ b/tests/test-credential-file-template.sh
@@ -1,0 +1,378 @@
+#!/usr/bin/env bash
+#===============================================================================
+# Test: Credential File Template Injection (Issue #241)
+#
+# Verifies that inject_file_template correctly substitutes {{VALUE}} placeholders
+# and writes formatted credential files with proper permissions.
+#
+# Category: security
+# Container required: No (sourced-function tests only)
+#===============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/test-framework.sh"
+
+ENTRYPOINT_SCRIPT="$KAPSIS_ROOT/scripts/entrypoint.sh"
+
+#===============================================================================
+# HELPER: Source inject_credential_files() from entrypoint.sh
+#
+# The entrypoint sources logging.sh and defines inject_credential_files().
+# We source the function in isolation by extracting it.
+#===============================================================================
+
+# Create a minimal environment to source entrypoint functions
+_setup_entrypoint_env() {
+    # Source logging (required by inject_credential_files)
+    source "$KAPSIS_ROOT/scripts/lib/logging.sh"
+    init_logging "test-credential-template" 2>/dev/null || true
+
+    # Source only the inject_credential_files function from entrypoint
+    eval "$(sed -n '/^inject_credential_files()/,/^}/p' "$ENTRYPOINT_SCRIPT")"
+}
+
+#===============================================================================
+# TEMPLATE SUBSTITUTION TESTS
+#===============================================================================
+
+test_template_basic_substitution() {
+    log_test "Testing basic {{VALUE}} substitution in template"
+
+    _setup_entrypoint_env
+
+    local output_dir="$TEST_PROJECT/.kapsis-tmpl-test-$$"
+    mkdir -p "$output_dir"
+    local output_file="$output_dir/hosts.yml"
+
+    # Create template: gh CLI hosts.yml format
+    local template
+    template=$(printf 'github.com:\n  oauth_token: {{VALUE}}\n  user: testuser\n  git_protocol: https\n')
+    local template_b64
+    template_b64=$(printf '%s' "$template" | base64)
+
+    # Set up env vars as entrypoint would see them
+    export TEST_GH_TOKEN="ghp_abc123secrettoken"
+    export KAPSIS_TMPL_TEST_GH_TOKEN="$template_b64"
+    export KAPSIS_CREDENTIAL_FILES="TEST_GH_TOKEN|${output_file}|0600"
+
+    # Run injection
+    inject_credential_files
+
+    # Verify file content
+    local content
+    content=$(cat "$output_file")
+    assert_contains "$content" "oauth_token: ghp_abc123secrettoken" \
+        "Template should substitute {{VALUE}} with secret"
+    assert_contains "$content" "git_protocol: https" \
+        "Template should preserve non-placeholder content"
+    assert_not_contains "$content" "{{VALUE}}" \
+        "No {{VALUE}} placeholder should remain"
+
+    # Verify permissions
+    local perms
+    perms=$(stat -f '%Lp' "$output_file" 2>/dev/null || stat -c '%a' "$output_file" 2>/dev/null)
+    assert_equals "600" "$perms" "File permissions should be 0600"
+
+    # Cleanup
+    rm -rf "$output_dir"
+    unset TEST_GH_TOKEN KAPSIS_TMPL_TEST_GH_TOKEN KAPSIS_CREDENTIAL_FILES 2>/dev/null || true
+}
+
+test_template_shell_metacharacters_in_secret() {
+    log_test "Testing secret with shell metacharacters is written literally"
+
+    _setup_entrypoint_env
+
+    local output_dir="$TEST_PROJECT/.kapsis-tmpl-meta-$$"
+    mkdir -p "$output_dir"
+    local output_file="$output_dir/config.yml"
+
+    local template
+    template=$(printf 'token: {{VALUE}}\n')
+    local template_b64
+    template_b64=$(printf '%s' "$template" | base64)
+
+    # Secret contains shell metacharacters that must NOT be interpreted
+    export META_TOKEN='$() `rm -rf /` ; echo pwned & | > /dev/null'
+    export KAPSIS_TMPL_META_TOKEN="$template_b64"
+    export KAPSIS_CREDENTIAL_FILES="META_TOKEN|${output_file}|0600"
+
+    inject_credential_files
+
+    local content
+    content=$(cat "$output_file")
+    # The shell metacharacters must appear literally in the file
+    assert_contains "$content" '$() `rm -rf /`' \
+        "Shell metacharacters should be written literally"
+    assert_contains "$content" "; echo pwned" \
+        "Semicolons should be written literally"
+
+    rm -rf "$output_dir"
+    unset META_TOKEN KAPSIS_TMPL_META_TOKEN KAPSIS_CREDENTIAL_FILES 2>/dev/null || true
+}
+
+test_template_sed_metacharacters_in_secret() {
+    log_test "Testing secret with sed metacharacters (& and \\1) is written literally"
+
+    _setup_entrypoint_env
+
+    local output_dir="$TEST_PROJECT/.kapsis-tmpl-sed-$$"
+    mkdir -p "$output_dir"
+    local output_file="$output_dir/config.yml"
+
+    local template
+    template=$(printf 'token: {{VALUE}}\n')
+    local template_b64
+    template_b64=$(printf '%s' "$template" | base64)
+
+    # Secret contains sed replacement metacharacters
+    export SED_TOKEN='value&with\1backref'
+    export KAPSIS_TMPL_SED_TOKEN="$template_b64"
+    export KAPSIS_CREDENTIAL_FILES="SED_TOKEN|${output_file}|0600"
+
+    inject_credential_files
+
+    local content
+    content=$(cat "$output_file")
+    assert_contains "$content" 'value&with\1backref' \
+        "Sed metacharacters should be written literally (bash parameter expansion, not sed)"
+
+    rm -rf "$output_dir"
+    unset SED_TOKEN KAPSIS_TMPL_SED_TOKEN KAPSIS_CREDENTIAL_FILES 2>/dev/null || true
+}
+
+test_template_multiline() {
+    log_test "Testing multi-line template preserves structure"
+
+    _setup_entrypoint_env
+
+    local output_dir="$TEST_PROJECT/.kapsis-tmpl-multiline-$$"
+    mkdir -p "$output_dir"
+    local output_file="$output_dir/kubeconfig.yml"
+
+    local template
+    template=$(cat <<'TMPL'
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://k8s.example.com
+  name: prod
+users:
+- name: deploy
+  user:
+    token: {{VALUE}}
+TMPL
+)
+    local template_b64
+    template_b64=$(printf '%s' "$template" | base64)
+
+    export K8S_TOKEN="eyJhbGciOiJSUzI1NiJ9.fake-jwt-token"
+    export KAPSIS_TMPL_K8S_TOKEN="$template_b64"
+    export KAPSIS_CREDENTIAL_FILES="K8S_TOKEN|${output_file}|0600"
+
+    inject_credential_files
+
+    local content
+    content=$(cat "$output_file")
+    assert_contains "$content" "apiVersion: v1" "Multi-line template should preserve first line"
+    assert_contains "$content" "token: eyJhbGciOiJSUzI1NiJ9.fake-jwt-token" \
+        "Multi-line template should substitute {{VALUE}}"
+    assert_contains "$content" "server: https://k8s.example.com" \
+        "Multi-line template should preserve non-placeholder lines"
+
+    rm -rf "$output_dir"
+    unset K8S_TOKEN KAPSIS_TMPL_K8S_TOKEN KAPSIS_CREDENTIAL_FILES 2>/dev/null || true
+}
+
+test_raw_value_without_template() {
+    log_test "Testing raw value write when no template is specified"
+
+    _setup_entrypoint_env
+
+    local output_dir="$TEST_PROJECT/.kapsis-tmpl-raw-$$"
+    mkdir -p "$output_dir"
+    local output_file="$output_dir/raw-token"
+
+    export RAW_TOKEN="plain-secret-value"
+    export KAPSIS_CREDENTIAL_FILES="RAW_TOKEN|${output_file}|0600"
+    # No KAPSIS_TMPL_RAW_TOKEN set — should fall through to raw write
+
+    inject_credential_files
+
+    local content
+    content=$(cat "$output_file")
+    # Raw write uses printf '%s\n' so there should be a trailing newline
+    assert_equals "plain-secret-value" "$content" \
+        "Raw value should be written as-is when no template"
+
+    rm -rf "$output_dir"
+    unset RAW_TOKEN KAPSIS_CREDENTIAL_FILES 2>/dev/null || true
+}
+
+test_template_env_vars_unset_after_injection() {
+    log_test "Testing KAPSIS_CREDENTIAL_FILES and KAPSIS_TMPL_* are unset after injection"
+
+    _setup_entrypoint_env
+
+    local output_dir="$TEST_PROJECT/.kapsis-tmpl-unset-$$"
+    mkdir -p "$output_dir"
+    local output_file="$output_dir/token"
+
+    local template
+    template=$(printf 'token: {{VALUE}}\n')
+    local template_b64
+    template_b64=$(printf '%s' "$template" | base64)
+
+    export UNSET_TOKEN="secret123"
+    export KAPSIS_TMPL_UNSET_TOKEN="$template_b64"
+    export KAPSIS_CREDENTIAL_FILES="UNSET_TOKEN|${output_file}|0600"
+
+    inject_credential_files
+
+    # KAPSIS_CREDENTIAL_FILES should be unset
+    assert_equals "" "${KAPSIS_CREDENTIAL_FILES:-}" \
+        "KAPSIS_CREDENTIAL_FILES should be unset after injection"
+    # KAPSIS_TMPL_* should be unset
+    assert_equals "" "${KAPSIS_TMPL_UNSET_TOKEN:-}" \
+        "KAPSIS_TMPL_UNSET_TOKEN should be unset after injection"
+
+    rm -rf "$output_dir"
+    unset UNSET_TOKEN 2>/dev/null || true
+}
+
+test_template_multiple_value_markers() {
+    log_test "Testing template with multiple {{VALUE}} markers substitutes all"
+
+    _setup_entrypoint_env
+
+    local output_dir="$TEST_PROJECT/.kapsis-tmpl-multi-marker-$$"
+    mkdir -p "$output_dir"
+    local output_file="$output_dir/config.json"
+
+    local template
+    template=$(printf '{"primary": "{{VALUE}}", "backup": "{{VALUE}}"}\n')
+    local template_b64
+    template_b64=$(printf '%s' "$template" | base64)
+
+    export MULTI_TOKEN="tok_abc"
+    export KAPSIS_TMPL_MULTI_TOKEN="$template_b64"
+    export KAPSIS_CREDENTIAL_FILES="MULTI_TOKEN|${output_file}|0600"
+
+    inject_credential_files
+
+    local content
+    content=$(cat "$output_file")
+    # Both occurrences should be replaced
+    local count
+    count=$(grep -o 'tok_abc' <<< "$content" | wc -l)
+    assert_equals "2" "$(echo "$count" | tr -d ' ')" \
+        "Both {{VALUE}} markers should be substituted"
+
+    rm -rf "$output_dir"
+    unset MULTI_TOKEN KAPSIS_TMPL_MULTI_TOKEN KAPSIS_CREDENTIAL_FILES 2>/dev/null || true
+}
+
+test_template_bad_base64_skipped() {
+    log_test "Testing invalid base64 template is skipped with error"
+
+    _setup_entrypoint_env
+
+    local output_dir="$TEST_PROJECT/.kapsis-tmpl-badb64-$$"
+    mkdir -p "$output_dir"
+    local output_file="$output_dir/token"
+
+    export BAD_TOKEN="secret"
+    export KAPSIS_TMPL_BAD_TOKEN="not-valid-base64!!!"
+    export KAPSIS_CREDENTIAL_FILES="BAD_TOKEN|${output_file}|0600"
+
+    # Should not crash — bad decode is skipped
+    inject_credential_files 2>/dev/null || true
+
+    # File should NOT be created (decode failed → skipped)
+    if [[ -f "$output_file" ]]; then
+        log_fail "Bad base64 should not produce a file"
+    else
+        log_pass "Bad base64 correctly skipped — no file created"
+    fi
+
+    rm -rf "$output_dir"
+    unset BAD_TOKEN KAPSIS_TMPL_BAD_TOKEN KAPSIS_CREDENTIAL_FILES 2>/dev/null || true
+}
+
+#===============================================================================
+# LAUNCH-AGENT VALIDATION TESTS (config parsing, no container)
+#===============================================================================
+
+test_template_validation_in_launch_script() {
+    log_test "Testing inject_file_template validation logic exists in launch-agent.sh"
+
+    local launch_script="$KAPSIS_ROOT/scripts/launch-agent.sh"
+
+    assert_contains "$(cat "$launch_script")" "KAPSIS_TMPL_" \
+        "launch-agent.sh should reference KAPSIS_TMPL_ env vars"
+    assert_contains "$(cat "$launch_script")" "inject_file_template" \
+        "launch-agent.sh should reference inject_file_template"
+    assert_contains "$(cat "$launch_script")" "missing required {{VALUE}}" \
+        "launch-agent.sh should validate {{VALUE}} marker"
+    assert_contains "$(cat "$launch_script")" "exceeds 64 KB limit" \
+        "launch-agent.sh should enforce size limit"
+    assert_contains "$(cat "$launch_script")" "contains NUL bytes" \
+        "launch-agent.sh should reject NUL bytes"
+    assert_contains "$(cat "$launch_script")" "markers (max 5)" \
+        "launch-agent.sh should cap marker count"
+}
+
+test_entrypoint_has_security_invariant() {
+    log_test "Testing entrypoint.sh has SECURITY INVARIANT comment"
+
+    local entrypoint="$KAPSIS_ROOT/scripts/entrypoint.sh"
+
+    assert_contains "$(cat "$entrypoint")" "SECURITY INVARIANT" \
+        "entrypoint.sh should have SECURITY INVARIANT comment"
+    assert_contains "$(cat "$entrypoint")" "NEVER use sed, envsubst, eval" \
+        "SECURITY INVARIANT should prohibit sed/envsubst/eval"
+}
+
+test_entrypoint_unsets_credential_files() {
+    log_test "Testing entrypoint.sh unsets KAPSIS_CREDENTIAL_FILES after injection"
+
+    local entrypoint="$KAPSIS_ROOT/scripts/entrypoint.sh"
+
+    assert_contains "$(cat "$entrypoint")" "unset KAPSIS_CREDENTIAL_FILES" \
+        "entrypoint.sh should unset KAPSIS_CREDENTIAL_FILES"
+}
+
+#===============================================================================
+# MAIN
+#===============================================================================
+
+main() {
+    print_test_header "Credential File Template Injection"
+    setup_test_project
+
+    # Template substitution tests (sourced function, no container)
+    run_test test_template_basic_substitution
+    run_test test_template_shell_metacharacters_in_secret
+    run_test test_template_sed_metacharacters_in_secret
+    run_test test_template_multiline
+    run_test test_raw_value_without_template
+    run_test test_template_env_vars_unset_after_injection
+    run_test test_template_multiple_value_markers
+    run_test test_template_bad_base64_skipped
+
+    # Launch-agent validation tests (file content checks)
+    run_test test_template_validation_in_launch_script
+    run_test test_entrypoint_has_security_invariant
+    run_test test_entrypoint_unsets_credential_files
+
+    # Cleanup
+    cleanup_test_project
+
+    # Summary
+    print_summary
+}
+
+main "$@"

--- a/tests/test-secret-store-injection.sh
+++ b/tests/test-secret-store-injection.sh
@@ -85,6 +85,85 @@ EOF
         "inject_to and inject_to_file should both be present"
 }
 
+#===============================================================================
+# INJECT FILE TEMPLATE TESTS (Issue #241)
+#===============================================================================
+
+test_yq_expr_includes_inject_file_template() {
+    log_test "Testing YQ expression includes inject_file_template as base64-encoded 10th field"
+
+    if ! command -v yq &> /dev/null; then
+        log_skip "yq not available"
+        return 0
+    fi
+
+    local test_config="$TEST_PROJECT/.kapsis-tmpl-yq-test.yaml"
+    cat > "$test_config" << 'EOF'
+agent:
+  command: "echo test"
+environment:
+  keychain:
+    GH_TOKEN:
+      service: "gh:github.com"
+      account: "testuser"
+      inject_to_file: "~/.config/gh/hosts.yml"
+      inject_file_template: |
+        github.com:
+          oauth_token: {{VALUE}}
+          user: testuser
+          git_protocol: https
+      mode: "0600"
+EOF
+
+    local parsed
+    parsed=$(parse_keychain_config "$test_config")
+
+    rm -f "$test_config"
+
+    # The 10th field should be a non-empty base64-encoded string
+    local template_b64
+    template_b64=$(echo "$parsed" | head -1 | cut -d'|' -f10)
+    assert_not_equals "" "$template_b64" "inject_file_template should produce non-empty 10th field"
+
+    # Decode and verify the template content
+    local decoded
+    decoded=$(echo "$template_b64" | base64 -d 2>/dev/null)
+    assert_contains "$decoded" "{{VALUE}}" "Decoded template should contain {{VALUE}} placeholder"
+    assert_contains "$decoded" "oauth_token" "Decoded template should contain oauth_token field"
+}
+
+test_yq_expr_empty_template_produces_empty_base64() {
+    log_test "Testing YQ expression produces base64 of empty string when no template specified"
+
+    if ! command -v yq &> /dev/null; then
+        log_skip "yq not available"
+        return 0
+    fi
+
+    local test_config="$TEST_PROJECT/.kapsis-tmpl-empty-test.yaml"
+    cat > "$test_config" << 'EOF'
+agent:
+  command: "echo test"
+environment:
+  keychain:
+    PLAIN_TOKEN:
+      service: "plain-service"
+      inject_to_file: "~/.config/plain/token"
+EOF
+
+    local parsed
+    parsed=$(parse_keychain_config "$test_config")
+
+    rm -f "$test_config"
+
+    # The 10th field should be base64("") which decodes to empty
+    local template_b64
+    template_b64=$(echo "$parsed" | head -1 | cut -d'|' -f10)
+    local decoded
+    decoded=$(echo "$template_b64" | base64 -d 2>/dev/null || true)
+    assert_equals "" "$decoded" "Empty template should decode to empty string"
+}
+
 test_secret_store_entries_dry_run() {
     log_test "Testing KAPSIS_SECRET_STORE_ENTRIES appears in dry-run when inject_to: secret_store"
 
@@ -490,6 +569,8 @@ main() {
     # Config parsing tests (no container required)
     run_test test_inject_to_field_in_yq_pipeline
     run_test test_inject_to_with_inject_to_file_coexist
+    run_test test_yq_expr_includes_inject_file_template
+    run_test test_yq_expr_empty_template_produces_empty_base64
     run_test test_secret_store_entries_dry_run
     run_test test_build_config_secret_store_toggle
     run_test test_build_config_minimal_no_secret_store


### PR DESCRIPTION
## Summary

- Add `inject_file_template` field to keychain config, allowing secrets to be embedded inside structured config files (gh CLI `hosts.yml`, kubeconfig, Docker config) using `{{VALUE}}` placeholder substitution
- Templates transit as `KAPSIS_TMPL_*` env vars via `--env-file` (not command line), keeping `CREDENTIAL_FILES` at 3 fields for full backward compatibility
- Substitution uses a split-and-rejoin loop — safe across all bash versions including 5.2+ where `patsub_replacement` makes `&` special in `${var//pat/rep}`

## Changes

| File | What |
|------|------|
| `scripts/lib/constants.sh` | Extended `KAPSIS_YQ_KEYCHAIN_EXPR` with 10th field (base64-encoded template) |
| `scripts/launch-agent.sh` | Template validation: NUL bytes, 64KB cap, `{{VALUE}}` required, marker count ≤5 |
| `scripts/entrypoint.sh` | Template substitution via split-and-rejoin, echo→printf fix, env var cleanup |
| `tests/test-credential-file-template.sh` | 11 new tests (substitution, metacharacters, multiline, cleanup, validation) |
| `tests/test-secret-store-injection.sh` | 2 new YQ parsing tests for 10th field |
| `tests/lib/test-framework.sh` | Updated comment documenting 10th field |
| `docs/CONFIG-REFERENCE.md` | New "Formatted Files with inject_file_template" subsection |
| `agent-sandbox.yaml.template` | Commented template example |

## Security

- **SECURITY INVARIANT**: Template substitution uses only bash string operations — never sed, envsubst, eval, or parameter expansion replacement (which has `&` metacharacter issues in bash 5.2+)
- All `KAPSIS_TMPL_*` and `KAPSIS_CREDENTIAL_FILES` env vars are unset after injection to prevent metadata leaking to the agent process
- Templates validated before encoding: NUL byte rejection, 64KB size cap, marker count ≤5

## Test plan

- [x] `./tests/run-all-tests.sh --quick` — 56/58 pass (2 pre-existing failures unrelated to this change)
- [x] `./tests/test-credential-file-template.sh` — 11/11 pass
- [x] `./tests/test-secret-store-injection.sh` — all pass including 2 new YQ tests
- [x] `shellcheck` clean on all modified scripts
- [ ] Integration test: launch agent with gh CLI `hosts.yml` template config and verify file content + permissions inside container

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)