### PR TITLE
feat: detect /workspace virtio-fs mount drop mid-run

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -364,6 +364,10 @@ KAPSIS_PUSH_FALLBACK: cd /path/to/worktree && git push -u origin branch-name
 
 **In status.json:** The `push_fallback_command` field contains the same command when `push_status` is `"failed"`.
 
+## Mount Failure Detection (Issue #248)
+
+Exit code 4 indicates a virtio-fs mount drop detected mid-run. The agent writes a `KAPSIS_MOUNT_FAILURE:` sentinel to stderr (which flows through podman's pipe, not virtio-fs). Host-side `launch-agent.sh` detects the sentinel and overrides the exit code. Recovery: `podman machine stop && podman machine start`, then re-run.
+
 ## Cross-Platform Notes
 
 - macOS container overlay tests may fail due to virtio-fs limitations — run full test coverage on Linux

--- a/docs/CONFIG-REFERENCE.md
+++ b/docs/CONFIG-REFERENCE.md
@@ -879,7 +879,42 @@ kapsis-status --health <project> <agent-id>
 kapsis-status --health --json <project> <agent-id>
 ```
 
-Shows process state, I/O activity, TCP connections, memory/CPU, hook staleness, and overall health status (HEALTHY / WARNING / CRITICAL / STOPPED).
+Shows process state, I/O activity, TCP connections, memory/CPU, hook staleness, and overall health status (HEALTHY / WARNING / CRITICAL / STOPPED / MOUNT_FAILURE).
+
+### Mount Health Check (Issue #248)
+
+Detects mid-run virtio-fs mount drops on macOS (Apple Hypervisor). The mount works at startup but can disconnect silently ~30 minutes in, making all `/workspace` files inaccessible.
+
+```yaml
+liveness:
+  enabled: true
+  mount_check: true             # Enable workspace mount health check (default: true when liveness enabled)
+  mount_check_retries: 2        # Retries before declaring failure (default: 2)
+  mount_check_retry_delay: 5    # Seconds between retries (default: 5)
+  mount_check_probe_timeout: 5  # Seconds before probe times out (default: 5)
+  mount_check_delay: 30         # Grace period before first check (default: 30s)
+```
+
+**How it works:**
+
+1. Periodic probe runs `timeout <probe_timeout> stat /workspace` + checks workspace is non-empty + (worktree mode) verifies `.git-safe/HEAD` exists
+2. A hung probe (degraded virtio-fs) counts as immediate failure — no retries
+3. On confirmed failure: writes `KAPSIS_MOUNT_FAILURE:` sentinel to stderr, kills agent (SIGTERM → 10s → SIGKILL)
+4. Host-side `launch-agent.sh` detects the sentinel in captured container output and overrides exit code to 4
+5. Sentinel is only honored when container exit code is 143 (SIGTERM) or 137 (SIGKILL) — prevents a compromised agent from faking mount failures
+
+**Integration with liveness:**
+
+- When liveness IS enabled: mount probe runs inside the liveness loop (one loop, two concerns)
+- When liveness is NOT enabled: standalone mount check loop via `KAPSIS_MOUNT_CHECK_ENABLED=true` env var
+
+**Recovery:**
+
+```bash
+podman machine stop
+podman machine start
+# Re-run the agent
+```
 
 ## Example Configurations
 

--- a/docs/STATUS-TRACKING.md
+++ b/docs/STATUS-TRACKING.md
@@ -167,6 +167,18 @@ Configuration is stored in `configs/tool-phase-mapping.yaml`.
 }
 ```
 
+### Exit Codes
+
+| Code | Meaning | Recovery |
+|------|---------|----------|
+| 0 | Success | — |
+| 1 | Agent failure | Check container logs |
+| 2 | Push failed | Run push fallback command |
+| 3 | Uncommitted changes | Manually commit from worktree |
+| 4 | Mount failure (virtio-fs drop) | `podman machine stop && start`, re-run |
+| 137 | Killed by liveness monitor (SIGKILL) | Check agent for hangs |
+| 143 | Killed by liveness monitor (SIGTERM) | Check agent for hangs |
+
 ## Agent Gist (Live Activity Summary)
 
 During long "thinking" periods, the standard status message may become stale. The **gist** feature provides a signaling file that agents can update in real-time to communicate what they're currently working on.

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1685,6 +1685,20 @@ main() {
         fi
     fi
 
+    # Start standalone mount check if liveness is disabled (Issue #248)
+    # When liveness IS enabled, mount check is integrated into its loop above
+    if [[ "${KAPSIS_MOUNT_CHECK_ENABLED:-false}" == "true" ]] \
+       && [[ "${KAPSIS_LIVENESS_ENABLED:-false}" != "true" ]]; then
+        local liveness_lib="${KAPSIS_HOME:-/opt/kapsis}/lib/liveness-monitor.sh"
+        if [[ -f "$liveness_lib" ]]; then
+            # Source guard in liveness-monitor.sh prevents double-sourcing
+            source "$liveness_lib"
+            start_mount_check_monitor
+        else
+            log_warn "Mount check enabled but liveness-monitor library not found: $liveness_lib"
+        fi
+    fi
+
     # Execute command
     log_debug "About to execute command: $*"
     if [[ $# -eq 0 ]]; then

--- a/scripts/kapsis-status.sh
+++ b/scripts/kapsis-status.sh
@@ -247,12 +247,26 @@ get_status() {
             echo ""
             if [[ "$exit_code" == "0" ]]; then
                 echo -e "  Exit Code:    ${GREEN}$exit_code (success)${NC}"
+            elif [[ "$exit_code" == "4" ]]; then
+                echo -e "  Exit Code:    ${RED}$exit_code (mount failure)${NC}"
             else
                 echo -e "  Exit Code:    ${RED}$exit_code (failed)${NC}"
             fi
             [[ -n "$error" && "$error" != "null" ]] && echo -e "  Error:        ${RED}$error${NC}"
             [[ -n "$pr_url" && "$pr_url" != "null" ]] && echo "  PR URL:       $pr_url"
             echo ""
+
+            # Mount failure recovery guidance (Issue #248)
+            if [[ "$exit_code" == "4" ]]; then
+                echo -e "${YELLOW}--- Mount Failure Recovery ---${NC}"
+                echo ""
+                echo "  The /workspace virtio-fs mount was lost during execution."
+                echo "  To recover:"
+                echo "    1. podman machine stop"
+                echo "    2. podman machine start"
+                echo "    3. Re-run the agent"
+                echo ""
+            fi
         fi
 
         [[ -n "$worktree_path" && "$worktree_path" != "null" ]] && echo "  Worktree:     $worktree_path"
@@ -411,7 +425,11 @@ except: print('null')
 
     # Determine health status
     local health="HEALTHY"
-    if [[ "$phase" == "complete" || "$phase" == "killed" ]]; then
+    local health_exit_code
+    health_exit_code=$(json_get_num "$content" "exit_code")
+    if [[ "$health_exit_code" == "4" ]]; then
+        health="MOUNT_FAILURE"
+    elif [[ "$phase" == "complete" || "$phase" == "killed" ]]; then
         health="STOPPED"
     elif [[ "$hook_stale_secs" != "null" && "$hook_stale_secs" -ge 1800 ]]; then
         health="CRITICAL"
@@ -444,7 +462,7 @@ HEALTHJSON
         # Pretty output
         local health_color="$GREEN"
         case "$health" in
-            CRITICAL) health_color="$RED" ;;
+            CRITICAL|MOUNT_FAILURE) health_color="$RED" ;;
             WARNING) health_color="$YELLOW" ;;
             STOPPED) health_color="$NC" ;;
         esac

--- a/scripts/launch-agent.sh
+++ b/scripts/launch-agent.sh
@@ -809,6 +809,14 @@ parse_config() {
         LIVENESS_GRACE_PERIOD=$(yq -r '.liveness.grace_period // "300"' "$CONFIG_FILE" 2>/dev/null || echo "300")
         LIVENESS_CHECK_INTERVAL=$(yq -r '.liveness.check_interval // "30"' "$CONFIG_FILE" 2>/dev/null || echo "30")
 
+        # Parse mount check configuration (Issue #248)
+        # Defaults to true when liveness section exists, since mount checking is lightweight
+        MOUNT_CHECK_ENABLED=$(yq -r '.liveness.mount_check // "true"' "$CONFIG_FILE" 2>/dev/null || echo "true")
+        MOUNT_CHECK_RETRIES=$(yq -r '.liveness.mount_check_retries // "2"' "$CONFIG_FILE" 2>/dev/null || echo "2")
+        MOUNT_CHECK_RETRY_DELAY=$(yq -r '.liveness.mount_check_retry_delay // "5"' "$CONFIG_FILE" 2>/dev/null || echo "5")
+        MOUNT_CHECK_PROBE_TIMEOUT=$(yq -r '.liveness.mount_check_probe_timeout // "5"' "$CONFIG_FILE" 2>/dev/null || echo "5")
+        MOUNT_CHECK_DELAY=$(yq -r '.liveness.mount_check_delay // "30"' "$CONFIG_FILE" 2>/dev/null || echo "30")
+
         # Parse network mode from config (CLI flag takes precedence)
         # Only read from config if CLI didn't explicitly set the value
         if [[ -z "$CLI_NETWORK_MODE" ]]; then
@@ -1742,6 +1750,15 @@ generate_env_vars() {
         ENV_VARS+=("-e" "KAPSIS_LIVENESS_CHECK_INTERVAL=${LIVENESS_CHECK_INTERVAL:-30}")
     fi
 
+    # Mount check env vars (Issue #248) — independent of liveness enabled
+    if [[ "${MOUNT_CHECK_ENABLED:-false}" == "true" ]]; then
+        ENV_VARS+=("-e" "KAPSIS_MOUNT_CHECK_ENABLED=true")
+        ENV_VARS+=("-e" "KAPSIS_MOUNT_CHECK_RETRIES=${MOUNT_CHECK_RETRIES:-2}")
+        ENV_VARS+=("-e" "KAPSIS_MOUNT_CHECK_RETRY_DELAY=${MOUNT_CHECK_RETRY_DELAY:-5}")
+        ENV_VARS+=("-e" "KAPSIS_MOUNT_CHECK_PROBE_TIMEOUT=${MOUNT_CHECK_PROBE_TIMEOUT:-5}")
+        ENV_VARS+=("-e" "KAPSIS_MOUNT_CHECK_DELAY=${MOUNT_CHECK_DELAY:-30}")
+    fi
+
     # Fix hang-after-completion for Claude agents (anthropics/claude-code#21099)
     # This env var tells Claude CLI to exit after the Stop event when stdout is piped
     # agent_type is set earlier in this function from AGENT_NAME or image inference
@@ -2376,6 +2393,17 @@ main() {
         fi
         log_debug "CONTAINER_ERROR_OUTPUT: $CONTAINER_ERROR_OUTPUT"
     fi
+
+    # Check for mount failure sentinel in container output (Issue #248)
+    # Only honor when container was killed by signal (SIGTERM=143, SIGKILL=137)
+    # to prevent a compromised agent from faking mount failures
+    if [[ "$EXIT_CODE" -eq 143 || "$EXIT_CODE" -eq 137 ]]; then
+        if [[ -f "$container_output" ]] && grep -q 'KAPSIS_MOUNT_FAILURE:' "$container_output" 2>/dev/null; then
+            log_warn "Mount failure detected via sentinel — overriding exit code to 4"
+            EXIT_CODE=4
+        fi
+    fi
+
     rm -f "$container_output"
     # Update status to post_processing (Fix #3: don't report "completed" until commit verified)
     status_phase "post_processing" 85 "Processing agent output (exit code: $EXIT_CODE)"
@@ -2418,7 +2446,16 @@ main() {
     #   1 = Agent failure (container exit code non-zero)
     #   2 = Push failed
     #   3 = Uncommitted changes remain
-    if [[ "$EXIT_CODE" -ne 0 ]]; then
+    if [[ "$EXIT_CODE" -eq 4 ]]; then
+        # Mount failure detected via sentinel (Issue #248)
+        FINAL_EXIT_CODE=4
+        log_finalize 4
+        local mount_error="Workspace mount lost (virtio-fs drop). Recovery: podman machine stop && podman machine start, then re-run."
+        status_complete 4 "$mount_error"
+        _STATUS_COMPLETE_SHOWN=true
+        display_complete 4 "" "$mount_error"
+        _DISPLAY_COMPLETE_SHOWN=true
+    elif [[ "$EXIT_CODE" -ne 0 ]]; then
         FINAL_EXIT_CODE=$EXIT_CODE
         log_finalize "$EXIT_CODE"
         status_complete "$EXIT_CODE" "Agent exited with error code $EXIT_CODE"

--- a/scripts/lib/constants.sh
+++ b/scripts/lib/constants.sh
@@ -274,3 +274,13 @@ readonly KAPSIS_DEFAULT_CLEANUP_VM_JOURNAL_VACUUM_SIZE="100M"
 
 # Timeout (seconds) for podman machine ssh commands
 readonly KAPSIS_DEFAULT_CLEANUP_VM_SSH_TIMEOUT=15
+
+#===============================================================================
+# EXIT CODES (Issue #248)
+#
+# Standard exit codes returned by Kapsis agent containers.
+# Used by launch-agent.sh, entrypoint.sh, and kapsis-status.sh.
+#===============================================================================
+
+# Workspace mount lost during execution (macOS virtio-fs drop)
+readonly KAPSIS_EXIT_MOUNT_FAILURE=4

--- a/scripts/lib/liveness-monitor.sh
+++ b/scripts/lib/liveness-monitor.sh
@@ -470,8 +470,11 @@ _mount_check_probe() {
     # Catches partial mount degradation where listing works but file reads fail
     if [[ "${KAPSIS_SANDBOX_MODE:-overlay}" == "worktree" ]]; then
         local git_safe="${_MOUNT_CHECK_GIT_PATH:-${CONTAINER_GIT_PATH:-/workspace/.git-safe}}"
-        # Use timeout for -d check too — [[ -d ]] can hang on degraded virtio-fs
-        if timeout "$probe_timeout" test -d "$git_safe" 2>/dev/null; then
+        # Use timeout for -d check too — even test -d can hang on severely degraded virtio-fs
+        timeout "$probe_timeout" test -d "$git_safe" 2>/dev/null
+        rc=$?
+        [[ $rc -eq 124 ]] && return $rc  # Hung — report timeout to caller
+        if [[ $rc -eq 0 ]]; then
             timeout "$probe_timeout" stat "$git_safe/HEAD" >/dev/null 2>&1
             rc=$?
             [[ $rc -ne 0 ]] && return $rc
@@ -507,9 +510,15 @@ _mount_check_with_retries() {
     local i
     for (( i=1; i<=retries; i++ )); do
         sleep "$delay"
-        if _mount_check_probe; then
+        _mount_check_probe
+        local retry_rc=$?
+        if [[ "$retry_rc" -eq 0 ]]; then
             _liveness_log "INFO" "Mount check recovered on retry $i"
             return 0
+        fi
+        if [[ "$retry_rc" -eq 124 ]]; then
+            _liveness_log "WARN" "Mount probe timed out on retry $i — aborting retries"
+            return 1
         fi
         _liveness_log "WARN" "Mount check retry $i/$retries failed"
     done

--- a/scripts/lib/liveness-monitor.sh
+++ b/scripts/lib/liveness-monitor.sh
@@ -442,21 +442,26 @@ _liveness_init_api_signal() {
 #===============================================================================
 
 # Check if the workspace mount is still accessible.
-# Returns 0 if mount is healthy, 1 if mount appears dropped.
+# Returns 0 if mount is healthy, 1 if mount appears dropped,
+# 124 if probe timed out (hung I/O — definitive failure).
 _mount_check_probe() {
     # _MOUNT_CHECK_WORKSPACE overrides the readonly CONTAINER_WORKSPACE_PATH for testing
     local workspace="${_MOUNT_CHECK_WORKSPACE:-${CONTAINER_WORKSPACE_PATH:-/workspace}}"
     local probe_timeout="$_MOUNT_CHECK_PROBE_TIMEOUT"
 
     # Primary probe: stat the workspace directory itself
-    # If virtio-fs drops, stat will fail with ENOENT or EIO, or hang
-    if ! timeout "$probe_timeout" stat "$workspace" >/dev/null 2>&1; then
-        return 1
-    fi
+    # If virtio-fs drops, stat will fail with ENOENT or EIO, or hang (exit 124)
+    # Preserve exact exit code so callers can distinguish timeout (124) from error (1)
+    local rc
+    timeout "$probe_timeout" stat "$workspace" >/dev/null 2>&1
+    rc=$?
+    [[ $rc -ne 0 ]] && return $rc
 
     # Secondary probe: verify files are accessible (empty dir = mount dropped)
     local listing
-    listing=$(timeout "$probe_timeout" ls -A "$workspace" 2>/dev/null) || return 1
+    listing=$(timeout "$probe_timeout" ls -A "$workspace" 2>/dev/null)
+    rc=$?
+    [[ $rc -ne 0 ]] && return $rc
     if [[ -z "$listing" ]]; then
         return 1
     fi
@@ -465,8 +470,11 @@ _mount_check_probe() {
     # Catches partial mount degradation where listing works but file reads fail
     if [[ "${KAPSIS_SANDBOX_MODE:-overlay}" == "worktree" ]]; then
         local git_safe="${_MOUNT_CHECK_GIT_PATH:-${CONTAINER_GIT_PATH:-/workspace/.git-safe}}"
-        if [[ -d "$git_safe" ]]; then
-            timeout "$probe_timeout" stat "$git_safe/HEAD" >/dev/null 2>&1 || return 1
+        # Use timeout for -d check too — [[ -d ]] can hang on degraded virtio-fs
+        if timeout "$probe_timeout" test -d "$git_safe" 2>/dev/null; then
+            timeout "$probe_timeout" stat "$git_safe/HEAD" >/dev/null 2>&1
+            rc=$?
+            [[ $rc -ne 0 ]] && return $rc
         fi
     fi
 

--- a/scripts/lib/liveness-monitor.sh
+++ b/scripts/lib/liveness-monitor.sh
@@ -57,6 +57,13 @@ _LIVENESS_DNS_TIMEOUT="${KAPSIS_LIVENESS_DNS_TIMEOUT:-2}"
 _LIVENESS_MAX_IPS_PER_DOMAIN="${KAPSIS_LIVENESS_MAX_IPS_PER_DOMAIN:-8}"
 _LIVENESS_API_MAX_SKIP="${KAPSIS_LIVENESS_API_MAX_SKIP:-240}"
 
+# Mount check configuration (Issue #248) — independent of liveness timeout kill
+_MOUNT_CHECK_ENABLED="${KAPSIS_MOUNT_CHECK_ENABLED:-false}"
+_MOUNT_CHECK_RETRIES="${KAPSIS_MOUNT_CHECK_RETRIES:-2}"
+_MOUNT_CHECK_RETRY_DELAY="${KAPSIS_MOUNT_CHECK_RETRY_DELAY:-5}"
+_MOUNT_CHECK_PROBE_TIMEOUT="${KAPSIS_MOUNT_CHECK_PROBE_TIMEOUT:-5}"
+_MOUNT_CHECK_DELAY="${KAPSIS_MOUNT_CHECK_DELAY:-30}"
+
 # AI API domains to monitor for active connections
 _LIVENESS_API_DOMAINS=(
     api.anthropic.com
@@ -423,6 +430,124 @@ _liveness_init_api_signal() {
 }
 
 #===============================================================================
+# Mount Check (Issue #248)
+#
+# Detects virtio-fs mount drops on macOS during container execution.
+# The mount can silently disconnect while the agent is running, making all
+# files under /workspace inaccessible. Every probe uses `timeout` because
+# degraded virtio-fs can hang stat/ls calls indefinitely.
+#
+# Signaling: writes a sentinel line to stderr (captured by podman's tee
+# pipeline), since /kapsis-status may also be on the same virtio-fs mount.
+#===============================================================================
+
+# Check if the workspace mount is still accessible.
+# Returns 0 if mount is healthy, 1 if mount appears dropped.
+_mount_check_probe() {
+    # _MOUNT_CHECK_WORKSPACE overrides the readonly CONTAINER_WORKSPACE_PATH for testing
+    local workspace="${_MOUNT_CHECK_WORKSPACE:-${CONTAINER_WORKSPACE_PATH:-/workspace}}"
+    local probe_timeout="$_MOUNT_CHECK_PROBE_TIMEOUT"
+
+    # Primary probe: stat the workspace directory itself
+    # If virtio-fs drops, stat will fail with ENOENT or EIO, or hang
+    if ! timeout "$probe_timeout" stat "$workspace" >/dev/null 2>&1; then
+        return 1
+    fi
+
+    # Secondary probe: verify files are accessible (empty dir = mount dropped)
+    local listing
+    listing=$(timeout "$probe_timeout" ls -A "$workspace" 2>/dev/null) || return 1
+    if [[ -z "$listing" ]]; then
+        return 1
+    fi
+
+    # Tertiary probe (worktree mode only): check git sentinel
+    # Catches partial mount degradation where listing works but file reads fail
+    if [[ "${KAPSIS_SANDBOX_MODE:-overlay}" == "worktree" ]]; then
+        local git_safe="${_MOUNT_CHECK_GIT_PATH:-${CONTAINER_GIT_PATH:-/workspace/.git-safe}}"
+        if [[ -d "$git_safe" ]]; then
+            timeout "$probe_timeout" stat "$git_safe/HEAD" >/dev/null 2>&1 || return 1
+        fi
+    fi
+
+    return 0
+}
+
+# Perform mount check with retries.
+# Returns 0 if mount is healthy, 1 if mount failure confirmed.
+# If probe hangs (timeout exit 124), skips retries — a hang is definitive.
+_mount_check_with_retries() {
+    local retries="$_MOUNT_CHECK_RETRIES"
+    local delay="$_MOUNT_CHECK_RETRY_DELAY"
+
+    # First check
+    _mount_check_probe
+    local probe_exit=$?
+
+    if [[ "$probe_exit" -eq 0 ]]; then
+        return 0
+    fi
+
+    # Check if timeout killed the probe (exit 124) — skip retries for hangs
+    if [[ "$probe_exit" -eq 124 ]]; then
+        _liveness_log "WARN" "Mount probe timed out (hung I/O) — skipping retries"
+        return 1
+    fi
+
+    _liveness_log "WARN" "Mount check failed, retrying ${retries} times (delay=${delay}s)"
+
+    local i
+    for (( i=1; i<=retries; i++ )); do
+        sleep "$delay"
+        if _mount_check_probe; then
+            _liveness_log "INFO" "Mount check recovered on retry $i"
+            return 0
+        fi
+        _liveness_log "WARN" "Mount check retry $i/$retries failed"
+    done
+
+    return 1
+}
+
+# Write mount-failure status and sentinel line.
+# Status write may fail if /kapsis-status is also on virtio-fs — that's OK,
+# the stderr sentinel reaches the host via podman's pipe regardless.
+_mount_check_write_failed_status() {
+    # Write sentinel to stderr — captured by podman tee pipeline on host
+    _liveness_log "ERROR" "KAPSIS_MOUNT_FAILURE: /workspace inaccessible (virtio-fs drop)"
+
+    # Best-effort status write (may fail if status mount is also gone)
+    if type status_phase &>/dev/null && type status_complete &>/dev/null; then
+        if type status_is_active &>/dev/null && status_is_active; then
+            status_complete 4 "Workspace mount lost: /workspace became inaccessible (virtio-fs drop)" 2>/dev/null || true
+        fi
+    fi
+}
+
+# Kill the agent after confirmed mount failure.
+_mount_check_kill_agent() {
+    local pid="$_LIVENESS_AGENT_PID"
+
+    _liveness_log "ERROR" "MOUNT FAILURE CONFIRMED: /workspace is inaccessible"
+    _liveness_log "ERROR" "Likely cause: macOS Podman VM virtio-fs mount drop"
+    _liveness_log "ERROR" "Killing agent (PID $pid)"
+
+    # Write status + sentinel before killing
+    _mount_check_write_failed_status
+
+    # SIGTERM first, then SIGKILL after 10s (same pattern as liveness kill)
+    kill -SIGTERM "$pid" 2>/dev/null || true
+    sleep 10
+
+    if kill -0 "$pid" 2>/dev/null; then
+        _liveness_log "WARN" "Agent did not exit after SIGTERM, sending SIGKILL"
+        kill -SIGKILL "$pid" 2>/dev/null || true
+    fi
+
+    _liveness_log "INFO" "Mount check: exiting after kill"
+}
+
+#===============================================================================
 # Kill Decision
 #===============================================================================
 
@@ -477,12 +602,20 @@ _liveness_monitor_loop() {
     local interval="$_LIVENESS_INTERVAL"
     local pid="$_LIVENESS_AGENT_PID"
 
-    _liveness_log "INFO" "Starting (timeout=${timeout}s, grace=${grace}s, interval=${interval}s)"
+    # Mount check has its own shorter grace period (Issue #248)
+    local mount_check_active="$_MOUNT_CHECK_ENABLED"
+    local mount_check_delay="$_MOUNT_CHECK_DELAY"
+    local mount_check_elapsed=0
+
+    _liveness_log "INFO" "Starting (timeout=${timeout}s, grace=${grace}s, interval=${interval}s, mount_check=${mount_check_active})"
 
     # Grace period: sleep before starting checks
     if [[ "$grace" -gt 0 ]]; then
         _liveness_log "INFO" "Grace period: sleeping ${grace}s before monitoring"
         sleep "$grace"
+        # Mount check delay is relative to container start, not post-grace
+        # Account for grace period already elapsed
+        ((mount_check_elapsed += grace)) || true
     fi
 
     # State tracking
@@ -504,6 +637,17 @@ _liveness_monitor_loop() {
         if ! kill -0 "$pid" 2>/dev/null; then
             _liveness_log "INFO" "Agent process (PID $pid) no longer running, exiting monitor"
             return 0
+        fi
+
+        # Mount check (Issue #248) — runs before liveness signals, kills immediately
+        if [[ "$mount_check_active" == "true" ]]; then
+            ((mount_check_elapsed += interval)) || true
+            if [[ "$mount_check_elapsed" -ge "$mount_check_delay" ]]; then
+                if ! _mount_check_with_retries; then
+                    _mount_check_kill_agent
+                    return 0
+                fi
+            fi
         fi
 
         # Refresh API IP list (no-op if TTL has not expired)
@@ -561,6 +705,43 @@ _liveness_monitor_loop() {
 }
 
 #===============================================================================
+# Standalone Mount Check Loop (Issue #248)
+#
+# Used when liveness monitoring is disabled but mount checking is enabled.
+# When liveness IS enabled, mount checks are integrated into its loop above.
+#===============================================================================
+
+_mount_check_loop() {
+    local interval="$_LIVENESS_INTERVAL"
+    local delay="$_MOUNT_CHECK_DELAY"
+    local pid="$_LIVENESS_AGENT_PID"
+
+    _liveness_log "INFO" "Mount check starting (interval=${interval}s, delay=${delay}s, retries=${_MOUNT_CHECK_RETRIES})"
+
+    # Grace period before first check
+    if [[ "$delay" -gt 0 ]]; then
+        _liveness_log "INFO" "Mount check: waiting ${delay}s before first probe"
+        sleep "$delay"
+    fi
+
+    while true; do
+        sleep "$interval"
+
+        # Check if agent process is still alive
+        if ! kill -0 "$pid" 2>/dev/null; then
+            _liveness_log "INFO" "Mount check: agent (PID $pid) no longer running, exiting"
+            return 0
+        fi
+
+        # Perform mount check with retries
+        if ! _mount_check_with_retries; then
+            _mount_check_kill_agent
+            return 0
+        fi
+    done
+}
+
+#===============================================================================
 # Public API
 #===============================================================================
 
@@ -581,5 +762,21 @@ start_liveness_monitor() {
     ( _liveness_monitor_loop ) &
     local monitor_pid=$!
 
-    _liveness_log "INFO" "Liveness monitor started (PID: $monitor_pid)"
+    _liveness_log "INFO" "Liveness monitor started (PID: $monitor_pid, mount_check=$_MOUNT_CHECK_ENABLED)"
+}
+
+# Start the standalone mount check monitor as a background process.
+# Used when liveness monitoring is disabled but mount checking is enabled.
+# Must be called before exec (after which PID 1 becomes the agent).
+start_mount_check_monitor() {
+    if [[ "$_MOUNT_CHECK_ENABLED" != "true" ]]; then
+        return 0
+    fi
+
+    _liveness_log "INFO" "Launching standalone mount check monitor"
+
+    ( _mount_check_loop ) &
+    local monitor_pid=$!
+
+    _liveness_log "INFO" "Mount check monitor started (PID: $monitor_pid)"
 }

--- a/tests/test-liveness-monitor.sh
+++ b/tests/test-liveness-monitor.sh
@@ -731,6 +731,199 @@ test_health_not_found() {
 }
 
 #===============================================================================
+# MOUNT CHECK UNIT TESTS (Issue #248)
+#===============================================================================
+
+test_mount_check_probe_healthy() {
+    log_test "Testing mount check probe returns 0 for populated workspace"
+
+    (
+        source "$KAPSIS_ROOT/scripts/lib/liveness-monitor.sh"
+
+        # Create a fake workspace with content
+        local workspace
+        workspace=$(mktemp -d)
+        mkdir -p "$workspace"
+        echo "test" > "$workspace/file.txt"
+
+        # Override workspace path for testing (CONTAINER_WORKSPACE_PATH is readonly)
+        _MOUNT_CHECK_WORKSPACE="$workspace"
+        _MOUNT_CHECK_PROBE_TIMEOUT=2
+
+        _mount_check_probe || exit 1
+
+        rm -rf "$workspace"
+    ) 2>/dev/null
+    local exit_code=$?
+
+    assert_equals 0 "$exit_code" "Probe should succeed for populated workspace"
+}
+
+test_mount_check_probe_empty_workspace() {
+    log_test "Testing mount check probe returns 1 for empty workspace"
+
+    (
+        source "$KAPSIS_ROOT/scripts/lib/liveness-monitor.sh"
+
+        # Create an empty workspace (simulates mount drop)
+        local workspace
+        workspace=$(mktemp -d)
+
+        _MOUNT_CHECK_WORKSPACE="$workspace"
+        _MOUNT_CHECK_PROBE_TIMEOUT=2
+
+        _mount_check_probe && exit 1  # Should fail
+        exit 0
+    ) 2>/dev/null
+    local exit_code=$?
+
+    assert_equals 0 "$exit_code" "Probe should fail for empty workspace"
+}
+
+test_mount_check_probe_missing_workspace() {
+    log_test "Testing mount check probe returns 1 for missing workspace"
+
+    (
+        source "$KAPSIS_ROOT/scripts/lib/liveness-monitor.sh"
+
+        _MOUNT_CHECK_WORKSPACE="/nonexistent/workspace/path"
+        _MOUNT_CHECK_PROBE_TIMEOUT=2
+
+        _mount_check_probe && exit 1  # Should fail
+        exit 0
+    ) 2>/dev/null
+    local exit_code=$?
+
+    assert_equals 0 "$exit_code" "Probe should fail for missing workspace"
+}
+
+test_mount_check_probe_worktree_git_sentinel() {
+    log_test "Testing mount check probe checks .git-safe/HEAD in worktree mode"
+
+    (
+        source "$KAPSIS_ROOT/scripts/lib/liveness-monitor.sh"
+
+        local workspace
+        workspace=$(mktemp -d)
+        echo "test" > "$workspace/file.txt"
+
+        # Create .git-safe/HEAD to simulate worktree mode
+        mkdir -p "$workspace/.git-safe"
+        echo "ref: refs/heads/main" > "$workspace/.git-safe/HEAD"
+
+        _MOUNT_CHECK_WORKSPACE="$workspace"
+        _MOUNT_CHECK_GIT_PATH="$workspace/.git-safe"
+        _MOUNT_CHECK_PROBE_TIMEOUT=2
+        KAPSIS_SANDBOX_MODE=worktree
+
+        _mount_check_probe || exit 1
+
+        # Now remove .git-safe/HEAD - probe should fail
+        rm "$workspace/.git-safe/HEAD"
+        _mount_check_probe && exit 2
+
+        rm -rf "$workspace"
+        exit 0
+    ) 2>/dev/null
+    local exit_code=$?
+
+    assert_equals 0 "$exit_code" "Probe should check .git-safe/HEAD in worktree mode"
+}
+
+test_mount_check_with_retries_recovers() {
+    log_test "Testing mount check recovers on retry"
+
+    (
+        source "$KAPSIS_ROOT/scripts/lib/liveness-monitor.sh"
+
+        local workspace
+        workspace=$(mktemp -d)
+        _MOUNT_CHECK_WORKSPACE="$workspace"
+        _MOUNT_CHECK_PROBE_TIMEOUT=2
+        _MOUNT_CHECK_RETRIES=2
+        _MOUNT_CHECK_RETRY_DELAY=1
+
+        # First call: workspace is empty (fail), then populate it for retry
+        local call_count=0
+        _mount_check_probe() {
+            ((call_count++)) || true
+            if [[ "$call_count" -le 1 ]]; then
+                return 1  # First call fails
+            fi
+            return 0  # Second call succeeds
+        }
+
+        _mount_check_with_retries || exit 1
+
+        rm -rf "$workspace"
+    ) 2>/dev/null
+    local exit_code=$?
+
+    assert_equals 0 "$exit_code" "Should recover on retry"
+}
+
+test_mount_check_with_retries_all_fail() {
+    log_test "Testing mount check fails after exhausted retries"
+
+    (
+        source "$KAPSIS_ROOT/scripts/lib/liveness-monitor.sh"
+
+        _MOUNT_CHECK_WORKSPACE="/nonexistent"
+        _MOUNT_CHECK_PROBE_TIMEOUT=2
+        _MOUNT_CHECK_RETRIES=2
+        _MOUNT_CHECK_RETRY_DELAY=1
+
+        _mount_check_with_retries && exit 1  # Should fail
+        exit 0
+    ) 2>/dev/null
+    local exit_code=$?
+
+    assert_equals 0 "$exit_code" "Should fail after exhausted retries"
+}
+
+test_mount_check_config_defaults() {
+    log_test "Testing mount check config defaults"
+
+    (
+        unset KAPSIS_MOUNT_CHECK_ENABLED KAPSIS_MOUNT_CHECK_RETRIES
+        unset KAPSIS_MOUNT_CHECK_RETRY_DELAY KAPSIS_MOUNT_CHECK_PROBE_TIMEOUT
+        unset KAPSIS_MOUNT_CHECK_DELAY
+        source "$KAPSIS_ROOT/scripts/lib/liveness-monitor.sh"
+
+        [[ "$_MOUNT_CHECK_ENABLED" == "false" ]] || exit 1
+        [[ "$_MOUNT_CHECK_RETRIES" == "2" ]] || exit 2
+        [[ "$_MOUNT_CHECK_RETRY_DELAY" == "5" ]] || exit 3
+        [[ "$_MOUNT_CHECK_PROBE_TIMEOUT" == "5" ]] || exit 4
+        [[ "$_MOUNT_CHECK_DELAY" == "30" ]] || exit 5
+    ) 2>/dev/null
+    local exit_code=$?
+
+    assert_equals 0 "$exit_code" "Should have correct defaults (false/2/5/5/30)"
+}
+
+test_mount_check_config_custom_values() {
+    log_test "Testing mount check config with custom env vars"
+
+    (
+        export KAPSIS_MOUNT_CHECK_ENABLED=true
+        export KAPSIS_MOUNT_CHECK_RETRIES=5
+        export KAPSIS_MOUNT_CHECK_RETRY_DELAY=10
+        export KAPSIS_MOUNT_CHECK_PROBE_TIMEOUT=3
+        export KAPSIS_MOUNT_CHECK_DELAY=60
+        source "$KAPSIS_ROOT/scripts/lib/liveness-monitor.sh"
+
+        [[ "$_MOUNT_CHECK_ENABLED" == "true" ]] || exit 1
+        [[ "$_MOUNT_CHECK_RETRIES" == "5" ]] || exit 2
+        [[ "$_MOUNT_CHECK_RETRY_DELAY" == "10" ]] || exit 3
+        [[ "$_MOUNT_CHECK_PROBE_TIMEOUT" == "3" ]] || exit 4
+        [[ "$_MOUNT_CHECK_DELAY" == "60" ]] || exit 5
+    ) 2>/dev/null
+    local exit_code=$?
+
+    assert_equals 0 "$exit_code" "Should accept custom values (true/5/10/3/60)"
+}
+
+#===============================================================================
 # MAIN
 #===============================================================================
 
@@ -778,6 +971,16 @@ main() {
     run_test test_health_flag_requires_args
     run_test test_health_json_output_valid
     run_test test_health_not_found
+
+    # Mount check tests (Issue #248)
+    run_test test_mount_check_probe_healthy
+    run_test test_mount_check_probe_empty_workspace
+    run_test test_mount_check_probe_missing_workspace
+    run_test test_mount_check_probe_worktree_git_sentinel
+    run_test test_mount_check_with_retries_recovers
+    run_test test_mount_check_with_retries_all_fail
+    run_test test_mount_check_config_defaults
+    run_test test_mount_check_config_custom_values
 
     print_summary
 }

--- a/tests/test-liveness-monitor.sh
+++ b/tests/test-liveness-monitor.sh
@@ -881,6 +881,42 @@ test_mount_check_with_retries_all_fail() {
     assert_equals 0 "$exit_code" "Should fail after exhausted retries"
 }
 
+test_mount_check_probe_returns_124_on_timeout() {
+    log_test "Testing mount check probe propagates exit code 124 on timeout"
+
+    (
+        source "$KAPSIS_ROOT/scripts/lib/liveness-monitor.sh"
+
+        # Mock _mount_check_probe to return 124 (as timeout(1) would)
+        _mount_check_probe() { return 124; }
+
+        _MOUNT_CHECK_RETRIES=3
+        _MOUNT_CHECK_RETRY_DELAY=0
+
+        # _mount_check_with_retries should skip retries on 124
+        # It returns 1 (failure confirmed) but the key assertion is
+        # that retries are skipped — verified by the function returning
+        # quickly without calling _mount_check_probe 3 more times
+        local call_count=0
+        _mount_check_probe() {
+            ((call_count++)) || true
+            return 124
+        }
+
+        _mount_check_with_retries
+        local retries_exit=$?
+
+        # Should have been called exactly once (no retries for hangs)
+        [[ "$call_count" -eq 1 ]] || exit 1
+        # Should return failure
+        [[ "$retries_exit" -ne 0 ]] || exit 2
+        exit 0
+    ) 2>/dev/null
+    local exit_code=$?
+
+    assert_equals 0 "$exit_code" "Probe timeout (124) should skip retries"
+}
+
 test_mount_check_config_defaults() {
     log_test "Testing mount check config defaults"
 
@@ -979,6 +1015,7 @@ main() {
     run_test test_mount_check_probe_worktree_git_sentinel
     run_test test_mount_check_with_retries_recovers
     run_test test_mount_check_with_retries_all_fail
+    run_test test_mount_check_probe_returns_124_on_timeout
     run_test test_mount_check_config_defaults
     run_test test_mount_check_config_custom_values
 

--- a/tests/test-liveness-monitor.sh
+++ b/tests/test-liveness-monitor.sh
@@ -887,16 +887,10 @@ test_mount_check_probe_returns_124_on_timeout() {
     (
         source "$KAPSIS_ROOT/scripts/lib/liveness-monitor.sh"
 
-        # Mock _mount_check_probe to return 124 (as timeout(1) would)
-        _mount_check_probe() { return 124; }
-
         _MOUNT_CHECK_RETRIES=3
         _MOUNT_CHECK_RETRY_DELAY=0
 
-        # _mount_check_with_retries should skip retries on 124
-        # It returns 1 (failure confirmed) but the key assertion is
-        # that retries are skipped — verified by the function returning
-        # quickly without calling _mount_check_probe 3 more times
+        # Verify _mount_check_with_retries exits immediately on first 124
         local call_count=0
         _mount_check_probe() {
             ((call_count++)) || true

--- a/tests/test-workspace-mount-validation.sh
+++ b/tests/test-workspace-mount-validation.sh
@@ -281,11 +281,121 @@ test_gc_callers_pass_agent_id() {
 }
 
 #===============================================================================
+# MOUNT FAILURE DETECTION TESTS (Issue #248)
+#===============================================================================
+
+test_mount_failure_exit_code_constant() {
+    log_test "Testing KAPSIS_EXIT_MOUNT_FAILURE == 4"
+
+    (
+        source "$KAPSIS_ROOT/scripts/lib/constants.sh"
+        [[ "$KAPSIS_EXIT_MOUNT_FAILURE" == "4" ]] || exit 1
+    ) 2>/dev/null
+    local exit_code=$?
+
+    assert_equals 0 "$exit_code" "KAPSIS_EXIT_MOUNT_FAILURE should be 4"
+}
+
+test_status_display_exit_code_4() {
+    log_test "Testing kapsis-status shows mount failure guidance for exit code 4"
+
+    local status_dir
+    status_dir=$(make_test_dir)
+    local status_file="$status_dir/kapsis-testproj-mount1.json"
+    cat > "$status_file" << 'EOF'
+{
+  "version": "1.0",
+  "agent_id": "mount1",
+  "project": "testproj",
+  "phase": "complete",
+  "progress": 100,
+  "message": "Workspace mount lost",
+  "exit_code": 4,
+  "error": "Workspace mount lost (virtio-fs drop)",
+  "updated_at": "2026-03-22T10:00:00Z",
+  "started_at": "2026-03-22T09:00:00Z",
+  "branch": null,
+  "worktree_path": null,
+  "pr_url": null,
+  "push_status": null,
+  "push_fallback_command": null,
+  "gist": null,
+  "gist_updated_at": null,
+  "heartbeat_at": null
+}
+EOF
+
+    local output
+    output=$(KAPSIS_STATUS_DIR="$status_dir" "$KAPSIS_ROOT/scripts/kapsis-status.sh" testproj mount1 2>&1) || true
+
+    assert_contains "$output" "mount failure" "Should show 'mount failure' label"
+    assert_contains "$output" "Mount Failure Recovery" "Should show recovery heading"
+    assert_contains "$output" "podman machine stop" "Should show recovery command"
+}
+
+test_launch_agent_sentinel_detection() {
+    log_test "Testing sentinel detection greps for KAPSIS_MOUNT_FAILURE"
+
+    local container_output
+    container_output=$(mktemp)
+
+    cat > "$container_output" << 'EOF'
+[2026-03-22 10:00:00] Starting agent...
+[2026-03-22 10:30:00] ERROR: KAPSIS_MOUNT_FAILURE: /workspace inaccessible (virtio-fs drop)
+EOF
+
+    local EXIT_CODE=143  # SIGTERM
+
+    # Replicate the sentinel detection from launch-agent.sh
+    if [[ "$EXIT_CODE" -eq 143 || "$EXIT_CODE" -eq 137 ]]; then
+        if [[ -f "$container_output" ]] && grep -q 'KAPSIS_MOUNT_FAILURE:' "$container_output" 2>/dev/null; then
+            EXIT_CODE=4
+        fi
+    fi
+
+    assert_equals 4 "$EXIT_CODE" "Should override exit code to 4 when sentinel found"
+
+    rm -f "$container_output"
+}
+
+test_sentinel_only_honored_on_signal_exit() {
+    log_test "Testing sentinel is ignored when exit code is not 143/137"
+
+    local container_output
+    container_output=$(mktemp)
+
+    cat > "$container_output" << 'EOF'
+[2026-03-22 10:00:00] Starting agent...
+[2026-03-22 10:30:00] ERROR: KAPSIS_MOUNT_FAILURE: /workspace inaccessible (virtio-fs drop)
+EOF
+
+    # Test with exit code 1 — sentinel should be ignored
+    local EXIT_CODE=1
+    if [[ "$EXIT_CODE" -eq 143 || "$EXIT_CODE" -eq 137 ]]; then
+        if [[ -f "$container_output" ]] && grep -q 'KAPSIS_MOUNT_FAILURE:' "$container_output" 2>/dev/null; then
+            EXIT_CODE=4
+        fi
+    fi
+    assert_equals 1 "$EXIT_CODE" "Should NOT override exit code when not a signal exit"
+
+    # Test with exit code 0 — sentinel should be ignored
+    EXIT_CODE=0
+    if [[ "$EXIT_CODE" -eq 143 || "$EXIT_CODE" -eq 137 ]]; then
+        if [[ -f "$container_output" ]] && grep -q 'KAPSIS_MOUNT_FAILURE:' "$container_output" 2>/dev/null; then
+            EXIT_CODE=4
+        fi
+    fi
+    assert_equals 0 "$EXIT_CODE" "Should NOT override exit code on success"
+
+    rm -f "$container_output"
+}
+
+#===============================================================================
 # MAIN
 #===============================================================================
 
 main() {
-    print_test_header "Workspace Mount Validation (Issue #221)"
+    print_test_header "Workspace Mount Validation (Issues #221, #248)"
 
     log_info "=== Entrypoint Workspace Validation ==="
     run_test test_validate_workspace_not_exists
@@ -304,6 +414,12 @@ main() {
     log_info "=== GC Self-Exclusion ==="
     run_test test_gc_excludes_current_agent
     run_test test_gc_callers_pass_agent_id
+
+    log_info "=== Mount Failure Detection (Issue #248) ==="
+    run_test test_mount_failure_exit_code_constant
+    run_test test_status_display_exit_code_4
+    run_test test_launch_agent_sentinel_detection
+    run_test test_sentinel_only_honored_on_signal_exit
 
     cleanup_test_dirs
 


### PR DESCRIPTION
## Summary

Closes #248. Detects mid-run virtio-fs mount drops on macOS and kills the agent with exit code 4 and recovery guidance.

- Adds periodic mount health probe (`stat` + non-empty + git sentinel) with configurable timeout, retries, and grace period
- Uses stderr sentinel (`KAPSIS_MOUNT_FAILURE:`) for exit code propagation — `/kapsis-status` shares the same virtio-fs transport, so marker files can't work when the mount fails
- Integrates into liveness monitor loop when enabled; standalone loop otherwise
- Sentinel only honored when container exits with 143 (SIGTERM) or 137 (SIGKILL) — prevents a compromised agent from faking mount failures
- `kapsis-status` shows recovery guidance: `podman machine stop && podman machine start`

## Files Changed

| File | Change |
|------|--------|
| `scripts/lib/constants.sh` | `KAPSIS_EXIT_MOUNT_FAILURE=4` |
| `scripts/lib/liveness-monitor.sh` | Mount probe, retry, kill, standalone/integrated loops |
| `scripts/entrypoint.sh` | Standalone mount check startup when liveness disabled |
| `scripts/launch-agent.sh` | YAML config, env injection, sentinel detection, exit code 4 handler |
| `scripts/kapsis-status.sh` | Exit code 4 display + recovery guidance + MOUNT_FAILURE health state |
| `tests/test-liveness-monitor.sh` | 8 mount check unit tests |
| `tests/test-workspace-mount-validation.sh` | 4 integration tests |
| `docs/CONFIG-REFERENCE.md` | Mount check config reference |
| `docs/STATUS-TRACKING.md` | Exit code table |
| `CLAUDE.md` | Mount failure section |

## Test plan

- [x] `shellcheck` passes on all modified scripts (0 errors/warnings)
- [x] `tests/test-liveness-monitor.sh` — 38/38 tests pass (8 new mount check tests)
- [x] `tests/test-workspace-mount-validation.sh` — 16/16 tests pass (4 new mount tests)
- [ ] Full `./tests/run-all-tests.sh --quick` suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)