### PR TITLE
fix: resolve inject_file_template NUL bytes false positive

### DIFF
--- a/scripts/launch-agent.sh
+++ b/scripts/launch-agent.sh
@@ -1558,8 +1558,13 @@ generate_env_vars() {
 
                     # Skip empty templates (field is base64("") when not specified)
                     if [[ -n "$template_raw" ]]; then
-                        # Reject NUL bytes (would truncate shell strings)
-                        if [[ "$template_raw" == *$'\0'* ]]; then
+                        # Reject NUL bytes (would corrupt template substitution)
+                        # Bash variables silently strip NUL, so [[ == *$'\0'* ]]
+                        # always matches (Bug #251). Check raw byte stream instead.
+                        local _raw_count _clean_count
+                        _raw_count=$(printf '%s' "$inject_file_template_b64" | base64 -d 2>/dev/null | wc -c)
+                        _clean_count=$(printf '%s' "$inject_file_template_b64" | base64 -d 2>/dev/null | tr -d '\0' | wc -c)
+                        if (( _raw_count != _clean_count )); then
                             log_error "inject_file_template for $var_name contains NUL bytes"
                             exit 1
                         fi

--- a/scripts/launch-agent.sh
+++ b/scripts/launch-agent.sh
@@ -1560,11 +1560,12 @@ generate_env_vars() {
                     if [[ -n "$template_raw" ]]; then
                         # Reject NUL bytes (would corrupt template substitution)
                         # Bash variables silently strip NUL, so [[ == *$'\0'* ]]
-                        # always matches (Bug #251). Check raw byte stream instead.
-                        local _raw_count _clean_count
-                        _raw_count=$(printf '%s' "$inject_file_template_b64" | base64 -d 2>/dev/null | wc -c)
-                        _clean_count=$(printf '%s' "$inject_file_template_b64" | base64 -d 2>/dev/null | tr -d '\0' | wc -c)
-                        if (( _raw_count != _clean_count )); then
+                        # always matches (Bug #251). Compare raw byte count from
+                        # the base64 stream against NUL-stripped count instead.
+                        local raw_byte_count clean_byte_count
+                        raw_byte_count=$(printf '%s' "$inject_file_template_b64" | base64 -d 2>/dev/null | wc -c)
+                        clean_byte_count=$(printf '%s' "$inject_file_template_b64" | base64 -d 2>/dev/null | tr -d '\0' | wc -c)
+                        if (( raw_byte_count != clean_byte_count )); then
                             log_error "inject_file_template for $var_name contains NUL bytes"
                             exit 1
                         fi

--- a/tests/test-credential-file-template.sh
+++ b/tests/test-credential-file-template.sh
@@ -359,6 +359,42 @@ test_template_validation_in_launch_script() {
         "launch-agent.sh should cap marker count"
 }
 
+test_nul_check_no_false_positive() {
+    log_test "Testing NUL byte check does not false-positive on valid template (Bug #251)"
+
+    # The old check [[ "$var" == *$'\0'* ]] always matches because bash
+    # variables cannot hold NUL bytes — $'\0' in a pattern is empty string,
+    # making *$'\0'* equivalent to * (matches everything).
+    # The new check compares raw byte counts via pipe.
+
+    # Valid template — should pass NUL check
+    local template='{"token": "{{VALUE}}"}'
+    local template_b64
+    template_b64=$(printf '%s' "$template" | base64)
+
+    local _raw_count _clean_count
+    _raw_count=$(printf '%s' "$template_b64" | base64 -d 2>/dev/null | wc -c)
+    _clean_count=$(printf '%s' "$template_b64" | base64 -d 2>/dev/null | tr -d '\0' | wc -c)
+
+    assert_equals "$_raw_count" "$_clean_count" \
+        "Valid template should have equal raw and clean byte counts"
+}
+
+test_nul_check_detects_actual_nul() {
+    log_test "Testing NUL byte check detects actual NUL bytes in template"
+
+    # Create a template WITH an embedded NUL byte, base64-encode it
+    local template_b64
+    template_b64=$(printf 'hello\0world' | base64)
+
+    local _raw_count _clean_count
+    _raw_count=$(printf '%s' "$template_b64" | base64 -d 2>/dev/null | wc -c)
+    _clean_count=$(printf '%s' "$template_b64" | base64 -d 2>/dev/null | tr -d '\0' | wc -c)
+
+    assert_true "(( _raw_count != _clean_count ))" \
+        "Template with NUL should have different raw vs clean byte counts"
+}
+
 test_entrypoint_has_security_invariant() {
     log_test "Testing entrypoint.sh has SECURITY INVARIANT comment"
 
@@ -400,6 +436,8 @@ main() {
 
     # Launch-agent validation tests (file content checks)
     run_test test_template_validation_in_launch_script
+    run_test test_nul_check_no_false_positive
+    run_test test_nul_check_detects_actual_nul
     run_test test_entrypoint_has_security_invariant
     run_test test_entrypoint_unsets_credential_files
 

--- a/tests/test-credential-file-template.sh
+++ b/tests/test-credential-file-template.sh
@@ -372,11 +372,11 @@ test_nul_check_no_false_positive() {
     local template_b64
     template_b64=$(printf '%s' "$template" | base64)
 
-    local _raw_count _clean_count
-    _raw_count=$(printf '%s' "$template_b64" | base64 -d 2>/dev/null | wc -c)
-    _clean_count=$(printf '%s' "$template_b64" | base64 -d 2>/dev/null | tr -d '\0' | wc -c)
+    local raw_byte_count clean_byte_count
+    raw_byte_count=$(printf '%s' "$template_b64" | base64 -d 2>/dev/null | wc -c)
+    clean_byte_count=$(printf '%s' "$template_b64" | base64 -d 2>/dev/null | tr -d '\0' | wc -c)
 
-    assert_equals "$_raw_count" "$_clean_count" \
+    assert_equals "$raw_byte_count" "$clean_byte_count" \
         "Valid template should have equal raw and clean byte counts"
 }
 
@@ -387,11 +387,11 @@ test_nul_check_detects_actual_nul() {
     local template_b64
     template_b64=$(printf 'hello\0world' | base64)
 
-    local _raw_count _clean_count
-    _raw_count=$(printf '%s' "$template_b64" | base64 -d 2>/dev/null | wc -c)
-    _clean_count=$(printf '%s' "$template_b64" | base64 -d 2>/dev/null | tr -d '\0' | wc -c)
+    local raw_byte_count clean_byte_count
+    raw_byte_count=$(printf '%s' "$template_b64" | base64 -d 2>/dev/null | wc -c)
+    clean_byte_count=$(printf '%s' "$template_b64" | base64 -d 2>/dev/null | tr -d '\0' | wc -c)
 
-    assert_true "(( _raw_count != _clean_count ))" \
+    assert_true "(( raw_byte_count != clean_byte_count ))" \
         "Template with NUL should have different raw vs clean byte counts"
 }
 


### PR DESCRIPTION
## Summary

- Fixes #251 — `inject_file_template` NUL byte check always triggers false positive
- Root cause: `[[ "$var" == *$'\0'* ]]` — bash variables cannot hold NUL bytes, so `$'\0'` in a pattern is the empty string, making `*$'\0'*` ≡ `*` (matches everything)
- Replace with pipe-based byte count comparison on the raw decoded stream
- Add 2 tests: no false positive on valid template, detection of actual NUL bytes

## Test plan
- [x] `test_nul_check_no_false_positive` — valid JSON template passes
- [x] `test_nul_check_detects_actual_nul` — embedded NUL detected
- [x] All 14 credential template tests pass
- [x] shellcheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)