### PR TITLE
feat: add agent_partial error type for container crash with committed work (#260)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -401,6 +401,15 @@ liveness:
   check_interval: 30     # default: 30s
 ```
 
+## Agent Partial Completion (Issue #260)
+
+When a container exits non-zero but the agent's work was successfully committed, `error_type` is set to `"agent_partial"` instead of `"agent_failure"`. This tells callers (slack-bot) NOT to retry — the work exists on the branch. Exit code remains 1.
+
+| Scenario | exit_code | error_type |
+|----------|-----------|-----------|
+| Container crashed, no work | 1 | `agent_failure` |
+| Container crashed, work committed | 1 | `agent_partial` |
+
 ## Commit Failure Detection (Issue #256)
 
 Exit code 6 indicates the post-container `git commit` command failed. The agent DID produce file changes, but they could not be committed (e.g., pre-commit hook failure, git permission issue, empty diff after filtering). The worktree is preserved with staged changes for manual recovery.

--- a/scripts/launch-agent.sh
+++ b/scripts/launch-agent.sh
@@ -2558,7 +2558,7 @@ main() {
     # Combine exit codes - fail if either container or post-container operations failed
     # Exit codes (Fix #3, Issue #256, Issue #257):
     #   0 = Success (changes committed or no changes)
-    #   1 = Agent failure (container exit code non-zero)
+    #   1 = Agent failure (container exit code non-zero; error_type=agent_partial if work committed)
     #   2 = Push failed
     #   3 = Uncommitted changes remain
     #   4 = Mount failure (virtio-fs drop)
@@ -2587,7 +2587,14 @@ main() {
     elif [[ "$EXIT_CODE" -ne 0 ]]; then
         FINAL_EXIT_CODE=$EXIT_CODE
         log_finalize "$EXIT_CODE"
-        status_set_error_type "agent_failure"
+        # Distinguish agent_partial (crashed but committed work) from agent_failure (Issue #260)
+        local _agent_commit_status
+        _agent_commit_status=$(status_get_commit_status 2>/dev/null || echo "unknown")
+        if [[ "$_agent_commit_status" == "success" ]]; then
+            status_set_error_type "agent_partial"
+        else
+            status_set_error_type "agent_failure"
+        fi
         status_complete "$EXIT_CODE" "Agent exited with error code $EXIT_CODE"
         _STATUS_COMPLETE_SHOWN=true
         # Include captured container error in the failure message

--- a/scripts/launch-agent.sh
+++ b/scripts/launch-agent.sh
@@ -2588,9 +2588,12 @@ main() {
         FINAL_EXIT_CODE=$EXIT_CODE
         log_finalize "$EXIT_CODE"
         # Distinguish agent_partial (crashed but committed work) from agent_failure (Issue #260)
-        local _agent_commit_status
-        _agent_commit_status=$(status_get_commit_status 2>/dev/null || echo "unknown")
-        if [[ "$_agent_commit_status" == "success" ]]; then
+        # Note: In overlay mode, commit_status is "overlay_pending" (not "success"),
+        # so overlay-mode crashes are always "agent_failure". This is intentional —
+        # overlay mode has no git commit, only an upper-dir with changes.
+        local agent_commit_status
+        agent_commit_status=$(status_get_commit_status 2>/dev/null || echo "unknown")
+        if [[ "$agent_commit_status" == "success" ]]; then
             status_set_error_type "agent_partial"
         else
             status_set_error_type "agent_failure"

--- a/scripts/lib/status.sh
+++ b/scripts/lib/status.sh
@@ -426,8 +426,8 @@ status_get_commit_sha() {
 # Set error type for structured error reporting (Issue #256)
 # Enables callers to programmatically distinguish failure modes
 # Arguments:
-#   $1 - Error type: "agent_failure", "commit_failure", "push_failure",
-#        "uncommitted_work", "mount_failure", "hung_after_completion"
+#   $1 - Error type: "agent_failure", "agent_partial", "commit_failure",
+#        "push_failure", "uncommitted_work", "mount_failure", "hung_after_completion"
 status_set_error_type() {
     _KAPSIS_ERROR_TYPE="${1:-}"
 }

--- a/tests/test-commit-failure-handling.sh
+++ b/tests/test-commit-failure-handling.sh
@@ -229,6 +229,7 @@ test_error_type_populated_for_all_exits() {
     grep -q 'status_set_error_type "mount_failure"' "$LAUNCH_AGENT_SCRIPT" || missing+=("mount_failure")
     grep -q 'status_set_error_type "hung_after_completion"' "$LAUNCH_AGENT_SCRIPT" || missing+=("hung_after_completion")
     grep -q 'status_set_error_type "agent_failure"' "$LAUNCH_AGENT_SCRIPT" || missing+=("agent_failure")
+    grep -q 'status_set_error_type "agent_partial"' "$LAUNCH_AGENT_SCRIPT" || missing+=("agent_partial")
     grep -q 'status_set_error_type "commit_failure"' "$LAUNCH_AGENT_SCRIPT" || missing+=("commit_failure")
     grep -q 'status_set_error_type "push_failure"' "$LAUNCH_AGENT_SCRIPT" || missing+=("push_failure")
     grep -q 'status_set_error_type "uncommitted_work"' "$LAUNCH_AGENT_SCRIPT" || missing+=("uncommitted_work")


### PR DESCRIPTION
## Summary

- When container exits non-zero but work was committed, `error_type` is now `"agent_partial"` instead of `"agent_failure"`
- Callers can use this to avoid blind retries when work already exists on the branch
- Exit code remains 1 — only `error_type` in status.json changes

## Changes

| File | What |
|------|------|
| `scripts/launch-agent.sh` | Check `commit_status == "success"` in EXIT_CODE block, set `agent_partial` |
| `scripts/lib/status.sh` | Added `agent_partial` to `status_set_error_type()` doc |
| `tests/test-commit-failure-handling.sh` | Added `agent_partial` to error_type completeness test |
| `CLAUDE.md` | Agent Partial Completion section |

## Test plan

- [x] shellcheck passes
- [x] 12/12 tests pass in test-commit-failure-handling.sh
- [x] error_type_populated_for_all_exits test now includes agent_partial

Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)