### PR TITLE
fix: detect and recover from stale Podman SSH tunnel in pre-flight

### DIFF
--- a/scripts/backends/podman.sh
+++ b/scripts/backends/podman.sh
@@ -55,6 +55,41 @@ backend_validate() {
         else
             log_debug "Podman machine is running"
         fi
+
+        # Verify SSH tunnel is functional (Issue #255)
+        # Machine may report "running" but SSH tunnel is dead after reboot/sleep.
+        if declare -f _podman_ssh_probe &>/dev/null; then
+            local probe_timeout="${KAPSIS_PREFLIGHT_SSH_PROBE_TIMEOUT:-${KAPSIS_DEFAULT_PREFLIGHT_SSH_PROBE_TIMEOUT:-10}}"
+            local max_retries="${KAPSIS_PREFLIGHT_SSH_RECOVERY_RETRIES:-${KAPSIS_DEFAULT_PREFLIGHT_SSH_RECOVERY_RETRIES:-2}}"
+            local retry_delay="${KAPSIS_PREFLIGHT_SSH_RECOVERY_DELAY:-${KAPSIS_DEFAULT_PREFLIGHT_SSH_RECOVERY_DELAY:-3}}"
+
+            log_debug "Probing Podman SSH tunnel..."
+            if ! _podman_ssh_probe "$probe_timeout"; then
+                log_warn "Podman SSH tunnel is stale. Attempting recovery (stop + start)..."
+                podman machine stop podman-machine-default &>/dev/null || true
+                podman machine start podman-machine-default &>/dev/null || true
+
+                local i
+                local recovered=false
+                for (( i=1; i<=max_retries; i++ )); do
+                    sleep "$retry_delay"
+                    if _podman_ssh_probe "$probe_timeout"; then
+                        recovered=true
+                        break
+                    fi
+                    log_warn "SSH recovery retry $i/$max_retries failed"
+                done
+
+                if [[ "$recovered" == "true" ]]; then
+                    log_success "Podman SSH tunnel recovered after restart"
+                else
+                    log_error "Podman SSH tunnel is broken. Run: podman machine stop && podman machine start"
+                    return 1
+                fi
+            else
+                log_debug "Podman SSH tunnel is functional"
+            fi
+        fi
     fi
 
     return 0

--- a/scripts/backends/podman.sh
+++ b/scripts/backends/podman.sh
@@ -42,7 +42,7 @@ backend_validate() {
     log_debug "Podman found at: $(command -v podman)"
 
     # Check Podman machine is running (macOS only)
-    if [[ "$(uname)" == "Darwin" ]]; then
+    if is_macos 2>/dev/null || [[ "$(uname)" == "Darwin" ]]; then
         log_debug "Checking Podman machine status..."
         if ! podman machine inspect podman-machine-default &>/dev/null || \
            [[ "$(podman machine inspect podman-machine-default --format '{{.State}}')" != "running" ]]; then
@@ -58,37 +58,21 @@ backend_validate() {
 
         # Verify SSH tunnel is functional (Issue #255)
         # Machine may report "running" but SSH tunnel is dead after reboot/sleep.
-        if declare -f _podman_ssh_probe &>/dev/null; then
+        # Skip if preflight already verified (avoids double probing).
+        if [[ "${KAPSIS_SSH_PROBE_PASSED:-}" != "1" ]] && declare -f _recover_podman_ssh_tunnel &>/dev/null; then
             local probe_timeout="${KAPSIS_PREFLIGHT_SSH_PROBE_TIMEOUT:-${KAPSIS_DEFAULT_PREFLIGHT_SSH_PROBE_TIMEOUT:-10}}"
             local max_retries="${KAPSIS_PREFLIGHT_SSH_RECOVERY_RETRIES:-${KAPSIS_DEFAULT_PREFLIGHT_SSH_RECOVERY_RETRIES:-2}}"
             local retry_delay="${KAPSIS_PREFLIGHT_SSH_RECOVERY_DELAY:-${KAPSIS_DEFAULT_PREFLIGHT_SSH_RECOVERY_DELAY:-3}}"
 
             log_debug "Probing Podman SSH tunnel..."
-            if ! _podman_ssh_probe "$probe_timeout"; then
-                log_warn "Podman SSH tunnel is stale. Attempting recovery (stop + start)..."
-                podman machine stop podman-machine-default &>/dev/null || true
-                podman machine start podman-machine-default &>/dev/null || true
-
-                local i
-                local recovered=false
-                for (( i=1; i<=max_retries; i++ )); do
-                    sleep "$retry_delay"
-                    if _podman_ssh_probe "$probe_timeout"; then
-                        recovered=true
-                        break
-                    fi
-                    log_warn "SSH recovery retry $i/$max_retries failed"
-                done
-
-                if [[ "$recovered" == "true" ]]; then
-                    log_success "Podman SSH tunnel recovered after restart"
-                else
-                    log_error "Podman SSH tunnel is broken. Run: podman machine stop && podman machine start"
-                    return 1
-                fi
-            else
+            if _recover_podman_ssh_tunnel "$probe_timeout" "$max_retries" "$retry_delay"; then
                 log_debug "Podman SSH tunnel is functional"
+            else
+                log_error "Podman SSH tunnel is broken. Run: podman machine stop && podman machine start"
+                return 1
             fi
+        else
+            log_debug "SSH probe already passed — skipping"
         fi
     fi
 

--- a/scripts/lib/compat.sh
+++ b/scripts/lib/compat.sh
@@ -261,3 +261,36 @@ sha256_hash() {
         shasum -a 256 | cut -d' ' -f1
     fi
 }
+
+#-------------------------------------------------------------------------------
+# _podman_ssh_probe [timeout_seconds]
+#
+# Verifies that the Podman SSH tunnel is functional (macOS only).
+# Runs `podman info` which exercises the full stack: CLI → SSH → VM → daemon.
+# On Linux (native Podman, no SSH tunnel), always returns 0.
+#
+# Returns: 0 if healthy, 1 if SSH tunnel is broken.
+#-------------------------------------------------------------------------------
+_podman_ssh_probe() {
+    local timeout_secs="${1:-10}"
+
+    # Linux uses native Podman — no SSH tunnel to probe
+    if is_linux; then
+        return 0
+    fi
+
+    # Find a timeout command (macOS may have gtimeout from coreutils)
+    local timeout_cmd=""
+    if command -v timeout &>/dev/null; then
+        timeout_cmd="timeout"
+    elif command -v gtimeout &>/dev/null; then
+        timeout_cmd="gtimeout"
+    fi
+
+    # Probe: `podman info` validates CLI → SSH → VM → daemon
+    if [[ -n "$timeout_cmd" ]]; then
+        "$timeout_cmd" "$timeout_secs" podman info &>/dev/null
+    else
+        podman info &>/dev/null
+    fi
+}

--- a/scripts/lib/compat.sh
+++ b/scripts/lib/compat.sh
@@ -263,6 +263,18 @@ sha256_hash() {
 }
 
 #-------------------------------------------------------------------------------
+# Timeout command cache — detected once at source time.
+# Used by _podman_ssh_probe and _recover_podman_ssh_tunnel.
+#-------------------------------------------------------------------------------
+if command -v timeout &>/dev/null; then
+    _KAPSIS_TIMEOUT_CMD="timeout"
+elif command -v gtimeout &>/dev/null; then
+    _KAPSIS_TIMEOUT_CMD="gtimeout"
+else
+    _KAPSIS_TIMEOUT_CMD=""
+fi
+
+#-------------------------------------------------------------------------------
 # _podman_ssh_probe [timeout_seconds]
 #
 # Verifies that the Podman SSH tunnel is functional (macOS only).
@@ -279,18 +291,84 @@ _podman_ssh_probe() {
         return 0
     fi
 
-    # Find a timeout command (macOS may have gtimeout from coreutils)
-    local timeout_cmd=""
-    if command -v timeout &>/dev/null; then
-        timeout_cmd="timeout"
-    elif command -v gtimeout &>/dev/null; then
-        timeout_cmd="gtimeout"
+    # Validate timeout is a positive integer within sane bounds (1-120)
+    if ! [[ "$timeout_secs" =~ ^[0-9]+$ ]] || (( timeout_secs < 1 || timeout_secs > 120 )); then
+        timeout_secs=10
     fi
 
     # Probe: `podman info` validates CLI → SSH → VM → daemon
-    if [[ -n "$timeout_cmd" ]]; then
-        "$timeout_cmd" "$timeout_secs" podman info &>/dev/null
+    if [[ -n "$_KAPSIS_TIMEOUT_CMD" ]]; then
+        "$_KAPSIS_TIMEOUT_CMD" "$timeout_secs" podman info &>/dev/null
     else
+        # No timeout binary — podman info could hang on stale SSH tunnel.
+        # Install coreutils (brew install coreutils) for gtimeout support.
         podman info &>/dev/null
     fi
+}
+
+#-------------------------------------------------------------------------------
+# _recover_podman_ssh_tunnel [probe_timeout] [max_retries] [retry_delay]
+#
+# Probes the Podman SSH tunnel and attempts recovery if stale (macOS only).
+# On Linux, always returns 0 (no SSH tunnel).
+#
+# Recovery: podman machine stop + start, then retry probe with backoff.
+# Sets KAPSIS_SSH_PROBE_PASSED=1 on success to avoid redundant probes.
+#
+# Returns: 0 if tunnel is healthy (or recovered), 1 if broken.
+#-------------------------------------------------------------------------------
+# shellcheck disable=SC2034
+_recover_podman_ssh_tunnel() {
+    # Linux — no SSH tunnel to recover
+    if is_linux; then
+        KAPSIS_SSH_PROBE_PASSED=1
+        return 0
+    fi
+
+    local probe_timeout="${1:-10}"
+    local max_retries="${2:-2}"
+    local retry_delay="${3:-3}"
+
+    # Validate inputs — cap at sane upper bounds
+    if ! [[ "$max_retries" =~ ^[0-9]+$ ]] || (( max_retries > 5 )); then
+        max_retries=2
+    fi
+    if ! [[ "$retry_delay" =~ ^[0-9]+$ ]] || (( retry_delay > 30 )); then
+        retry_delay=3
+    fi
+
+    # Probe SSH tunnel
+    if _podman_ssh_probe "$probe_timeout"; then
+        KAPSIS_SSH_PROBE_PASSED=1
+        return 0
+    fi
+
+    # Tunnel is stale — attempt recovery via stop + start
+    if [[ -n "$_KAPSIS_TIMEOUT_CMD" ]]; then
+        "$_KAPSIS_TIMEOUT_CMD" 30 podman machine stop podman-machine-default &>/dev/null || true
+        if ! "$_KAPSIS_TIMEOUT_CMD" 60 podman machine start podman-machine-default 2>/dev/null; then
+            # Log start failure for diagnosis (visible with KAPSIS_DEBUG=1)
+            declare -f log_debug &>/dev/null && log_debug "podman machine start failed during SSH recovery"
+        fi
+    else
+        podman machine stop podman-machine-default &>/dev/null || true
+        if ! podman machine start podman-machine-default 2>/dev/null; then
+            declare -f log_debug &>/dev/null && log_debug "podman machine start failed during SSH recovery"
+        fi
+    fi
+
+    # Retry probe after recovery
+    local i
+    for (( i=1; i<=max_retries; i++ )); do
+        if (( i > 1 )); then
+            sleep "$retry_delay"
+        fi
+        if _podman_ssh_probe "$probe_timeout"; then
+            KAPSIS_SSH_PROBE_PASSED=1
+            return 0
+        fi
+        declare -f log_warn &>/dev/null && log_warn "SSH recovery retry $i/$max_retries failed"
+    done
+
+    return 1
 }

--- a/scripts/lib/constants.sh
+++ b/scripts/lib/constants.sh
@@ -276,6 +276,23 @@ readonly KAPSIS_DEFAULT_CLEANUP_VM_JOURNAL_VACUUM_SIZE="100M"
 readonly KAPSIS_DEFAULT_CLEANUP_VM_SSH_TIMEOUT=15
 
 #===============================================================================
+# SSH PROBE DEFAULTS (Issue #255)
+#
+# Pre-flight connectivity check for Podman SSH tunnel (macOS only).
+# After reboot/sleep, the machine may report "running" while SSH is dead.
+# Override via environment variables (e.g., KAPSIS_PREFLIGHT_SSH_PROBE_TIMEOUT=5).
+#===============================================================================
+
+# Timeout (seconds) for the `podman info` SSH connectivity probe
+readonly KAPSIS_DEFAULT_PREFLIGHT_SSH_PROBE_TIMEOUT=10
+
+# Max retries after stop/start recovery attempt
+readonly KAPSIS_DEFAULT_PREFLIGHT_SSH_RECOVERY_RETRIES=2
+
+# Delay (seconds) between recovery retries
+readonly KAPSIS_DEFAULT_PREFLIGHT_SSH_RECOVERY_DELAY=3
+
+#===============================================================================
 # EXIT CODES (Issue #248)
 #
 # Standard exit codes returned by Kapsis agent containers.

--- a/scripts/preflight-check.sh
+++ b/scripts/preflight-check.sh
@@ -88,37 +88,21 @@ check_podman() {
 
     # Verify SSH tunnel is functional (macOS only — Issue #255)
     # After reboot/sleep, machine reports "running" but SSH tunnel may be dead.
-    if is_macos && declare -f _podman_ssh_probe &>/dev/null; then
+    if ! is_linux && declare -f _recover_podman_ssh_tunnel &>/dev/null; then
         local probe_timeout="${KAPSIS_PREFLIGHT_SSH_PROBE_TIMEOUT:-${KAPSIS_DEFAULT_PREFLIGHT_SSH_PROBE_TIMEOUT:-10}}"
         local max_retries="${KAPSIS_PREFLIGHT_SSH_RECOVERY_RETRIES:-${KAPSIS_DEFAULT_PREFLIGHT_SSH_RECOVERY_RETRIES:-2}}"
         local retry_delay="${KAPSIS_PREFLIGHT_SSH_RECOVERY_DELAY:-${KAPSIS_DEFAULT_PREFLIGHT_SSH_RECOVERY_DELAY:-3}}"
 
         log_info "Verifying Podman SSH tunnel..."
 
-        if _podman_ssh_probe "$probe_timeout"; then
-            preflight_ok "Podman SSH tunnel is functional"
-        else
-            log_warn "Podman SSH tunnel is stale, attempting recovery (stop + start)..."
-            podman machine stop podman-machine-default &>/dev/null || true
-            podman machine start podman-machine-default &>/dev/null || true
-
-            local i
-            local recovered=false
-            for (( i=1; i<=max_retries; i++ )); do
-                sleep "$retry_delay"
-                if _podman_ssh_probe "$probe_timeout"; then
-                    recovered=true
-                    break
-                fi
-                log_warn "SSH recovery retry $i/$max_retries failed"
-            done
-
-            if [[ "$recovered" == "true" ]]; then
-                preflight_ok "Podman SSH tunnel recovered after restart"
-            else
-                preflight_error "Podman SSH tunnel is broken — run: podman machine stop && podman machine start"
-                return 1
+        if _recover_podman_ssh_tunnel "$probe_timeout" "$max_retries" "$retry_delay"; then
+            if [[ "${KAPSIS_SSH_PROBE_PASSED:-}" == "1" ]]; then
+                preflight_ok "Podman SSH tunnel is functional"
             fi
+        else
+            # preflight_error does not return non-zero; explicit return required
+            preflight_error "Podman SSH tunnel is broken — run: podman machine stop && podman machine start"
+            return 1
         fi
     fi
 

--- a/scripts/preflight-check.sh
+++ b/scripts/preflight-check.sh
@@ -31,6 +31,11 @@ if [[ -z "${_KAPSIS_COMPAT_LOADED:-}" ]] && [[ -f "$PREFLIGHT_SCRIPT_DIR/lib/com
     source "$PREFLIGHT_SCRIPT_DIR/lib/compat.sh"
 fi
 
+# Source constants (only if not already loaded — provides SSH probe defaults)
+if [[ -z "${_KAPSIS_CONSTANTS_LOADED:-}" ]] && [[ -f "$PREFLIGHT_SCRIPT_DIR/lib/constants.sh" ]]; then
+    source "$PREFLIGHT_SCRIPT_DIR/lib/constants.sh"
+fi
+
 #===============================================================================
 # PREFLIGHT CHECK RESULTS
 #===============================================================================
@@ -80,6 +85,43 @@ check_podman() {
     fi
 
     preflight_ok "Podman machine is running"
+
+    # Verify SSH tunnel is functional (macOS only — Issue #255)
+    # After reboot/sleep, machine reports "running" but SSH tunnel may be dead.
+    if is_macos && declare -f _podman_ssh_probe &>/dev/null; then
+        local probe_timeout="${KAPSIS_PREFLIGHT_SSH_PROBE_TIMEOUT:-${KAPSIS_DEFAULT_PREFLIGHT_SSH_PROBE_TIMEOUT:-10}}"
+        local max_retries="${KAPSIS_PREFLIGHT_SSH_RECOVERY_RETRIES:-${KAPSIS_DEFAULT_PREFLIGHT_SSH_RECOVERY_RETRIES:-2}}"
+        local retry_delay="${KAPSIS_PREFLIGHT_SSH_RECOVERY_DELAY:-${KAPSIS_DEFAULT_PREFLIGHT_SSH_RECOVERY_DELAY:-3}}"
+
+        log_info "Verifying Podman SSH tunnel..."
+
+        if _podman_ssh_probe "$probe_timeout"; then
+            preflight_ok "Podman SSH tunnel is functional"
+        else
+            log_warn "Podman SSH tunnel is stale, attempting recovery (stop + start)..."
+            podman machine stop podman-machine-default &>/dev/null || true
+            podman machine start podman-machine-default &>/dev/null || true
+
+            local i
+            local recovered=false
+            for (( i=1; i<=max_retries; i++ )); do
+                sleep "$retry_delay"
+                if _podman_ssh_probe "$probe_timeout"; then
+                    recovered=true
+                    break
+                fi
+                log_warn "SSH recovery retry $i/$max_retries failed"
+            done
+
+            if [[ "$recovered" == "true" ]]; then
+                preflight_ok "Podman SSH tunnel recovered after restart"
+            else
+                preflight_error "Podman SSH tunnel is broken — run: podman machine stop && podman machine start"
+                return 1
+            fi
+        fi
+    fi
+
     return 0
 }
 

--- a/tests/test-preflight-check.sh
+++ b/tests/test-preflight-check.sh
@@ -432,82 +432,22 @@ test_preflight_error_messages_actionable() {
 # TEST CASES: SSH Tunnel Connectivity (Issue #255)
 #===============================================================================
 
-test_check_podman_verifies_ssh_connectivity() {
-    log_test "Testing check_podman verifies SSH connectivity on macOS"
+# Helper: create a mock podman script for SSH tests
+# Args: $1=mock_dir, $2=info_behavior ("fail"|"succeed"|"fail_then_succeed")
+_create_ssh_mock_podman() {
+    local mock_dir="$1"
+    local info_behavior="${2:-fail}"
 
-    local content
-    content=$(cat "$PREFLIGHT_SCRIPT")
+    # State file for fail_then_succeed mode
+    local call_count_file="$mock_dir/.podman_info_calls"
+    echo "0" > "$call_count_file"
 
-    assert_contains "$content" "_podman_ssh_probe" \
-        "check_podman should call _podman_ssh_probe"
-    assert_contains "$content" "SSH tunnel is broken" \
-        "check_podman should report SSH tunnel broken on probe failure"
-    assert_contains "$content" "is_macos" \
-        "SSH probe should be gated on macOS platform check"
-}
-
-test_ssh_probe_defined_in_compat() {
-    log_test "Testing _podman_ssh_probe is defined in compat.sh"
-
-    local compat_file="$KAPSIS_ROOT/scripts/lib/compat.sh"
-    local content
-    content=$(cat "$compat_file")
-
-    assert_contains "$content" "_podman_ssh_probe()" \
-        "_podman_ssh_probe function should be defined in compat.sh"
-    assert_contains "$content" "podman info" \
-        "_podman_ssh_probe should use 'podman info' as connectivity check"
-    assert_contains "$content" "is_linux" \
-        "_podman_ssh_probe should skip on Linux (native Podman)"
-}
-
-test_ssh_probe_constants_exist() {
-    log_test "Testing SSH probe constants exist in constants.sh"
-
-    local constants_file="$KAPSIS_ROOT/scripts/lib/constants.sh"
-    local content
-    content=$(cat "$constants_file")
-
-    assert_contains "$content" "KAPSIS_DEFAULT_PREFLIGHT_SSH_PROBE_TIMEOUT" \
-        "SSH probe timeout constant should exist"
-    assert_contains "$content" "KAPSIS_DEFAULT_PREFLIGHT_SSH_RECOVERY_RETRIES" \
-        "SSH recovery retries constant should exist"
-    assert_contains "$content" "KAPSIS_DEFAULT_PREFLIGHT_SSH_RECOVERY_DELAY" \
-        "SSH recovery delay constant should exist"
-}
-
-test_backend_validate_has_ssh_recovery() {
-    log_test "Testing backend_validate includes SSH recovery logic"
-
-    local backend_file="$KAPSIS_ROOT/scripts/backends/podman.sh"
-    local content
-    content=$(cat "$backend_file")
-
-    assert_contains "$content" "_podman_ssh_probe" \
-        "backend_validate should call _podman_ssh_probe"
-    assert_contains "$content" "SSH tunnel is stale" \
-        "backend_validate should detect stale SSH tunnel"
-    assert_contains "$content" "podman machine stop" \
-        "backend_validate should attempt stop as part of recovery"
-    assert_contains "$content" "SSH tunnel recovered" \
-        "backend_validate should report successful recovery"
-    assert_contains "$content" "SSH tunnel is broken" \
-        "backend_validate should report if recovery fails"
-}
-
-test_check_podman_fails_on_stale_ssh() {
-    log_test "Testing check_podman fails when SSH tunnel is stale"
-
-    local mock_dir
-    mock_dir=$(mktemp -d)
-
-    # Mock podman: machine inspect returns "running" but podman info fails
-    cat > "$mock_dir/podman" <<'MOCK'
+    cat > "$mock_dir/podman" <<MOCK
 #!/usr/bin/env bash
-if [[ "${1:-}" == "machine" ]]; then
-    if [[ "${2:-}" == "inspect" ]]; then
-        for arg in "$@"; do
-            if [[ "$arg" == *"{{.State}}"* ]]; then
+if [[ "\${1:-}" == "machine" ]]; then
+    if [[ "\${2:-}" == "inspect" ]]; then
+        for arg in "\$@"; do
+            if [[ "\$arg" == *"{{.State}}"* ]]; then
                 echo "running"
                 exit 0
             fi
@@ -518,116 +458,201 @@ if [[ "${1:-}" == "machine" ]]; then
     # machine stop / machine start — succeed silently
     exit 0
 fi
-if [[ "${1:-}" == "info" ]]; then
-    # Simulate stale SSH: podman info fails
-    exit 125
-fi
-exit 0
-MOCK
-    chmod +x "$mock_dir/podman"
-
-    # Mock timeout to just pass through
-    cat > "$mock_dir/timeout" <<'MOCK'
-#!/usr/bin/env bash
-shift  # skip timeout value
-exec "$@"
-MOCK
-    chmod +x "$mock_dir/timeout"
-
-    # Run in a fresh bash process to avoid readonly variable inheritance
-    local test_script="$mock_dir/run-test.sh"
-    cat > "$test_script" <<TESTEOF
-#!/usr/bin/env bash
-set -euo pipefail
-export PATH="$mock_dir:\$PATH"
-source "$KAPSIS_ROOT/scripts/lib/logging.sh"
-log_init "test"
-source "$KAPSIS_ROOT/scripts/lib/compat.sh"
-source "$KAPSIS_ROOT/scripts/lib/constants.sh"
-# Force macOS detection for CI environments
-_KAPSIS_OS="Darwin"
-source "$PREFLIGHT_SCRIPT"
-_PREFLIGHT_ERRORS=0
-_PREFLIGHT_WARNINGS=0
-KAPSIS_PREFLIGHT_SSH_PROBE_TIMEOUT=2
-KAPSIS_PREFLIGHT_SSH_RECOVERY_RETRIES=1
-KAPSIS_PREFLIGHT_SSH_RECOVERY_DELAY=0
-check_podman
-TESTEOF
-    chmod +x "$test_script"
-
-    local output
-    local result=0
-    output=$(bash "$test_script" 2>&1) || result=$?
-
-    rm -rf "$mock_dir"
-
-    assert_not_equals 0 "$result" "check_podman should fail when SSH tunnel is stale"
-    assert_contains "$output" "SSH tunnel is broken" "Should report broken SSH tunnel"
-}
-
-test_check_podman_passes_on_healthy_ssh() {
-    log_test "Testing check_podman passes when SSH tunnel is healthy"
-
-    local mock_dir
-    mock_dir=$(mktemp -d)
-
-    # Mock podman: both inspect and info succeed
-    cat > "$mock_dir/podman" <<'MOCK'
-#!/usr/bin/env bash
-if [[ "${1:-}" == "machine" ]] && [[ "${2:-}" == "inspect" ]]; then
-    for arg in "$@"; do
-        if [[ "$arg" == *"{{.State}}"* ]]; then
-            echo "running"
+if [[ "\${1:-}" == "info" ]]; then
+    case "$info_behavior" in
+        fail)
+            exit 125
+            ;;
+        succeed)
+            echo "host:"
             exit 0
-        fi
-    done
-    echo "{}"
-    exit 0
-fi
-if [[ "${1:-}" == "info" ]]; then
-    echo "host:"
-    exit 0
+            ;;
+        fail_then_succeed)
+            count=\$(cat "$call_count_file")
+            count=\$((count + 1))
+            echo "\$count" > "$call_count_file"
+            if [[ \$count -le 1 ]]; then
+                exit 125  # first call fails
+            else
+                echo "host:"
+                exit 0    # subsequent calls succeed
+            fi
+            ;;
+    esac
 fi
 exit 0
 MOCK
     chmod +x "$mock_dir/podman"
 
+    # Mock timeout to pass through (strips timeout arg)
     cat > "$mock_dir/timeout" <<'MOCK'
 #!/usr/bin/env bash
 shift
 exec "$@"
 MOCK
     chmod +x "$mock_dir/timeout"
+}
 
-    # Run in a fresh bash process to avoid readonly variable inheritance
+# Helper: create a test script that sources libraries and runs check_podman
+# Args: $1=mock_dir, $2...=extra lines to add before check_podman
+_create_ssh_test_script() {
+    local mock_dir="$1"
+    shift
+    local extra_lines=("$@")
+
     local test_script="$mock_dir/run-test.sh"
-    cat > "$test_script" <<TESTEOF
-#!/usr/bin/env bash
-set -euo pipefail
-export PATH="$mock_dir:\$PATH"
-source "$KAPSIS_ROOT/scripts/lib/logging.sh"
-log_init "test"
-source "$KAPSIS_ROOT/scripts/lib/compat.sh"
-source "$KAPSIS_ROOT/scripts/lib/constants.sh"
-# Force macOS detection for CI environments
-_KAPSIS_OS="Darwin"
-source "$PREFLIGHT_SCRIPT"
-_PREFLIGHT_ERRORS=0
-_PREFLIGHT_WARNINGS=0
-KAPSIS_PREFLIGHT_SSH_PROBE_TIMEOUT=2
-check_podman
-TESTEOF
+    {
+        echo '#!/usr/bin/env bash'
+        echo 'set -euo pipefail'
+        echo "export PATH=\"$mock_dir:\$PATH\""
+        echo "source \"$KAPSIS_ROOT/scripts/lib/logging.sh\""
+        echo 'log_init "test"'
+        echo "source \"$KAPSIS_ROOT/scripts/lib/compat.sh\""
+        echo "source \"$KAPSIS_ROOT/scripts/lib/constants.sh\""
+        echo '_KAPSIS_OS="Darwin"'
+        echo "source \"$PREFLIGHT_SCRIPT\""
+        echo '_PREFLIGHT_ERRORS=0'
+        echo '_PREFLIGHT_WARNINGS=0'
+        echo 'KAPSIS_PREFLIGHT_SSH_PROBE_TIMEOUT=2'
+        for line in "${extra_lines[@]}"; do
+            echo "$line"
+        done
+        echo 'check_podman'
+        # shellcheck disable=SC2016
+        echo 'echo "ERRORS=$_PREFLIGHT_ERRORS"'
+    } > "$test_script"
     chmod +x "$test_script"
+}
 
-    local output
-    local result=0
-    output=$(bash "$test_script" 2>&1) || result=$?
+# Smoke test: key integration points exist in source
+test_ssh_probe_source_integration() {
+    log_test "Testing SSH probe integration points exist in source"
 
+    local compat_content preflight_content backend_content constants_content
+    compat_content=$(cat "$KAPSIS_ROOT/scripts/lib/compat.sh")
+    preflight_content=$(cat "$PREFLIGHT_SCRIPT")
+    backend_content=$(cat "$KAPSIS_ROOT/scripts/backends/podman.sh")
+    constants_content=$(cat "$KAPSIS_ROOT/scripts/lib/constants.sh")
+
+    # Probe and recovery functions defined in compat.sh
+    assert_contains "$compat_content" "_podman_ssh_probe()" \
+        "_podman_ssh_probe should be defined in compat.sh"
+    assert_contains "$compat_content" "_recover_podman_ssh_tunnel()" \
+        "_recover_podman_ssh_tunnel should be defined in compat.sh"
+    assert_contains "$compat_content" "podman info" \
+        "Probe should use 'podman info' as connectivity check"
+
+    # Callers use shared recovery function
+    assert_contains "$preflight_content" "_recover_podman_ssh_tunnel" \
+        "preflight should call shared recovery function"
+    assert_contains "$backend_content" "_recover_podman_ssh_tunnel" \
+        "backend should call shared recovery function"
+
+    # Constants defined
+    assert_contains "$constants_content" "KAPSIS_DEFAULT_PREFLIGHT_SSH_PROBE_TIMEOUT=10" \
+        "SSH probe timeout constant should exist with default 10"
+    assert_contains "$constants_content" "KAPSIS_DEFAULT_PREFLIGHT_SSH_RECOVERY_RETRIES=2" \
+        "SSH recovery retries constant should exist with default 2"
+    assert_contains "$constants_content" "KAPSIS_DEFAULT_PREFLIGHT_SSH_RECOVERY_DELAY=3" \
+        "SSH recovery delay constant should exist with default 3"
+
+    # Backend skips if probe already passed
+    assert_contains "$backend_content" "KAPSIS_SSH_PROBE_PASSED" \
+        "backend should check KAPSIS_SSH_PROBE_PASSED to avoid double probing"
+}
+
+# Behavioral: check_podman fails when SSH tunnel is permanently stale
+test_check_podman_fails_on_stale_ssh() {
+    log_test "Testing check_podman fails when SSH tunnel is stale"
+
+    local mock_dir
+    mock_dir=$(mktemp -d)
+    _create_ssh_mock_podman "$mock_dir" "fail"
+    _create_ssh_test_script "$mock_dir" \
+        'KAPSIS_PREFLIGHT_SSH_RECOVERY_RETRIES=1' \
+        'KAPSIS_PREFLIGHT_SSH_RECOVERY_DELAY=0'
+
+    local output result=0
+    output=$(bash "$mock_dir/run-test.sh" 2>&1) || result=$?
+    rm -rf "$mock_dir"
+
+    assert_not_equals 0 "$result" "check_podman should fail when SSH tunnel is stale"
+    assert_contains "$output" "SSH tunnel is broken" "Should report broken SSH tunnel"
+    assert_not_contains "$output" "SSH tunnel is functional" "Should NOT report functional"
+}
+
+# Behavioral: check_podman passes when SSH tunnel is healthy
+test_check_podman_passes_on_healthy_ssh() {
+    log_test "Testing check_podman passes when SSH tunnel is healthy"
+
+    local mock_dir
+    mock_dir=$(mktemp -d)
+    _create_ssh_mock_podman "$mock_dir" "succeed"
+    _create_ssh_test_script "$mock_dir"
+
+    local output result=0
+    output=$(bash "$mock_dir/run-test.sh" 2>&1) || result=$?
     rm -rf "$mock_dir"
 
     assert_equals 0 "$result" "check_podman should pass when SSH tunnel is healthy"
     assert_contains "$output" "SSH tunnel is functional" "Should report functional SSH tunnel"
+    assert_contains "$output" "ERRORS=0" "Should have zero preflight errors"
+}
+
+# Behavioral: recovery succeeds on retry after initial failure
+test_check_podman_recovers_on_retry() {
+    log_test "Testing check_podman recovers when SSH tunnel heals after restart"
+
+    local mock_dir
+    mock_dir=$(mktemp -d)
+    _create_ssh_mock_podman "$mock_dir" "fail_then_succeed"
+    _create_ssh_test_script "$mock_dir" \
+        'KAPSIS_PREFLIGHT_SSH_RECOVERY_RETRIES=2' \
+        'KAPSIS_PREFLIGHT_SSH_RECOVERY_DELAY=0'
+
+    local output result=0
+    output=$(bash "$mock_dir/run-test.sh" 2>&1) || result=$?
+    rm -rf "$mock_dir"
+
+    assert_equals 0 "$result" "check_podman should succeed after recovery"
+    assert_contains "$output" "SSH tunnel is functional" "Should report functional after recovery"
+    assert_not_contains "$output" "SSH tunnel is broken" "Should NOT report broken"
+    assert_contains "$output" "ERRORS=0" "Should have zero preflight errors"
+}
+
+# Behavioral: SSH probe is skipped on Linux
+test_check_podman_skips_ssh_on_linux() {
+    log_test "Testing check_podman skips SSH probe on Linux"
+
+    local mock_dir
+    mock_dir=$(mktemp -d)
+    # Use fail behavior — but on Linux, probe should never run
+    _create_ssh_mock_podman "$mock_dir" "fail"
+
+    local test_script="$mock_dir/run-test.sh"
+    {
+        echo '#!/usr/bin/env bash'
+        echo 'set -euo pipefail'
+        echo "export PATH=\"$mock_dir:\$PATH\""
+        echo "source \"$KAPSIS_ROOT/scripts/lib/logging.sh\""
+        echo 'log_init "test"'
+        echo "source \"$KAPSIS_ROOT/scripts/lib/compat.sh\""
+        echo "source \"$KAPSIS_ROOT/scripts/lib/constants.sh\""
+        echo '_KAPSIS_OS="Linux"'
+        echo "source \"$PREFLIGHT_SCRIPT\""
+        echo '_PREFLIGHT_ERRORS=0'
+        echo '_PREFLIGHT_WARNINGS=0'
+        echo 'KAPSIS_PREFLIGHT_SSH_PROBE_TIMEOUT=2'
+        echo 'check_podman'
+    } > "$test_script"
+    chmod +x "$test_script"
+
+    local output result=0
+    output=$(bash "$test_script" 2>&1) || result=$?
+    rm -rf "$mock_dir"
+
+    assert_equals 0 "$result" "check_podman should pass on Linux (no SSH probe)"
+    assert_not_contains "$output" "SSH tunnel" "Should not mention SSH tunnel on Linux"
 }
 
 #===============================================================================
@@ -668,12 +693,11 @@ main() {
     run_test test_preflight_error_messages_actionable
 
     # SSH connectivity tests (Issue #255)
-    run_test test_check_podman_verifies_ssh_connectivity
-    run_test test_ssh_probe_defined_in_compat
-    run_test test_ssh_probe_constants_exist
-    run_test test_backend_validate_has_ssh_recovery
+    run_test test_ssh_probe_source_integration
     run_test test_check_podman_fails_on_stale_ssh
     run_test test_check_podman_passes_on_healthy_ssh
+    run_test test_check_podman_recovers_on_retry
+    run_test test_check_podman_skips_ssh_on_linux
 
     # Summary
     print_summary

--- a/tests/test-preflight-check.sh
+++ b/tests/test-preflight-check.sh
@@ -14,6 +14,9 @@
 # - Worktree conflict detection
 #===============================================================================
 # shellcheck disable=SC1090  # Dynamic source paths are intentional in tests
+# shellcheck disable=SC2030,SC2031  # Subshell variable modifications are intentional in mock tests
+# shellcheck disable=SC2034  # Variables used by sourced functions inside subshells
+# shellcheck disable=SC2329  # Functions defined in subshells are invoked by sourced scripts
 
 set -euo pipefail
 
@@ -426,6 +429,208 @@ test_preflight_error_messages_actionable() {
 }
 
 #===============================================================================
+# TEST CASES: SSH Tunnel Connectivity (Issue #255)
+#===============================================================================
+
+test_check_podman_verifies_ssh_connectivity() {
+    log_test "Testing check_podman verifies SSH connectivity on macOS"
+
+    local content
+    content=$(cat "$PREFLIGHT_SCRIPT")
+
+    assert_contains "$content" "_podman_ssh_probe" \
+        "check_podman should call _podman_ssh_probe"
+    assert_contains "$content" "SSH tunnel is broken" \
+        "check_podman should report SSH tunnel broken on probe failure"
+    assert_contains "$content" "is_macos" \
+        "SSH probe should be gated on macOS platform check"
+}
+
+test_ssh_probe_defined_in_compat() {
+    log_test "Testing _podman_ssh_probe is defined in compat.sh"
+
+    local compat_file="$KAPSIS_ROOT/scripts/lib/compat.sh"
+    local content
+    content=$(cat "$compat_file")
+
+    assert_contains "$content" "_podman_ssh_probe()" \
+        "_podman_ssh_probe function should be defined in compat.sh"
+    assert_contains "$content" "podman info" \
+        "_podman_ssh_probe should use 'podman info' as connectivity check"
+    assert_contains "$content" "is_linux" \
+        "_podman_ssh_probe should skip on Linux (native Podman)"
+}
+
+test_ssh_probe_constants_exist() {
+    log_test "Testing SSH probe constants exist in constants.sh"
+
+    local constants_file="$KAPSIS_ROOT/scripts/lib/constants.sh"
+    local content
+    content=$(cat "$constants_file")
+
+    assert_contains "$content" "KAPSIS_DEFAULT_PREFLIGHT_SSH_PROBE_TIMEOUT" \
+        "SSH probe timeout constant should exist"
+    assert_contains "$content" "KAPSIS_DEFAULT_PREFLIGHT_SSH_RECOVERY_RETRIES" \
+        "SSH recovery retries constant should exist"
+    assert_contains "$content" "KAPSIS_DEFAULT_PREFLIGHT_SSH_RECOVERY_DELAY" \
+        "SSH recovery delay constant should exist"
+}
+
+test_backend_validate_has_ssh_recovery() {
+    log_test "Testing backend_validate includes SSH recovery logic"
+
+    local backend_file="$KAPSIS_ROOT/scripts/backends/podman.sh"
+    local content
+    content=$(cat "$backend_file")
+
+    assert_contains "$content" "_podman_ssh_probe" \
+        "backend_validate should call _podman_ssh_probe"
+    assert_contains "$content" "SSH tunnel is stale" \
+        "backend_validate should detect stale SSH tunnel"
+    assert_contains "$content" "podman machine stop" \
+        "backend_validate should attempt stop as part of recovery"
+    assert_contains "$content" "SSH tunnel recovered" \
+        "backend_validate should report successful recovery"
+    assert_contains "$content" "SSH tunnel is broken" \
+        "backend_validate should report if recovery fails"
+}
+
+test_check_podman_fails_on_stale_ssh() {
+    log_test "Testing check_podman fails when SSH tunnel is stale"
+
+    local mock_dir
+    mock_dir=$(mktemp -d)
+
+    # Mock podman: machine inspect returns "running" but podman info fails
+    cat > "$mock_dir/podman" <<'MOCK'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "machine" ]]; then
+    if [[ "${2:-}" == "inspect" ]]; then
+        for arg in "$@"; do
+            if [[ "$arg" == *"{{.State}}"* ]]; then
+                echo "running"
+                exit 0
+            fi
+        done
+        echo "{}"
+        exit 0
+    fi
+    # machine stop / machine start — succeed silently
+    exit 0
+fi
+if [[ "${1:-}" == "info" ]]; then
+    # Simulate stale SSH: podman info fails
+    exit 125
+fi
+exit 0
+MOCK
+    chmod +x "$mock_dir/podman"
+
+    # Mock timeout to just pass through
+    cat > "$mock_dir/timeout" <<'MOCK'
+#!/usr/bin/env bash
+shift  # skip timeout value
+exec "$@"
+MOCK
+    chmod +x "$mock_dir/timeout"
+
+    # Run in a fresh bash process to avoid readonly variable inheritance
+    local test_script="$mock_dir/run-test.sh"
+    cat > "$test_script" <<TESTEOF
+#!/usr/bin/env bash
+set -euo pipefail
+export PATH="$mock_dir:\$PATH"
+source "$KAPSIS_ROOT/scripts/lib/logging.sh"
+log_init "test"
+source "$KAPSIS_ROOT/scripts/lib/compat.sh"
+source "$KAPSIS_ROOT/scripts/lib/constants.sh"
+# Force macOS detection for CI environments
+_KAPSIS_OS="Darwin"
+source "$PREFLIGHT_SCRIPT"
+_PREFLIGHT_ERRORS=0
+_PREFLIGHT_WARNINGS=0
+KAPSIS_PREFLIGHT_SSH_PROBE_TIMEOUT=2
+KAPSIS_PREFLIGHT_SSH_RECOVERY_RETRIES=1
+KAPSIS_PREFLIGHT_SSH_RECOVERY_DELAY=0
+check_podman
+TESTEOF
+    chmod +x "$test_script"
+
+    local output
+    local result=0
+    output=$(bash "$test_script" 2>&1) || result=$?
+
+    rm -rf "$mock_dir"
+
+    assert_not_equals 0 "$result" "check_podman should fail when SSH tunnel is stale"
+    assert_contains "$output" "SSH tunnel is broken" "Should report broken SSH tunnel"
+}
+
+test_check_podman_passes_on_healthy_ssh() {
+    log_test "Testing check_podman passes when SSH tunnel is healthy"
+
+    local mock_dir
+    mock_dir=$(mktemp -d)
+
+    # Mock podman: both inspect and info succeed
+    cat > "$mock_dir/podman" <<'MOCK'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "machine" ]] && [[ "${2:-}" == "inspect" ]]; then
+    for arg in "$@"; do
+        if [[ "$arg" == *"{{.State}}"* ]]; then
+            echo "running"
+            exit 0
+        fi
+    done
+    echo "{}"
+    exit 0
+fi
+if [[ "${1:-}" == "info" ]]; then
+    echo "host:"
+    exit 0
+fi
+exit 0
+MOCK
+    chmod +x "$mock_dir/podman"
+
+    cat > "$mock_dir/timeout" <<'MOCK'
+#!/usr/bin/env bash
+shift
+exec "$@"
+MOCK
+    chmod +x "$mock_dir/timeout"
+
+    # Run in a fresh bash process to avoid readonly variable inheritance
+    local test_script="$mock_dir/run-test.sh"
+    cat > "$test_script" <<TESTEOF
+#!/usr/bin/env bash
+set -euo pipefail
+export PATH="$mock_dir:\$PATH"
+source "$KAPSIS_ROOT/scripts/lib/logging.sh"
+log_init "test"
+source "$KAPSIS_ROOT/scripts/lib/compat.sh"
+source "$KAPSIS_ROOT/scripts/lib/constants.sh"
+# Force macOS detection for CI environments
+_KAPSIS_OS="Darwin"
+source "$PREFLIGHT_SCRIPT"
+_PREFLIGHT_ERRORS=0
+_PREFLIGHT_WARNINGS=0
+KAPSIS_PREFLIGHT_SSH_PROBE_TIMEOUT=2
+check_podman
+TESTEOF
+    chmod +x "$test_script"
+
+    local output
+    local result=0
+    output=$(bash "$test_script" 2>&1) || result=$?
+
+    rm -rf "$mock_dir"
+
+    assert_equals 0 "$result" "check_podman should pass when SSH tunnel is healthy"
+    assert_contains "$output" "SSH tunnel is functional" "Should report functional SSH tunnel"
+}
+
+#===============================================================================
 # MAIN
 #===============================================================================
 
@@ -461,6 +666,14 @@ main() {
     run_test test_preflight_full_pass
     run_test test_preflight_branch_conflict_fails
     run_test test_preflight_error_messages_actionable
+
+    # SSH connectivity tests (Issue #255)
+    run_test test_check_podman_verifies_ssh_connectivity
+    run_test test_ssh_probe_defined_in_compat
+    run_test test_ssh_probe_constants_exist
+    run_test test_backend_validate_has_ssh_recovery
+    run_test test_check_podman_fails_on_stale_ssh
+    run_test test_check_podman_passes_on_healthy_ssh
 
     # Summary
     print_summary


### PR DESCRIPTION
## Summary

Closes #255

- Add `_podman_ssh_probe()` to `compat.sh` — runs `podman info` with timeout to verify the full CLI→SSH→VM→daemon stack (macOS only, no-op on Linux)
- Enhance `check_podman()` in pre-flight to detect stale SSH tunnels after Mac reboot/sleep and auto-recover via `podman machine stop && start` with configurable retries
- Add same SSH probe + recovery to `backend_validate()` in `podman.sh` for defense-in-depth when pre-flight is skipped
- Add 3 configurable constants: `KAPSIS_DEFAULT_PREFLIGHT_SSH_PROBE_TIMEOUT` (10s), `KAPSIS_DEFAULT_PREFLIGHT_SSH_RECOVERY_RETRIES` (2), `KAPSIS_DEFAULT_PREFLIGHT_SSH_RECOVERY_DELAY` (3s)

## Test plan

- [x] shellcheck passes on all 5 modified files
- [x] 24/24 preflight tests pass (6 new SSH connectivity tests)
- [x] 976/976 quick tests pass, 0 failures
- [ ] Manual: suspend Mac, wake, run `./scripts/preflight-check.sh . main` — should auto-recover

🤖 Generated with [Claude Code](https://claude.com/claude-code)