### PR TITLE
fix: detect and recover from hung agent after completion (#257)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -364,9 +364,41 @@ KAPSIS_PUSH_FALLBACK: cd /path/to/worktree && git push -u origin branch-name
 
 **In status.json:** The `push_fallback_command` field contains the same command when `push_status` is `"failed"`.
 
+## Exit Codes
+
+| Code | Meaning | Detection |
+|------|---------|-----------|
+| 0 | Success (changes committed or no changes) | Normal exit |
+| 1 | Agent failure | Container exit non-zero |
+| 2 | Push failed | Post-container push failure |
+| 3 | Uncommitted changes remain | Commit status check |
+| 4 | Mount failure (virtio-fs drop, Issue #248) | `KAPSIS_MOUNT_FAILURE:` sentinel in stderr |
+| 5 | Agent completed but process hung (Issue #257) | Liveness monitor kills + status.json phase is "complete" |
+
 ## Mount Failure Detection (Issue #248)
 
 Exit code 4 indicates a virtio-fs mount drop detected mid-run. The agent writes a `KAPSIS_MOUNT_FAILURE:` sentinel to stderr (which flows through podman's pipe, not virtio-fs). Host-side `launch-agent.sh` detects the sentinel and overrides the exit code. Recovery: `podman machine stop && podman machine start`, then re-run.
+
+## Hung Agent Detection (Issue #257)
+
+Liveness monitoring is **enabled by default** (timeout: 900s). It detects hung agents via three signals: `updated_at` staleness, process tree I/O activity, and active API TCP connections. When all signals are stale, the agent is killed.
+
+Key features:
+- **Descendant I/O monitoring**: Sums I/O across all container processes, not just PID 1
+- **Post-completion short timeout**: 120s when agent reports done but process hasn't exited
+- **API staleness override**: Kills after 1800s even with active API connection (stuck tool call scenario)
+- **Auto-diagnostics**: Captures process tree, FDs, TCP connections before kill
+- **Exit code 5**: Written when agent completed work but process hung (e.g., stuck MCP server or tool call)
+
+Configuration in `agent-sandbox.yaml`:
+```yaml
+liveness:
+  enabled: true          # default: true
+  timeout: 900           # default: 900s
+  completion_timeout: 120  # default: 120s (post-completion)
+  grace_period: 300      # default: 300s
+  check_interval: 30     # default: 30s
+```
 
 ## Cross-Platform Notes
 

--- a/agent-sandbox.yaml.template
+++ b/agent-sandbox.yaml.template
@@ -224,6 +224,31 @@ sandbox:
   interactive_merge: true
 
 #===============================================================================
+# LIVENESS MONITORING (Issue #257)
+#===============================================================================
+# Detects hung agents and auto-kills them after timeout.
+# Monitors: status.json hook updates, /proc I/O activity, API TCP connections.
+# All three signals must be stale to trigger kill.
+liveness:
+  # Enable liveness monitoring (default: true)
+  enabled: true
+
+  # Kill after N seconds of no activity (default: 900)
+  timeout: 900
+
+  # Skip checks for N seconds after start (default: 300)
+  grace_period: 300
+
+  # Check every N seconds (default: 30)
+  check_interval: 30
+
+  # Post-completion timeout: shorter timeout when agent reports done (default: 120)
+  completion_timeout: 120
+
+  # Mount check: detect virtio-fs drops on macOS (default: true)
+  mount_check: true
+
+#===============================================================================
 # GIT WORKFLOW (Auto-Push to Branch for PR Review)
 #===============================================================================
 git:

--- a/docs/CONFIG-REFERENCE.md
+++ b/docs/CONFIG-REFERENCE.md
@@ -851,16 +851,17 @@ image:
 
 ## Liveness Monitoring
 
-Built-in agent liveness monitoring detects and kills hung agent processes. When enabled, a background monitor checks two signals: hook-driven `updated_at` timestamps and `/proc/1/io` disk activity. Both must be stale before the agent is killed (defense against false positives during long thinking phases).
+Built-in agent liveness monitoring detects and kills hung agent processes. **Enabled by default** (Issue #257). The monitor checks three signals: hook-driven `updated_at` timestamps, process tree I/O activity across all container descendants, and active TCP connections to AI API endpoints. All three must be stale before the agent is killed (defense against false positives during long thinking phases or API calls).
 
 ### Configuration
 
 ```yaml
 liveness:
-  enabled: true           # Enable liveness monitoring (default: false)
-  timeout: 1800           # Kill after N seconds of no activity (default: 1800, min: 60)
-  grace_period: 300       # Skip checks for N seconds after start (default: 300)
-  check_interval: 30      # Check every N seconds (default: 30, min: 10)
+  enabled: true              # Enable liveness monitoring (default: true)
+  timeout: 900               # Kill after N seconds of no activity (default: 900, min: 60)
+  grace_period: 300          # Skip checks for N seconds after start (default: 300)
+  check_interval: 30         # Check every N seconds (default: 30, min: 10)
+  completion_timeout: 120    # Shorter timeout when agent reports done (default: 120)
 ```
 
 ### K8s Backend (AgentRequest CR)
@@ -869,7 +870,7 @@ liveness:
 spec:
   liveness:
     enabled: true
-    timeoutSeconds: 1800
+    timeoutSeconds: 900
     gracePeriodSeconds: 300
     checkIntervalSeconds: 30
 ```
@@ -879,9 +880,14 @@ spec:
 1. **Grace period**: No checks for the first `grace_period` seconds after agent start
 2. **Activity check**: Every `check_interval` seconds, monitor reads:
    - `updated_at` from status.json (set by PostToolUse hooks)
-   - `read_bytes + write_bytes` from `/proc/1/io` (kernel I/O counters)
-3. **Kill decision**: If `updated_at` is stale for >= `timeout` seconds AND I/O counters unchanged for 2+ consecutive cycles → SIGTERM, wait 10s, SIGKILL
-4. **Heartbeat**: Monitor writes `heartbeat_at` to status.json on every check cycle (independent of agent activity)
+   - `read_bytes + write_bytes` from `/proc/[0-9]*/io` (all container process I/O)
+   - Active TCP connections to AI API endpoints (port 443)
+3. **Kill decision**: If `updated_at` is stale for >= `timeout` seconds AND I/O counters unchanged for 2+ consecutive cycles AND no active API connections → SIGTERM, wait 10s, SIGKILL
+4. **Post-completion timeout** (Issue #257): When status.json phase is "complete" but process hasn't exited and no API connections exist, the shorter `completion_timeout` (120s) applies instead of the full timeout
+5. **API staleness override** (Issue #257): If `updated_at` is stale for >= 1800s but an API connection exists, the agent is killed anyway — this catches stuck tool calls where the API connection stays alive indefinitely
+6. **Exit code 5**: When liveness kills an agent that had completed its work (phase="complete"/"committing"/"pushing"), exit code 5 is used instead of 137
+7. **Auto-diagnostics**: Before killing, captures process tree, open FDs, TCP connections, and status.json to `kapsis-liveness-diagnostics.txt`
+8. **Heartbeat**: Monitor writes `heartbeat_at` to status.json on every check cycle (independent of agent activity)
 
 ### Claude Hang Fix
 

--- a/docs/STATUS-TRACKING.md
+++ b/docs/STATUS-TRACKING.md
@@ -176,6 +176,7 @@ Configuration is stored in `configs/tool-phase-mapping.yaml`.
 | 2 | Push failed | Run push fallback command |
 | 3 | Uncommitted changes | Manually commit from worktree |
 | 4 | Mount failure (virtio-fs drop) | `podman machine stop && start`, re-run |
+| 5 | Agent completed but process hung (Issue #257) | Work is saved; check diagnostics file |
 | 137 | Killed by liveness monitor (SIGKILL) | Check agent for hangs |
 | 143 | Killed by liveness monitor (SIGTERM) | Check agent for hangs |
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1685,7 +1685,7 @@ main() {
 
     # Start liveness monitor if enabled (background process, survives exec)
     # Must happen after status_init (writes to status.json) and before exec
-    if [[ "${KAPSIS_LIVENESS_ENABLED:-false}" == "true" ]]; then
+    if [[ "${KAPSIS_LIVENESS_ENABLED:-true}" == "true" ]]; then
         local liveness_lib="${KAPSIS_HOME:-/opt/kapsis}/lib/liveness-monitor.sh"
         if [[ -f "$liveness_lib" ]]; then
             source "$liveness_lib"
@@ -1698,7 +1698,7 @@ main() {
     # Start standalone mount check if liveness is disabled (Issue #248)
     # When liveness IS enabled, mount check is integrated into its loop above
     if [[ "${KAPSIS_MOUNT_CHECK_ENABLED:-false}" == "true" ]] \
-       && [[ "${KAPSIS_LIVENESS_ENABLED:-false}" != "true" ]]; then
+       && [[ "${KAPSIS_LIVENESS_ENABLED:-true}" != "true" ]]; then
         local liveness_lib="${KAPSIS_HOME:-/opt/kapsis}/lib/liveness-monitor.sh"
         if [[ -f "$liveness_lib" ]]; then
             # Source guard in liveness-monitor.sh prevents double-sourcing

--- a/scripts/launch-agent.sh
+++ b/scripts/launch-agent.sh
@@ -827,10 +827,11 @@ parse_config() {
         LSP_SERVERS_JSON=$(yq -r '.lsp_servers // {} | tojson' "$CONFIG_FILE" 2>/dev/null || echo "{}")
 
         # Parse liveness monitoring configuration
-        LIVENESS_ENABLED=$(yq -r '.liveness.enabled // "false"' "$CONFIG_FILE" 2>/dev/null || echo "false")
-        LIVENESS_TIMEOUT=$(yq -r '.liveness.timeout // "1800"' "$CONFIG_FILE" 2>/dev/null || echo "1800")
+        LIVENESS_ENABLED=$(yq -r '.liveness.enabled // "true"' "$CONFIG_FILE" 2>/dev/null || echo "true")
+        LIVENESS_TIMEOUT=$(yq -r '.liveness.timeout // "900"' "$CONFIG_FILE" 2>/dev/null || echo "900")
         LIVENESS_GRACE_PERIOD=$(yq -r '.liveness.grace_period // "300"' "$CONFIG_FILE" 2>/dev/null || echo "300")
         LIVENESS_CHECK_INTERVAL=$(yq -r '.liveness.check_interval // "30"' "$CONFIG_FILE" 2>/dev/null || echo "30")
+        LIVENESS_COMPLETION_TIMEOUT=$(yq -r '.liveness.completion_timeout // "120"' "$CONFIG_FILE" 2>/dev/null || echo "120")
 
         # Parse mount check configuration (Issue #248)
         # Defaults to true when liveness section exists, since mount checking is lightweight
@@ -1842,12 +1843,13 @@ generate_env_vars() {
         ENV_VARS+=("-e" "KAPSIS_LSP_SERVERS_JSON=${LSP_SERVERS_JSON}")
     fi
 
-    # Liveness monitoring env vars
-    if [[ "${LIVENESS_ENABLED:-false}" == "true" ]]; then
+    # Liveness monitoring env vars (Issue #257: enabled by default)
+    if [[ "${LIVENESS_ENABLED:-true}" == "true" ]]; then
         ENV_VARS+=("-e" "KAPSIS_LIVENESS_ENABLED=true")
-        ENV_VARS+=("-e" "KAPSIS_LIVENESS_TIMEOUT=${LIVENESS_TIMEOUT:-1800}")
+        ENV_VARS+=("-e" "KAPSIS_LIVENESS_TIMEOUT=${LIVENESS_TIMEOUT:-900}")
         ENV_VARS+=("-e" "KAPSIS_LIVENESS_GRACE_PERIOD=${LIVENESS_GRACE_PERIOD:-300}")
         ENV_VARS+=("-e" "KAPSIS_LIVENESS_CHECK_INTERVAL=${LIVENESS_CHECK_INTERVAL:-30}")
+        ENV_VARS+=("-e" "KAPSIS_LIVENESS_COMPLETION_TIMEOUT=${LIVENESS_COMPLETION_TIMEOUT:-120}")
     fi
 
     # Mount check env vars (Issue #248) — independent of liveness enabled
@@ -2504,6 +2506,17 @@ main() {
         fi
     fi
 
+    # Check for hung-after-completion in status.json (Issue #257)
+    # When liveness monitor kills AND agent had completed work, exit_code 5 is in status.json
+    if [[ "$EXIT_CODE" -eq 143 || "$EXIT_CODE" -eq 137 ]]; then
+        local status_exit
+        status_exit=$(status_get_exit_code 2>/dev/null || echo "")
+        if [[ "$status_exit" == "5" ]]; then
+            log_warn "Agent completed but process hung (exit code 5 from liveness monitor)"
+            EXIT_CODE=5
+        fi
+    fi
+
     rm -f "$container_output"
     # Update status to post_processing (Fix #3: don't report "completed" until commit verified)
     status_phase "post_processing" 85 "Processing agent output (exit code: $EXIT_CODE)"
@@ -2541,11 +2554,13 @@ main() {
     log_timer_end "total"
 
     # Combine exit codes - fail if either container or post-container operations failed
-    # Exit codes (Fix #3):
+    # Exit codes (Fix #3, Issue #257):
     #   0 = Success (changes committed or no changes)
     #   1 = Agent failure (container exit code non-zero)
     #   2 = Push failed
     #   3 = Uncommitted changes remain
+    #   4 = Mount failure (virtio-fs drop)
+    #   5 = Agent completed but process hung (stuck child process)
     if [[ "$EXIT_CODE" -eq 4 ]]; then
         # Mount failure detected via sentinel (Issue #248)
         FINAL_EXIT_CODE=4
@@ -2554,6 +2569,15 @@ main() {
         status_complete 4 "$mount_error"
         _STATUS_COMPLETE_SHOWN=true
         display_complete 4 "" "$mount_error"
+        _DISPLAY_COMPLETE_SHOWN=true
+    elif [[ "$EXIT_CODE" -eq 5 ]]; then
+        # Agent completed but process hung (Issue #257)
+        FINAL_EXIT_CODE=5
+        log_finalize 5
+        local hung_error="Agent completed work but process hung (killed by liveness monitor). Likely cause: stuck child process (e.g., tool call subprocess)."
+        status_complete 5 "$hung_error"
+        _STATUS_COMPLETE_SHOWN=true
+        display_complete 5 "" "$hung_error"
         _DISPLAY_COMPLETE_SHOWN=true
     elif [[ "$EXIT_CODE" -ne 0 ]]; then
         FINAL_EXIT_CODE=$EXIT_CODE

--- a/scripts/lib/constants.sh
+++ b/scripts/lib/constants.sh
@@ -284,3 +284,7 @@ readonly KAPSIS_DEFAULT_CLEANUP_VM_SSH_TIMEOUT=15
 
 # Workspace mount lost during execution (macOS virtio-fs drop)
 readonly KAPSIS_EXIT_MOUNT_FAILURE=4
+
+# Agent completed work but process hung (Issue #257)
+# e.g., child process (MCP server, stuck tool call) keeps container alive
+readonly KAPSIS_EXIT_HUNG_AFTER_COMPLETION=5

--- a/scripts/lib/liveness-monitor.sh
+++ b/scripts/lib/liveness-monitor.sh
@@ -47,7 +47,7 @@ _KAPSIS_LIVENESS_MONITOR_LOADED=1
 # Configuration
 #===============================================================================
 
-_LIVENESS_TIMEOUT="${KAPSIS_LIVENESS_TIMEOUT:-1800}"
+_LIVENESS_TIMEOUT="${KAPSIS_LIVENESS_TIMEOUT:-900}"
 _LIVENESS_GRACE="${KAPSIS_LIVENESS_GRACE_PERIOD:-300}"
 _LIVENESS_INTERVAL="${KAPSIS_LIVENESS_CHECK_INTERVAL:-30}"
 
@@ -55,7 +55,15 @@ _LIVENESS_INTERVAL="${KAPSIS_LIVENESS_CHECK_INTERVAL:-30}"
 _LIVENESS_IPS_TTL="${KAPSIS_LIVENESS_IPS_TTL:-300}"
 _LIVENESS_DNS_TIMEOUT="${KAPSIS_LIVENESS_DNS_TIMEOUT:-2}"
 _LIVENESS_MAX_IPS_PER_DOMAIN="${KAPSIS_LIVENESS_MAX_IPS_PER_DOMAIN:-8}"
-_LIVENESS_API_MAX_SKIP="${KAPSIS_LIVENESS_API_MAX_SKIP:-240}"
+_LIVENESS_API_MAX_SKIP="${KAPSIS_LIVENESS_API_MAX_SKIP:-60}"
+
+# Post-completion short timeout (Issue #257): when agent reports completion
+# but process hasn't exited, use this shorter timeout instead of the full timeout
+_LIVENESS_COMPLETION_TIMEOUT="${KAPSIS_LIVENESS_COMPLETION_TIMEOUT:-120}"
+
+# API staleness override (Issue #257): kill even when API connection exists
+# if updated_at has been stale for this many seconds (stuck mid-tool-call scenario)
+_LIVENESS_API_STALENESS_OVERRIDE="${KAPSIS_LIVENESS_API_STALENESS_OVERRIDE:-1800}"
 
 # Mount check configuration (Issue #248) — independent of liveness timeout kill
 _MOUNT_CHECK_ENABLED="${KAPSIS_MOUNT_CHECK_ENABLED:-false}"
@@ -107,15 +115,15 @@ _liveness_log() {
 # I/O Monitoring
 #===============================================================================
 
-# Read total I/O bytes (read + write) from /proc/<pid>/io
+# Read total I/O bytes (read + write) across all container processes (Issue #257)
+# In container PID namespace, /proc/[0-9]*/io covers only container processes.
+# Summing all descendants detects I/O from child processes (MCP servers, tool calls)
+# that PID 1's /proc/1/io alone would miss.
 # Returns 0 if /proc/io is unavailable (e.g., restricted permissions)
 _liveness_get_io_total() {
     local pid="$1"
-    if [[ -r "/proc/${pid}/io" ]]; then
-        awk '/^(read|write)_bytes:/ {s+=$2} END {print s+0}' "/proc/${pid}/io" 2>/dev/null || echo "0"
-    else
-        echo "0"
-    fi
+    # shellcheck disable=SC2086,SC2035
+    awk '/^(read|write)_bytes:/ {s+=$2} END {print s+0}' /proc/[0-9]*/io 2>/dev/null || echo "0"
 }
 
 #===============================================================================
@@ -138,6 +146,26 @@ _liveness_get_updated_at() {
         local content
         content=$(cat "$status_file" 2>/dev/null) || return
         if [[ "$content" =~ \"updated_at\":\ *\"([^\"]*)\" ]]; then
+            echo "${BASH_REMATCH[1]}"
+        fi
+    fi
+}
+
+# Get phase from status.json (Issue #257)
+# Uses native bash regex to avoid subprocess overhead (same pattern as _liveness_get_updated_at)
+_liveness_get_phase() {
+    local status_dir="/kapsis-status"
+    [[ -d "$status_dir" ]] || status_dir="${HOME}/.kapsis/status"
+
+    local status_file
+    for f in "$status_dir"/kapsis-*.json; do
+        [[ -f "$f" ]] && status_file="$f" && break
+    done
+
+    if [[ -n "${status_file:-}" && -f "$status_file" ]]; then
+        local content
+        content=$(cat "$status_file" 2>/dev/null) || return
+        if [[ "$content" =~ \"phase\":\ *\"([^\"]*)\" ]]; then
             echo "${BASH_REMATCH[1]}"
         fi
     fi
@@ -170,12 +198,19 @@ _liveness_write_heartbeat() {
     fi
 }
 
-# Write killed status to status.json
+# Write killed status to status.json (Issue #257: exit code 5 when post-completion)
 _liveness_write_killed_status() {
     local reason="$1"
     if type status_phase &>/dev/null && type status_complete &>/dev/null; then
         if type status_is_active &>/dev/null && status_is_active; then
-            status_complete 137 "Agent killed by liveness monitor: $reason"
+            local phase
+            phase=$(_liveness_get_phase)
+            local exit_code=137
+            if [[ "$phase" == "complete" || "$phase" == "committing" || "$phase" == "pushing" ]]; then
+                exit_code=5
+                _liveness_log "INFO" "Phase is '$phase' — using exit code 5 (hung after completion)"
+            fi
+            status_complete "$exit_code" "Agent killed by liveness monitor: $reason"
         fi
     fi
 }
@@ -565,6 +600,93 @@ _mount_check_kill_agent() {
 }
 
 #===============================================================================
+# Pre-Kill Diagnostics (Issue #257)
+#===============================================================================
+
+# Capture diagnostic information before killing the agent.
+# Writes to a diagnostics file alongside status.json for post-mortem analysis.
+# Must be fast — budget 5s max before SIGTERM.
+_liveness_capture_diagnostics() {
+    local pid="$1"
+    local reason="$2"
+    local stale_seconds="$3"
+
+    local diag_dir="/kapsis-status"
+    [[ -d "$diag_dir" ]] || diag_dir="${HOME}/.kapsis/status"
+
+    local diag_file="${diag_dir}/kapsis-liveness-diagnostics.txt"
+    local ts
+    ts=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+
+    {
+        echo "=== Kapsis Liveness Kill Diagnostics ==="
+        echo "Timestamp: $ts"
+        echo "Reason: $reason"
+        echo "Staleness: ${stale_seconds}s"
+        echo "Agent PID: $pid"
+        echo ""
+
+        echo "=== Process Tree ==="
+        ps aux 2>/dev/null || echo "(ps unavailable)"
+        echo ""
+
+        echo "=== Open File Descriptors (PID $pid) ==="
+        ls -la "/proc/${pid}/fd/" 2>/dev/null || echo "(fd listing unavailable)"
+        echo ""
+
+        echo "=== TCP Connections ==="
+        if [[ -n "${_LIVENESS_SS_BIN:-}" ]]; then
+            "$_LIVENESS_SS_BIN" -tpn 2>/dev/null || echo "(ss unavailable)"
+        elif [[ -r /proc/net/tcp ]]; then
+            echo "--- /proc/net/tcp ---"
+            cat /proc/net/tcp 2>/dev/null || true
+            echo "--- /proc/net/tcp6 ---"
+            cat /proc/net/tcp6 2>/dev/null || true
+        else
+            echo "(no tcp info available)"
+        fi
+        echo ""
+
+        echo "=== Status JSON ==="
+        local status_file
+        for f in "$diag_dir"/kapsis-*.json; do
+            [[ -f "$f" ]] && status_file="$f" && break
+        done
+        if [[ -n "${status_file:-}" ]]; then
+            cat "$status_file" 2>/dev/null || echo "(status file unreadable)"
+        else
+            echo "(no status file found)"
+        fi
+        echo ""
+
+        echo "=== Descendant Process I/O ==="
+        local proc_pid
+        for proc_io in /proc/[0-9]*/io; do
+            proc_pid="${proc_io#/proc/}"
+            proc_pid="${proc_pid%/io}"
+            echo "--- PID $proc_pid ---"
+            cat "$proc_io" 2>/dev/null || echo "(unreadable)"
+        done
+        echo ""
+
+        echo "=== Process States ==="
+        local name state
+        for proc_status in /proc/[0-9]*/status; do
+            proc_pid="${proc_status#/proc/}"
+            proc_pid="${proc_pid%/status}"
+            name=$(awk '/^Name:/ {print $2}' "$proc_status" 2>/dev/null) || name="?"
+            state=$(awk '/^State:/ {print $2}' "$proc_status" 2>/dev/null) || state="?"
+            echo "PID $proc_pid: $name ($state)"
+        done
+
+        echo ""
+        echo "=== End Diagnostics ==="
+    } > "$diag_file" 2>/dev/null || true
+
+    _liveness_log "INFO" "Diagnostics captured to $diag_file"
+}
+
+#===============================================================================
 # Kill Decision
 #===============================================================================
 
@@ -592,7 +714,17 @@ _liveness_should_kill() {
         local prev_io_cycles="$_io_stale_ref"
         _io_stale_ref=0
         (( _LIVENESS_API_SKIP_COUNT++ )) || true
-        if [[ "$_LIVENESS_API_SKIP_COUNT" -ge "$_LIVENESS_API_MAX_SKIP" ]]; then
+
+        # Issue #257: Time-based override — if updated_at stale for >N seconds
+        # AND API connection exists, the agent is likely stuck mid-tool-call.
+        # This catches the case where a hung child process (e.g., jira CLI) blocks
+        # the tool call, keeping the API connection alive indefinitely.
+        if [[ "$stale_seconds" -ge "$_LIVENESS_API_STALENESS_OVERRIDE" ]]; then
+            _liveness_log "WARN" "API connection active but updated_at stale for ${stale_seconds}s (>= ${_LIVENESS_API_STALENESS_OVERRIDE}s) — overriding API protection"
+            _LIVENESS_API_SKIP_COUNT=0
+            _io_stale_ref="$prev_io_cycles"
+            # fall through — return 0 (kill)
+        elif [[ "$_LIVENESS_API_SKIP_COUNT" -ge "$_LIVENESS_API_MAX_SKIP" ]]; then
             # Layer 3: cap exceeded — kill anyway to prevent indefinite bypass
             _liveness_log "WARN" "API skip cap exceeded (${_LIVENESS_API_SKIP_COUNT}/${_LIVENESS_API_MAX_SKIP}), proceeding with kill"
             _LIVENESS_API_SKIP_COUNT=0
@@ -697,14 +829,35 @@ _liveness_monitor_loop() {
             prev_updated_at="$current_updated_at"
         fi
 
+        # Issue #257: Phase-aware timeout — if agent reported completion but
+        # process hasn't exited, use shorter timeout (stuck child process scenario)
+        local effective_timeout="$timeout"
+        local current_phase
+        current_phase=$(_liveness_get_phase)
+        if [[ "$current_phase" == "complete" || "$current_phase" == "committing" || "$current_phase" == "pushing" ]]; then
+            if ! _liveness_has_active_api_connections; then
+                effective_timeout="$_LIVENESS_COMPLETION_TIMEOUT"
+                _liveness_log "DEBUG" "Phase=$current_phase, no API connections — using completion timeout (${effective_timeout}s)"
+            else
+                _liveness_log "DEBUG" "Phase=$current_phase but API connection active — using normal timeout"
+            fi
+        fi
+
         # Decision logic: kill only when all three signals are stale
-        if _liveness_should_kill "$stale_seconds" "$timeout" io_stale_cycles; then
+        if _liveness_should_kill "$stale_seconds" "$effective_timeout" io_stale_cycles; then
             # All three signals stale (or cap exceeded): agent is hung
-            _liveness_log "WARN" "Agent hung detected! updated_at stale for ${stale_seconds}s, I/O unchanged for ${io_stale_cycles} cycles"
+            local kill_type="standard hung"
+            if [[ "$current_phase" == "complete" || "$current_phase" == "committing" || "$current_phase" == "pushing" ]]; then
+                kill_type="hung after completion (phase=$current_phase)"
+            fi
+            _liveness_log "WARN" "Agent $kill_type detected! updated_at stale for ${stale_seconds}s, I/O unchanged for ${io_stale_cycles} cycles"
             _liveness_log "WARN" "Sending SIGTERM to PID $pid"
 
+            # Issue #257: Capture diagnostics before kill
+            _liveness_capture_diagnostics "$pid" "No activity for ${stale_seconds}s ($kill_type)" "$stale_seconds"
+
             # Write killed status before sending signal
-            _liveness_write_killed_status "No activity for ${stale_seconds}s (updated_at stale, I/O idle)"
+            _liveness_write_killed_status "No activity for ${stale_seconds}s ($kill_type)"
 
             # SIGTERM first, then SIGKILL after 10s
             kill -SIGTERM "$pid" 2>/dev/null || true
@@ -765,7 +918,7 @@ _mount_check_loop() {
 # Start the liveness monitor as a background process
 # Must be called before exec (after which PID 1 becomes the agent)
 start_liveness_monitor() {
-    if [[ "${KAPSIS_LIVENESS_ENABLED:-false}" != "true" ]]; then
+    if [[ "${KAPSIS_LIVENESS_ENABLED:-true}" != "true" ]]; then
         return 0
     fi
 

--- a/scripts/lib/status.sh
+++ b/scripts/lib/status.sh
@@ -660,6 +660,17 @@ status_get_phase() {
     fi
 }
 
+# Get exit code from status file (for host-side scripts reading container status)
+status_get_exit_code() {
+    if [[ -f "$_KAPSIS_STATUS_FILE" ]]; then
+        local content
+        content=$(<"$_KAPSIS_STATUS_FILE") 2>/dev/null || return
+        if [[ "$content" =~ \"exit_code\":\ *([0-9]+) ]]; then
+            echo "${BASH_REMATCH[1]}"
+        fi
+    fi
+}
+
 # Check if status tracking is active
 status_is_active() {
     [[ "$KAPSIS_STATUS_ENABLED" == "true" && "$_KAPSIS_STATUS_INITIALIZED" == "true" ]]

--- a/tests/test-liveness-monitor.sh
+++ b/tests/test-liveness-monitor.sh
@@ -110,14 +110,17 @@ test_liveness_config_defaults() {
         unset KAPSIS_LIVENESS_TIMEOUT KAPSIS_LIVENESS_GRACE_PERIOD KAPSIS_LIVENESS_CHECK_INTERVAL
         source "$KAPSIS_ROOT/scripts/lib/liveness-monitor.sh"
 
-        # Check defaults are set correctly
-        [[ "$_LIVENESS_TIMEOUT" == "1800" ]] || exit 1
+        # Check defaults are set correctly (Issue #257: timeout 1800→900, API max skip 240→60)
+        [[ "$_LIVENESS_TIMEOUT" == "900" ]] || exit 1
         [[ "$_LIVENESS_GRACE" == "300" ]] || exit 2
         [[ "$_LIVENESS_INTERVAL" == "30" ]] || exit 3
+        [[ "$_LIVENESS_API_MAX_SKIP" == "60" ]] || exit 4
+        [[ "$_LIVENESS_COMPLETION_TIMEOUT" == "120" ]] || exit 5
+        [[ "$_LIVENESS_API_STALENESS_OVERRIDE" == "1800" ]] || exit 6
     ) 2>/dev/null
     local exit_code=$?
 
-    assert_equals 0 "$exit_code" "Should have correct defaults (1800/300/30)"
+    assert_equals 0 "$exit_code" "Should have correct defaults (900/300/30/60/120/1800)"
 }
 
 test_liveness_config_custom_values() {
@@ -412,6 +415,7 @@ test_liveness_skip_kill_when_api_connection() {
 
         _LIVENESS_API_SKIP_COUNT=0
         _LIVENESS_API_MAX_SKIP=240
+        _LIVENESS_API_STALENESS_OVERRIDE=99999  # Prevent staleness override from triggering
 
         local cycles=5
         if _liveness_should_kill 9999 1800 cycles; then
@@ -954,6 +958,276 @@ test_mount_check_config_custom_values() {
 }
 
 #===============================================================================
+# ISSUE #257 TESTS: hung agent detection
+#===============================================================================
+
+test_liveness_get_phase() {
+    log_test "Testing _liveness_get_phase extracts phase from status.json"
+
+    local err exit_code=0
+    err=$(
+        source "$KAPSIS_ROOT/scripts/lib/liveness-monitor.sh"
+
+        # Create a mock status dir with a status file
+        local status_dir
+        status_dir=$(mktemp -d)
+        mkdir -p "$status_dir"
+        cat > "$status_dir/kapsis-test-1.json" << 'STATUSEOF'
+{
+  "phase": "complete",
+  "updated_at": "2026-03-22T10:30:00Z"
+}
+STATUSEOF
+
+        # Override status dir discovery
+        _liveness_get_phase() {
+            local content
+            content=$(cat "$status_dir/kapsis-test-1.json" 2>/dev/null) || return
+            if [[ "$content" =~ \"phase\":\ *\"([^\"]*)\" ]]; then
+                echo "${BASH_REMATCH[1]}"
+            fi
+        }
+
+        local phase
+        phase=$(_liveness_get_phase)
+        [[ "$phase" == "complete" ]] || { echo "Expected 'complete', got '$phase'"; exit 1; }
+
+        rm -rf "$status_dir"
+    ) 2>&1 || exit_code=$?
+
+    assert_equals 0 "$exit_code" "Should extract phase from status.json: $err"
+}
+
+test_liveness_get_phase_running() {
+    log_test "Testing _liveness_get_phase returns 'running' when agent is active"
+
+    local err exit_code=0
+    err=$(
+        source "$KAPSIS_ROOT/scripts/lib/liveness-monitor.sh"
+
+        local status_dir
+        status_dir=$(mktemp -d)
+        cat > "$status_dir/kapsis-test-1.json" << 'STATUSEOF'
+{
+  "phase": "running",
+  "updated_at": "2026-03-22T10:30:00Z"
+}
+STATUSEOF
+
+        _liveness_get_phase() {
+            local content
+            content=$(cat "$status_dir/kapsis-test-1.json" 2>/dev/null) || return
+            if [[ "$content" =~ \"phase\":\ *\"([^\"]*)\" ]]; then
+                echo "${BASH_REMATCH[1]}"
+            fi
+        }
+
+        local phase
+        phase=$(_liveness_get_phase)
+        [[ "$phase" == "running" ]] || { echo "Expected 'running', got '$phase'"; exit 1; }
+
+        rm -rf "$status_dir"
+    ) 2>&1 || exit_code=$?
+
+    assert_equals 0 "$exit_code" "Should extract 'running' phase: $err"
+}
+
+test_liveness_exit_code_5_on_completion() {
+    log_test "Testing _liveness_write_killed_status uses exit 5 when phase=complete"
+
+    local err exit_code=0
+    err=$(
+        source "$KAPSIS_ROOT/scripts/lib/liveness-monitor.sh"
+
+        # Mock _liveness_get_phase to return "complete"
+        _liveness_get_phase() { echo "complete"; }
+
+        # Track what status_complete was called with
+        local captured_exit_code=""
+        status_phase() { true; }
+        status_complete() { captured_exit_code="$1"; }
+        status_is_active() { return 0; }
+
+        _liveness_write_killed_status "test reason"
+
+        [[ "$captured_exit_code" == "5" ]] || { echo "Expected exit code 5, got '$captured_exit_code'"; exit 1; }
+    ) 2>&1 || exit_code=$?
+
+    assert_equals 0 "$exit_code" "Should use exit code 5 when phase=complete: $err"
+}
+
+test_liveness_exit_code_137_when_running() {
+    log_test "Testing _liveness_write_killed_status uses exit 137 when phase=running"
+
+    local err exit_code=0
+    err=$(
+        source "$KAPSIS_ROOT/scripts/lib/liveness-monitor.sh"
+
+        _liveness_get_phase() { echo "running"; }
+
+        local captured_exit_code=""
+        status_phase() { true; }
+        status_complete() { captured_exit_code="$1"; }
+        status_is_active() { return 0; }
+
+        _liveness_write_killed_status "test reason"
+
+        [[ "$captured_exit_code" == "137" ]] || { echo "Expected exit code 137, got '$captured_exit_code'"; exit 1; }
+    ) 2>&1 || exit_code=$?
+
+    assert_equals 0 "$exit_code" "Should use exit code 137 when phase=running: $err"
+}
+
+test_liveness_io_total_descendants() {
+    log_test "Testing I/O total sums across multiple process io files"
+
+    local tmpdir
+    tmpdir=$(mktemp -d)
+
+    # Create mock /proc/<pid>/io files
+    create_mock_proc_io "$tmpdir/1" 1000 2000   # PID 1: 3000
+    create_mock_proc_io "$tmpdir/2" 500 500      # PID 2: 1000
+    create_mock_proc_io "$tmpdir/3" 100 200      # PID 3: 300
+
+    # Test the awk command directly (same as _liveness_get_io_total uses)
+    local io_total
+    io_total=$(awk '/^(read|write)_bytes:/ {s+=$2} END {print s+0}' "$tmpdir"/[0-9]*/io 2>/dev/null || echo "0")
+
+    assert_equals "4300" "$io_total" "Should sum I/O across all processes (3000+1000+300)"
+
+    rm -rf "$tmpdir"
+}
+
+test_liveness_api_staleness_override() {
+    log_test "Testing _liveness_should_kill triggers kill via API staleness override"
+
+    local err exit_code=0
+    err=$(
+        source "$KAPSIS_ROOT/scripts/lib/liveness-monitor.sh"
+        _liveness_has_active_api_connections() { return 0; }  # API active
+        _liveness_log() { true; }
+
+        _LIVENESS_API_SKIP_COUNT=0
+        _LIVENESS_API_MAX_SKIP=999  # High cap — won't be reached
+        _LIVENESS_API_STALENESS_OVERRIDE=1800  # Override at 30 min
+
+        local cycles=5
+        # stale_seconds=2000 > 1800 → should trigger staleness override
+        if ! _liveness_should_kill 2000 900 cycles; then
+            echo "ERROR: should_kill returned 1 (spare) but staleness override should trigger"
+            exit 1
+        fi
+
+        # cycles should be restored
+        [[ "$cycles" -eq 5 ]] || { echo "Expected cycles=5 (restored), got $cycles"; exit 2; }
+    ) 2>&1 || exit_code=$?
+
+    assert_equals 0 "$exit_code" "Should kill via API staleness override: $err"
+}
+
+test_liveness_api_staleness_no_override_below_threshold() {
+    log_test "Testing _liveness_should_kill skips kill when below staleness override"
+
+    local err exit_code=0
+    err=$(
+        source "$KAPSIS_ROOT/scripts/lib/liveness-monitor.sh"
+        _liveness_has_active_api_connections() { return 0; }  # API active
+        _liveness_log() { true; }
+
+        _LIVENESS_API_SKIP_COUNT=0
+        _LIVENESS_API_MAX_SKIP=999
+        _LIVENESS_API_STALENESS_OVERRIDE=1800
+
+        local cycles=5
+        # stale_seconds=1500 < 1800 → should NOT trigger staleness override
+        if _liveness_should_kill 1500 900 cycles; then
+            echo "ERROR: should_kill returned 0 (kill) but staleness override should NOT trigger"
+            exit 1
+        fi
+    ) 2>&1 || exit_code=$?
+
+    assert_equals 0 "$exit_code" "Should not kill below staleness override threshold: $err"
+}
+
+test_liveness_diagnostics_capture() {
+    log_test "Testing _liveness_capture_diagnostics creates diagnostics file"
+
+    local err exit_code=0
+    err=$(
+        source "$KAPSIS_ROOT/scripts/lib/liveness-monitor.sh"
+
+        local diag_dir
+        diag_dir=$(mktemp -d)
+
+        # Override the diagnostics dir path
+        _liveness_capture_diagnostics() {
+            local pid="$1"
+            local reason="$2"
+            local stale_seconds="$3"
+            local diag_file="${diag_dir}/kapsis-liveness-diagnostics.txt"
+
+            {
+                echo "=== Kapsis Liveness Kill Diagnostics ==="
+                echo "Reason: $reason"
+                echo "Staleness: ${stale_seconds}s"
+                echo "=== Process Tree ==="
+                echo "test process tree"
+                echo "=== End Diagnostics ==="
+            } > "$diag_file" 2>/dev/null || true
+        }
+
+        _liveness_capture_diagnostics 1 "test reason" 900
+
+        local diag_file="${diag_dir}/kapsis-liveness-diagnostics.txt"
+        [[ -f "$diag_file" ]] || { echo "Diagnostics file not created"; exit 1; }
+        grep -q "Kapsis Liveness Kill Diagnostics" "$diag_file" || { echo "Missing header"; exit 2; }
+        grep -q "test reason" "$diag_file" || { echo "Missing reason"; exit 3; }
+        grep -q "End Diagnostics" "$diag_file" || { echo "Missing footer"; exit 4; }
+
+        rm -rf "$diag_dir"
+    ) 2>&1 || exit_code=$?
+
+    assert_equals 0 "$exit_code" "Should create diagnostics file with expected sections: $err"
+}
+
+test_liveness_exit_code_5_constant() {
+    log_test "Testing KAPSIS_EXIT_HUNG_AFTER_COMPLETION constant is defined"
+
+    (
+        source "$KAPSIS_ROOT/scripts/lib/constants.sh"
+        [[ "$KAPSIS_EXIT_HUNG_AFTER_COMPLETION" == "5" ]] || exit 1
+    ) 2>/dev/null
+    local exit_code=$?
+
+    assert_equals 0 "$exit_code" "KAPSIS_EXIT_HUNG_AFTER_COMPLETION should be 5"
+}
+
+test_status_get_exit_code() {
+    log_test "Testing status_get_exit_code reads exit_code from status file"
+
+    (
+        export KAPSIS_STATUS_DIR
+        KAPSIS_STATUS_DIR=$(mktemp -d)
+        export KAPSIS_STATUS_ENABLED=true
+        source "$KAPSIS_ROOT/scripts/lib/status.sh"
+        status_init "test-project" "test-ec5" "main" "overlay"
+
+        # Write a complete status with exit code 5
+        status_complete 5 "Agent killed by liveness monitor"
+
+        local ec
+        ec=$(status_get_exit_code)
+        [[ "$ec" == "5" ]] || exit 1
+
+        rm -f "$_KAPSIS_STATUS_FILE"
+        rm -rf "$KAPSIS_STATUS_DIR"
+    ) 2>/dev/null
+    local exit_code=$?
+
+    assert_equals 0 "$exit_code" "Should read exit_code 5 from status file"
+}
+
+#===============================================================================
 # MAIN
 #===============================================================================
 
@@ -1001,6 +1275,18 @@ main() {
     run_test test_health_flag_requires_args
     run_test test_health_json_output_valid
     run_test test_health_not_found
+
+    # Issue #257 tests: hung agent detection
+    run_test test_liveness_get_phase
+    run_test test_liveness_get_phase_running
+    run_test test_liveness_exit_code_5_on_completion
+    run_test test_liveness_exit_code_137_when_running
+    run_test test_liveness_io_total_descendants
+    run_test test_liveness_api_staleness_override
+    run_test test_liveness_api_staleness_no_override_below_threshold
+    run_test test_liveness_diagnostics_capture
+    run_test test_liveness_exit_code_5_constant
+    run_test test_status_get_exit_code
 
     # Mount check tests (Issue #248)
     run_test test_mount_check_probe_healthy


### PR DESCRIPTION
## Summary

- **Enable liveness by default** (timeout 900s, was off) — agents are now monitored out of the box
- **Exit code 5** = "agent completed but process hung" — distinguishes from generic liveness kill (137)
- **Descendant I/O monitoring** — sums `/proc/[0-9]*/io` across all container processes, not just PID 1
- **Post-completion short timeout** (120s) — when status.json phase is "complete" but process hasn't exited
- **API staleness override** (1800s) — kills even with active API connection if `updated_at` is stale, catching stuck tool calls (root cause: `jira` CLI hung on `unix_stream_data_wait`)
- **Auto-diagnostics** — captures process tree, FDs, TCP connections before kill to `kapsis-liveness-diagnostics.txt`
- **Reduced API safety cap** (240→60 cycles, ~30min) — faster detection of stuck-mid-turn agents

Closes #257

## Files changed (10)

| File | Change |
|------|--------|
| `scripts/lib/liveness-monitor.sh` | Core: descendant I/O, phase detection, diagnostics, completion timeout, API override, new defaults |
| `scripts/lib/constants.sh` | `KAPSIS_EXIT_HUNG_AFTER_COMPLETION=5` |
| `scripts/lib/status.sh` | `status_get_exit_code()` |
| `scripts/launch-agent.sh` | Exit code 5 handling, config parsing, updated defaults |
| `scripts/entrypoint.sh` | Liveness enabled by default |
| `agent-sandbox.yaml.template` | New liveness config section |
| `tests/test-liveness-monitor.sh` | 10 new tests (49 total) |
| `CLAUDE.md` | Exit code table, hung agent detection docs |
| `docs/CONFIG-REFERENCE.md` | Updated liveness behavior docs |
| `docs/STATUS-TRACKING.md` | Exit code 5 in table |

## Test plan

- [x] `shellcheck` passes on all modified scripts (0 errors)
- [x] `./tests/test-liveness-monitor.sh` — 49/49 pass (10 new)
- [x] `./tests/run-all-tests.sh --quick` — full quick suite passes, 0 failures
- [ ] Container test: launch agent with `liveness.enabled: true`, verify monitor starts
- [ ] Simulate hung process: verify exit code 5 and diagnostics file creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)