### PR TITLE
fix: detect and repair corrupted Podman container store

### DIFF
--- a/scripts/kapsis-cleanup.sh
+++ b/scripts/kapsis-cleanup.sh
@@ -399,12 +399,11 @@ clean_sandboxes() {
             else
                 local cleaned=false
                 # Try fixing permissions first (overlay mount corruption leaves root-owned files)
-                # Use find to avoid following symlinks in subtree
-                if find "$sandbox" -not -type l -exec chmod u+rwX {} + 2>/dev/null; then
-                    if rm -rf "$sandbox" 2>/dev/null; then
-                        print_item "sandbox" "$name" "$size_human (via chmod fix)"
-                        cleaned=true
-                    fi
+                # Use find -xdev to avoid crossing filesystem boundaries, -not -type l to skip symlinks
+                find "$sandbox" -xdev -not -type l -exec chmod u+rwX {} + 2>/dev/null || true
+                if rm -rf "$sandbox" 2>/dev/null; then
+                    print_item "sandbox" "$name" "$size_human (via chmod fix)"
+                    cleaned=true
                 fi
                 # Escalate to podman unshare (Linux) or sudo (macOS)
                 if [[ "$cleaned" != "true" ]] && command -v podman &>/dev/null; then
@@ -573,12 +572,6 @@ clean_containers() {
         return
     fi
 
-    # Quick store health check before attempting individual removals
-    if ! podman system check --quick 2>/dev/null; then
-        log_warn "Podman store health check failed — store may be corrupted"
-        STORE_CORRUPTED=true
-    fi
-
     local count=0
     local corruption_count=0
 
@@ -591,6 +584,14 @@ clean_containers() {
         return
     fi
 
+    # Quick store health check before attempting individual removals (skip in dry-run)
+    if [[ "$DRY_RUN" != "true" ]]; then
+        if ! podman system check --quick 2>/dev/null; then
+            log_warn "Podman store health check failed — store may be corrupted"
+            STORE_CORRUPTED=true
+        fi
+    fi
+
     while IFS= read -r container; do
         [[ -z "$container" ]] && continue
 
@@ -601,19 +602,21 @@ clean_containers() {
 
         if [[ "$DRY_RUN" == "true" ]]; then
             print_item "container" "$container" "N/A"
+            ((count++)) || true
         else
             local rm_output
-            rm_output=$(podman rm "$container" 2>&1) || {
+            if rm_output=$(timeout 30 podman rm "$container" 2>&1); then
+                print_item "container" "$container" "N/A"
+                ((count++)) || true
+            else
                 if [[ "$rm_output" == *"not known"* ]] || [[ "$rm_output" == *"no such"* ]]; then
                     ((corruption_count++)) || true
                     log_warn "Container '$container' — store corruption detected"
                 else
-                    log_debug "podman rm '$container' failed: $rm_output"
+                    log_warn "Container '$container' removal failed: $rm_output"
                 fi
-            }
-            print_item "container" "$container" "N/A"
+            fi
         fi
-        ((count++)) || true
     done <<< "$containers"
 
     # Report corruption if detected
@@ -1218,8 +1221,9 @@ repair_store() {
 
     # Verify podman machine is running
     local ssh_timeout="${KAPSIS_CLEANUP_VM_SSH_TIMEOUT:-${KAPSIS_DEFAULT_CLEANUP_VM_SSH_TIMEOUT:-15}}"
+    local machine_name="${KAPSIS_PODMAN_MACHINE:-podman-machine-default}"
     local machine_state
-    machine_state=$(timeout "$ssh_timeout" podman machine inspect podman-machine-default --format '{{.State}}' 2>/dev/null || echo "not-found")
+    machine_state=$(timeout "$ssh_timeout" podman machine inspect "$machine_name" --format '{{.State}}' 2>/dev/null || echo "not-found")
     machine_state=$(echo "$machine_state" | tr -d '[:space:]' | tr -d '"')
 
     if [[ "$machine_state" != "running" ]]; then
@@ -1232,17 +1236,15 @@ repair_store() {
 
     if [[ "$DRY_RUN" == "true" ]]; then
         echo -e "  ${CYAN}[DRY-RUN]${NC} Would run: podman system check --repair --force"
-        echo -e "  ${CYAN}[DRY-RUN]${NC} Would run sanity check: podman run --rm alpine echo ok"
+        echo -e "  ${CYAN}[DRY-RUN]${NC} Would run sanity check: podman info"
         return 0
     fi
 
-    local repair_output
-    repair_output=$(podman system check --repair --force 2>&1) || true
-    log_info "Repair output: $repair_output"
+    podman system check --repair --force 2>&1 | tee -a "${KAPSIS_LOG_FILE:-/dev/null}" || true
 
-    # Sanity check — can we run a basic container?
+    # Sanity check — verify store is accessible
     log_info "Running post-repair sanity check..."
-    if podman run --rm alpine echo "store-ok" &>/dev/null; then
+    if podman info --format '{{.Store.GraphRoot}}' &>/dev/null; then
         log_success "Store repair successful — Podman is functional"
         return 0
     fi
@@ -1262,13 +1264,13 @@ repair_store() {
     fi
 
     log_info "Removing and recreating Podman machine..."
-    podman machine rm -f 2>&1 || true
-    podman machine init 2>&1 || {
+    podman machine rm -f "$machine_name" 2>&1 || true
+    podman machine init "$machine_name" 2>&1 || {
         log_error "Failed to initialize new Podman machine"
         log_error "Manual recovery: podman machine init && podman machine start"
         return 1
     }
-    podman machine start 2>&1 || {
+    podman machine start "$machine_name" 2>&1 || {
         log_error "Failed to start new Podman machine"
         log_error "Manual recovery: podman machine start"
         return 1
@@ -1276,7 +1278,7 @@ repair_store() {
 
     # Post-reset sanity check
     log_info "Running post-reset sanity check..."
-    if podman run --rm alpine echo "store-ok" &>/dev/null; then
+    if podman info --format '{{.Store.GraphRoot}}' &>/dev/null; then
         log_success "VM reset successful — Podman is functional"
         log_warn "All Kapsis images must be rebuilt: scripts/build-image.sh"
     else

--- a/scripts/kapsis-cleanup.sh
+++ b/scripts/kapsis-cleanup.sh
@@ -59,6 +59,10 @@ CLEAN_IMAGES=false
 CLEAN_BRANCHES=false
 CLEAN_VM_HEALTH=false
 CLEAN_WORKTREES=false
+CLEAN_REPAIR=false
+
+# Module-level corruption tracking (set by clean_containers when store errors detected)
+STORE_CORRUPTED=false
 
 # How long to allow `du` to run on a single directory before giving up.
 # Protects against stale FUSE/NFS mounts and slow network filesystems.
@@ -99,6 +103,9 @@ OPTIONS:
     --worktrees         Clean git worktrees (included by default, explicit for scripting)
     --vm-health         Check Podman VM health (inode %, disk %, journal size)
                         Warns at 70% inodes, auto-cleans images at 90%
+    --repair            Repair corrupted Podman container store
+                        Stage 1: podman system check --repair --force
+                        Stage 2 (if needed): full VM reset (requires --force)
     --force, -f         Skip confirmation prompts
     --help, -h          Show this help message
 
@@ -114,6 +121,7 @@ WHAT GETS CLEANED:
     Logs            Old log files (with --logs)
     SSH cache       Cached SSH host keys (with --ssh-cache)
     Branches        Agent-created git branches (with --branches or --all)
+    Store repair    Podman container store corruption (with --repair)
 
 EXAMPLES:
     # See what would be cleaned
@@ -136,6 +144,12 @@ EXAMPLES:
 
     # Clear SSH host key cache (after key rotation)
     $cmd_name --ssh-cache
+
+    # Repair corrupted container store (after mount drop)
+    $cmd_name --repair
+
+    # Force repair with full VM reset if needed
+    $cmd_name --repair --force
 EOF
 }
 
@@ -383,10 +397,17 @@ clean_sandboxes() {
             if rm -rf "$sandbox" 2>/dev/null; then
                 print_item "sandbox" "$name" "$size_human"
             else
-                # Try podman unshare (Linux) or other elevated methods
                 local cleaned=false
-                if command -v podman &>/dev/null; then
-                    # Check if we're on macOS (remote podman)
+                # Try fixing permissions first (overlay mount corruption leaves root-owned files)
+                # Use find to avoid following symlinks in subtree
+                if find "$sandbox" -not -type l -exec chmod u+rwX {} + 2>/dev/null; then
+                    if rm -rf "$sandbox" 2>/dev/null; then
+                        print_item "sandbox" "$name" "$size_human (via chmod fix)"
+                        cleaned=true
+                    fi
+                fi
+                # Escalate to podman unshare (Linux) or sudo (macOS)
+                if [[ "$cleaned" != "true" ]] && command -v podman &>/dev/null; then
                     if [[ "$(uname)" == "Darwin" ]]; then
                         # On macOS, overlay dirs owned by VM - try sudo
                         if sudo rm -rf "$sandbox" 2>/dev/null; then
@@ -552,7 +573,14 @@ clean_containers() {
         return
     fi
 
+    # Quick store health check before attempting individual removals
+    if ! podman system check --quick 2>/dev/null; then
+        log_warn "Podman store health check failed — store may be corrupted"
+        STORE_CORRUPTED=true
+    fi
+
     local count=0
+    local corruption_count=0
 
     # Get stopped kapsis containers
     local containers
@@ -574,11 +602,26 @@ clean_containers() {
         if [[ "$DRY_RUN" == "true" ]]; then
             print_item "container" "$container" "N/A"
         else
-            podman rm "$container" &>/dev/null || true
+            local rm_output
+            rm_output=$(podman rm "$container" 2>&1) || {
+                if [[ "$rm_output" == *"not known"* ]] || [[ "$rm_output" == *"no such"* ]]; then
+                    ((corruption_count++)) || true
+                    log_warn "Container '$container' — store corruption detected"
+                else
+                    log_debug "podman rm '$container' failed: $rm_output"
+                fi
+            }
             print_item "container" "$container" "N/A"
         fi
         ((count++)) || true
     done <<< "$containers"
+
+    # Report corruption if detected
+    if (( corruption_count > 0 )); then
+        STORE_CORRUPTED=true
+        echo -e "  ${YELLOW}Store corruption: $corruption_count container(s) not removable${NC}"
+        echo -e "  ${CYAN}Run: kapsis-cleanup --repair${NC}"
+    fi
 
     if (( count == 0 )); then
         echo "  No containers to clean"
@@ -1157,6 +1200,94 @@ vm_health_check() {
     return 0
 }
 
+# Repair corrupted Podman container store (Fix #249)
+repair_store() {
+    section "Store Repair"
+
+    if ! command -v podman &>/dev/null; then
+        echo "  Podman not available"
+        return 1
+    fi
+
+    # Platform guard — podman machine only exists on macOS
+    if is_linux; then
+        log_info "On Linux, repair the store directly:"
+        log_info "  podman system check --repair --force"
+        return 0
+    fi
+
+    # Verify podman machine is running
+    local ssh_timeout="${KAPSIS_CLEANUP_VM_SSH_TIMEOUT:-${KAPSIS_DEFAULT_CLEANUP_VM_SSH_TIMEOUT:-15}}"
+    local machine_state
+    machine_state=$(timeout "$ssh_timeout" podman machine inspect podman-machine-default --format '{{.State}}' 2>/dev/null || echo "not-found")
+    machine_state=$(echo "$machine_state" | tr -d '[:space:]' | tr -d '"')
+
+    if [[ "$machine_state" != "running" ]]; then
+        log_error "Podman machine is not running (state: $machine_state). Start it first: podman machine start"
+        return 1
+    fi
+
+    # Stage 1: Use Podman's first-party repair tool
+    log_info "Stage 1: Running podman system check --repair --force..."
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        echo -e "  ${CYAN}[DRY-RUN]${NC} Would run: podman system check --repair --force"
+        echo -e "  ${CYAN}[DRY-RUN]${NC} Would run sanity check: podman run --rm alpine echo ok"
+        return 0
+    fi
+
+    local repair_output
+    repair_output=$(podman system check --repair --force 2>&1) || true
+    log_info "Repair output: $repair_output"
+
+    # Sanity check — can we run a basic container?
+    log_info "Running post-repair sanity check..."
+    if podman run --rm alpine echo "store-ok" &>/dev/null; then
+        log_success "Store repair successful — Podman is functional"
+        return 0
+    fi
+
+    log_warn "Stage 1 repair did not fully restore the store"
+
+    # Stage 2: Nuclear option — full VM reset
+    log_warn "Stage 2: Full VM reset required"
+    log_warn "This will DESTROY all container images, volumes, and build caches"
+    log_warn "You will need to rebuild all Kapsis images (est. 10-30 min)"
+
+    if [[ "$FORCE" != "true" ]]; then
+        if ! confirm "Proceed with full VM reset?"; then
+            echo "  Aborted. Run with --force to skip confirmation."
+            return 1
+        fi
+    fi
+
+    log_info "Removing and recreating Podman machine..."
+    podman machine rm -f 2>&1 || true
+    podman machine init 2>&1 || {
+        log_error "Failed to initialize new Podman machine"
+        log_error "Manual recovery: podman machine init && podman machine start"
+        return 1
+    }
+    podman machine start 2>&1 || {
+        log_error "Failed to start new Podman machine"
+        log_error "Manual recovery: podman machine start"
+        return 1
+    }
+
+    # Post-reset sanity check
+    log_info "Running post-reset sanity check..."
+    if podman run --rm alpine echo "store-ok" &>/dev/null; then
+        log_success "VM reset successful — Podman is functional"
+        log_warn "All Kapsis images must be rebuilt: scripts/build-image.sh"
+    else
+        log_error "Podman still not functional after VM reset"
+        log_error "Manual investigation required"
+        return 1
+    fi
+
+    return 0
+}
+
 # Print summary
 print_summary() {
     echo -e "\n${BOLD}${GREEN}=== Summary ===${NC}"
@@ -1167,6 +1298,10 @@ print_summary() {
     else
         echo -e "  Cleaned: $ITEMS_CLEANED items"
         echo -e "  Space freed: $(format_size $TOTAL_SIZE_FREED)"
+    fi
+    if [[ "$STORE_CORRUPTED" == "true" ]]; then
+        echo -e "\n  ${YELLOW}WARNING: Container store corruption detected${NC}"
+        echo -e "  ${CYAN}Run: kapsis-cleanup --repair${NC}"
     fi
 }
 
@@ -1234,6 +1369,11 @@ main() {
                 ;;
             --vm-health)
                 CLEAN_VM_HEALTH=true
+                explicit_action_requested=true
+                shift
+                ;;
+            --repair)
+                CLEAN_REPAIR=true
                 explicit_action_requested=true
                 shift
                 ;;
@@ -1319,6 +1459,10 @@ main() {
 
     if [[ "$CLEAN_VM_HEALTH" == "true" ]] || [[ "$CLEAN_ALL" == "true" ]]; then
         vm_health_check || true
+    fi
+
+    if [[ "$CLEAN_REPAIR" == "true" ]]; then
+        repair_store || true
     fi
 
     # Summary

--- a/tests/test-cleanup-store-repair.sh
+++ b/tests/test-cleanup-store-repair.sh
@@ -10,6 +10,7 @@
 #   5. Corruption detection prints --repair suggestion
 #   6. Sandbox cleanup uses find -not -type l for chmod
 #   7. repair_store() has Linux platform guard
+#   8. --all does NOT trigger repair_store()
 #
 # Category: validation
 # All tests are QUICK (no container needed).
@@ -42,13 +43,12 @@ test_clean_repair_variable_declared() {
 }
 
 test_repair_flag_sets_explicit_action() {
-    local content
-    content=$(cat "$CLEANUP_SCRIPT")
-    # Extract the case-branch body for --repair using awk.
+    # Extract only the --repair) case branch at the correct indentation
+    # (inside the while/case block, not inside the usage heredoc)
     local branch
-    branch=$(awk -v pat="--repair)" '
-        $0 ~ pat {capture=1; next}
-        capture && /;;/ {capture=0}
+    branch=$(awk '
+        /^            --repair\)/ {capture=1; next}
+        capture && /;;/ {print; capture=0; next}
         capture {print}
     ' "$CLEANUP_SCRIPT")
     assert_contains "$branch" "explicit_action_requested=true" \
@@ -75,8 +75,8 @@ test_sandbox_chmod_uses_find_not_type_l() {
     local content
     content=$(cat "$CLEANUP_SCRIPT")
     # shellcheck disable=SC2016  # literal match, not expansion
-    assert_contains "$content" 'find "$sandbox" -not -type l -exec chmod' \
-        "clean_sandboxes should use find -not -type l for symlink-safe chmod"
+    assert_contains "$content" 'find "$sandbox" -xdev -not -type l -exec chmod' \
+        "clean_sandboxes should use find -xdev -not -type l for symlink-safe chmod"
 }
 
 test_repair_linux_guard() {
@@ -118,6 +118,38 @@ test_summary_shows_corruption_warning() {
         "print_summary should check STORE_CORRUPTED flag"
 }
 
+test_health_check_skipped_in_dry_run() {
+    # The podman system check --quick should be gated by DRY_RUN != true
+    local snippet
+    snippet=$(sed -n '/^clean_containers()/,/^}/p' "$CLEANUP_SCRIPT")
+    assert_contains "$snippet" 'DRY_RUN" != "true"' \
+        "Health check should be gated by DRY_RUN"
+}
+
+test_podman_rm_uses_timeout() {
+    # podman rm should be wrapped with timeout to avoid hanging on corrupted store
+    local snippet
+    snippet=$(sed -n '/^clean_containers()/,/^}/p' "$CLEANUP_SCRIPT")
+    assert_contains "$snippet" "timeout 30 podman rm" \
+        "podman rm should use timeout wrapper"
+}
+
+test_repair_uses_machine_name_variable() {
+    # repair_store should use a configurable machine name, not hardcoded
+    local snippet
+    snippet=$(sed -n '/^repair_store()/,/^}/p' "$CLEANUP_SCRIPT")
+    assert_contains "$snippet" "KAPSIS_PODMAN_MACHINE" \
+        "repair_store should use KAPSIS_PODMAN_MACHINE variable"
+}
+
+test_sanity_check_uses_podman_info() {
+    # Post-repair sanity check should use podman info (no network dependency)
+    local snippet
+    snippet=$(sed -n '/^repair_store()/,/^}/p' "$CLEANUP_SCRIPT")
+    assert_contains "$snippet" "podman info" \
+        "repair_store sanity check should use podman info"
+}
+
 #===============================================================================
 # Behavioral runtime tests (no container)
 #===============================================================================
@@ -148,7 +180,7 @@ print_summary()        { :; }
 confirm()              { return 0; }
 STUBS
 
-    MARKER_DIR="$marker_dir" FORCE=true bash -c '
+    MARKER_DIR="$marker_dir" bash -c '
         set +e
         script_body=$(sed "s|^main \"\\\$@\"$|# main invocation suppressed|" "'"$CLEANUP_SCRIPT"'")
         # shellcheck disable=SC1090
@@ -162,11 +194,13 @@ test_repair_flag_recognized() {
     local marker_dir
     marker_dir=$(mktemp -d "${TMPDIR:-/tmp}/kapsis-249-parse.XXXXXX")
 
-    # Should not error out when parsing --repair
+    # --repair --dry-run should parse and invoke repair_store
     _invoke_cleanup "$marker_dir" --repair --dry-run
 
+    assert_file_exists "$marker_dir/repair_store" \
+        "--repair --dry-run should invoke repair_store()"
+
     rm -rf "$marker_dir"
-    return 0
 }
 
 test_repair_invokes_repair_store() {
@@ -193,6 +227,23 @@ test_repair_skips_defaults() {
     assert_file_not_exists "$marker_dir/clean_status"        "--repair alone must NOT trigger clean_status"
     assert_file_not_exists "$marker_dir/clean_sanitized_git" "--repair alone must NOT trigger clean_sanitized_git"
     assert_file_not_exists "$marker_dir/clean_audit"         "--repair alone must NOT trigger clean_audit"
+    assert_file_not_exists "$marker_dir/clean_containers"    "--repair alone must NOT trigger clean_containers"
+    assert_file_not_exists "$marker_dir/clean_volumes"       "--repair alone must NOT trigger clean_volumes"
+    assert_file_not_exists "$marker_dir/clean_images"        "--repair alone must NOT trigger clean_images"
+    assert_file_not_exists "$marker_dir/clean_logs"          "--repair alone must NOT trigger clean_logs"
+    assert_file_not_exists "$marker_dir/clean_branches"      "--repair alone must NOT trigger clean_branches"
+
+    rm -rf "$marker_dir"
+}
+
+test_all_flag_excludes_repair() {
+    local marker_dir
+    marker_dir=$(mktemp -d "${TMPDIR:-/tmp}/kapsis-249-all.XXXXXX")
+
+    _invoke_cleanup "$marker_dir" --all --force --dry-run
+
+    assert_file_not_exists "$marker_dir/repair_store" \
+        "--all must NOT trigger repair_store (repair is not routine cleanup)"
 
     rm -rf "$marker_dir"
 }
@@ -211,8 +262,13 @@ run_test test_repair_linux_guard
 run_test test_repair_stage2_uses_machine_rm
 run_test test_repair_in_usage_help
 run_test test_summary_shows_corruption_warning
+run_test test_health_check_skipped_in_dry_run
+run_test test_podman_rm_uses_timeout
+run_test test_repair_uses_machine_name_variable
+run_test test_sanity_check_uses_podman_info
 run_test test_repair_flag_recognized
 run_test test_repair_invokes_repair_store
 run_test test_repair_skips_defaults
+run_test test_all_flag_excludes_repair
 
 print_summary

--- a/tests/test-cleanup-store-repair.sh
+++ b/tests/test-cleanup-store-repair.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+#===============================================================================
+# Test: Cleanup --repair and store corruption detection (Issue #249)
+#
+# Verifies:
+#   1. --repair flag is parsed and dispatches repair_store()
+#   2. --repair sets explicit_action_requested (skips defaults)
+#   3. STORE_CORRUPTED variable is declared
+#   4. clean_containers() uses podman system check for pre-check
+#   5. Corruption detection prints --repair suggestion
+#   6. Sandbox cleanup uses find -not -type l for chmod
+#   7. repair_store() has Linux platform guard
+#
+# Category: validation
+# All tests are QUICK (no container needed).
+#===============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tests/lib/test-framework.sh
+source "$SCRIPT_DIR/lib/test-framework.sh"
+
+CLEANUP_SCRIPT="$KAPSIS_ROOT/scripts/kapsis-cleanup.sh"
+
+#===============================================================================
+# Static-content assertions on kapsis-cleanup.sh
+#===============================================================================
+
+test_store_corrupted_variable_declared() {
+    local content
+    content=$(cat "$CLEANUP_SCRIPT")
+    assert_contains "$content" "STORE_CORRUPTED=false" \
+        "STORE_CORRUPTED should be initialized to false"
+}
+
+test_clean_repair_variable_declared() {
+    local content
+    content=$(cat "$CLEANUP_SCRIPT")
+    assert_contains "$content" "CLEAN_REPAIR=false" \
+        "CLEAN_REPAIR should be initialized to false"
+}
+
+test_repair_flag_sets_explicit_action() {
+    local content
+    content=$(cat "$CLEANUP_SCRIPT")
+    # Extract the case-branch body for --repair using awk.
+    local branch
+    branch=$(awk -v pat="--repair)" '
+        $0 ~ pat {capture=1; next}
+        capture && /;;/ {capture=0}
+        capture {print}
+    ' "$CLEANUP_SCRIPT")
+    assert_contains "$branch" "explicit_action_requested=true" \
+        "Branch for --repair should set explicit_action_requested=true"
+}
+
+test_corruption_detection_uses_system_check() {
+    # clean_containers() should call podman system check --quick as a pre-check
+    local content
+    content=$(cat "$CLEANUP_SCRIPT")
+    assert_contains "$content" "podman system check --quick" \
+        "clean_containers should run podman system check --quick"
+}
+
+test_corruption_prints_repair_suggestion() {
+    local content
+    content=$(cat "$CLEANUP_SCRIPT")
+    assert_contains "$content" "kapsis-cleanup --repair" \
+        "Corruption detection should suggest kapsis-cleanup --repair"
+}
+
+test_sandbox_chmod_uses_find_not_type_l() {
+    # clean_sandboxes() should use find ... -not -type l to avoid following symlinks
+    local content
+    content=$(cat "$CLEANUP_SCRIPT")
+    # shellcheck disable=SC2016  # literal match, not expansion
+    assert_contains "$content" 'find "$sandbox" -not -type l -exec chmod' \
+        "clean_sandboxes should use find -not -type l for symlink-safe chmod"
+}
+
+test_repair_linux_guard() {
+    # repair_store() should check for Linux and provide direct instructions
+    local snippet
+    snippet=$(sed -n '/^repair_store()/,/^}/p' "$CLEANUP_SCRIPT")
+    assert_contains "$snippet" "is_linux" \
+        "repair_store should contain is_linux platform guard"
+    assert_contains "$snippet" "podman system check --repair --force" \
+        "repair_store should reference podman system check --repair --force"
+}
+
+test_repair_stage2_uses_machine_rm() {
+    # Stage 2 should use podman machine rm, not SSH+rm-rf
+    local snippet
+    snippet=$(sed -n '/^repair_store()/,/^}/p' "$CLEANUP_SCRIPT")
+    assert_contains "$snippet" "podman machine rm -f" \
+        "repair_store stage 2 should use podman machine rm -f"
+    assert_contains "$snippet" "podman machine init" \
+        "repair_store stage 2 should run podman machine init"
+    assert_contains "$snippet" "podman machine start" \
+        "repair_store stage 2 should run podman machine start"
+}
+
+test_repair_in_usage_help() {
+    local content
+    content=$(cat "$CLEANUP_SCRIPT")
+    assert_contains "$content" "--repair" \
+        "usage() should document --repair flag"
+    assert_contains "$content" "Store repair" \
+        "WHAT GETS CLEANED should include Store repair"
+}
+
+test_summary_shows_corruption_warning() {
+    # print_summary() should check STORE_CORRUPTED and warn
+    local snippet
+    snippet=$(sed -n '/^print_summary()/,/^}/p' "$CLEANUP_SCRIPT")
+    assert_contains "$snippet" "STORE_CORRUPTED" \
+        "print_summary should check STORE_CORRUPTED flag"
+}
+
+#===============================================================================
+# Behavioral runtime tests (no container)
+#===============================================================================
+
+# Helper: invoke kapsis-cleanup.sh with cleanup functions stubbed out, so we
+# can observe which ones ran based on marker files. Reuses the pattern from
+# test-cleanup-vm-health.sh.
+_invoke_cleanup() {
+    local marker_dir="$1"
+    shift
+
+    local stub_file="$marker_dir/stubs.sh"
+    cat > "$stub_file" <<'STUBS'
+clean_worktrees()      { touch "$MARKER_DIR/clean_worktrees"; }
+clean_sandboxes()      { touch "$MARKER_DIR/clean_sandboxes"; }
+clean_status()         { touch "$MARKER_DIR/clean_status"; }
+clean_sanitized_git()  { touch "$MARKER_DIR/clean_sanitized_git"; }
+clean_audit()          { touch "$MARKER_DIR/clean_audit"; }
+clean_containers()     { touch "$MARKER_DIR/clean_containers"; }
+clean_volumes()        { touch "$MARKER_DIR/clean_volumes"; }
+clean_images()         { touch "$MARKER_DIR/clean_images"; }
+clean_logs()           { touch "$MARKER_DIR/clean_logs"; }
+clean_ssh_cache()      { touch "$MARKER_DIR/clean_ssh_cache"; }
+clean_branches()       { touch "$MARKER_DIR/clean_branches"; }
+vm_health_check()      { touch "$MARKER_DIR/vm_health_check"; }
+repair_store()         { touch "$MARKER_DIR/repair_store"; }
+print_summary()        { :; }
+confirm()              { return 0; }
+STUBS
+
+    MARKER_DIR="$marker_dir" FORCE=true bash -c '
+        set +e
+        script_body=$(sed "s|^main \"\\\$@\"$|# main invocation suppressed|" "'"$CLEANUP_SCRIPT"'")
+        # shellcheck disable=SC1090
+        source /dev/stdin <<< "$script_body"
+        source "'"$stub_file"'"
+        main "$@"
+    ' -- "$@" >/dev/null 2>&1 || true
+}
+
+test_repair_flag_recognized() {
+    local marker_dir
+    marker_dir=$(mktemp -d "${TMPDIR:-/tmp}/kapsis-249-parse.XXXXXX")
+
+    # Should not error out when parsing --repair
+    _invoke_cleanup "$marker_dir" --repair --dry-run
+
+    rm -rf "$marker_dir"
+    return 0
+}
+
+test_repair_invokes_repair_store() {
+    local marker_dir
+    marker_dir=$(mktemp -d "${TMPDIR:-/tmp}/kapsis-249-invoke.XXXXXX")
+
+    _invoke_cleanup "$marker_dir" --repair --force
+
+    assert_file_exists "$marker_dir/repair_store" \
+        "--repair --force should invoke repair_store()"
+
+    rm -rf "$marker_dir"
+}
+
+test_repair_skips_defaults() {
+    local marker_dir
+    marker_dir=$(mktemp -d "${TMPDIR:-/tmp}/kapsis-249-skip.XXXXXX")
+
+    _invoke_cleanup "$marker_dir" --repair --force --dry-run
+
+    assert_file_exists     "$marker_dir/repair_store"        "--repair should invoke repair_store"
+    assert_file_not_exists "$marker_dir/clean_worktrees"     "--repair alone must NOT trigger clean_worktrees"
+    assert_file_not_exists "$marker_dir/clean_sandboxes"     "--repair alone must NOT trigger clean_sandboxes"
+    assert_file_not_exists "$marker_dir/clean_status"        "--repair alone must NOT trigger clean_status"
+    assert_file_not_exists "$marker_dir/clean_sanitized_git" "--repair alone must NOT trigger clean_sanitized_git"
+    assert_file_not_exists "$marker_dir/clean_audit"         "--repair alone must NOT trigger clean_audit"
+
+    rm -rf "$marker_dir"
+}
+
+#===============================================================================
+# Runner
+#===============================================================================
+
+run_test test_store_corrupted_variable_declared
+run_test test_clean_repair_variable_declared
+run_test test_repair_flag_sets_explicit_action
+run_test test_corruption_detection_uses_system_check
+run_test test_corruption_prints_repair_suggestion
+run_test test_sandbox_chmod_uses_find_not_type_l
+run_test test_repair_linux_guard
+run_test test_repair_stage2_uses_machine_rm
+run_test test_repair_in_usage_help
+run_test test_summary_shows_corruption_warning
+run_test test_repair_flag_recognized
+run_test test_repair_invokes_repair_store
+run_test test_repair_skips_defaults
+
+print_summary


### PR DESCRIPTION
## Summary

Closes #249

After a virtio-fs mount drop corrupts the Podman container store, `kapsis-cleanup --all --force` fails silently — `podman rm` errors are swallowed by `|| true`, ghost container entries persist, and sandbox directories get "permission denied" with no recovery path.

- **Store corruption detection**: Pre-check via `podman system check --quick`, capture `podman rm` errors to detect "not known" corruption patterns, print actionable `--repair` suggestion
- **`--repair` flag**: Two-stage recovery — Stage 1: `podman system check --repair --force`, Stage 2: full VM reset via `podman machine rm/init/start` (requires `--force`)
- **Sandbox permission fix**: Symlink-safe `find -not -type l -exec chmod` before existing sudo/podman-unshare escalation
- **No auto-escalation**: Corruption detection only prints guidance, never auto-invokes repair

## Test plan

- [x] ShellCheck passes on both modified files
- [x] 13 new tests in `test-cleanup-store-repair.sh` (all QUICK, no container)
- [x] 17 existing `test-cleanup-vm-health.sh` tests pass (no regressions)
- [x] `--help` shows `--repair` flag documentation
- [x] `--repair --dry-run` executes without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)