### PR TITLE
fix: detect curl -v/--verbose as potential auth header leak in audit (#246)

### DIFF
--- a/scripts/lib/audit-patterns.sh
+++ b/scripts/lib/audit-patterns.sh
@@ -317,6 +317,7 @@ _pattern_sensitive_path_access() {
 # Suspicious patterns:
 #   - base64 -d (decoding obfuscated payloads)
 #   - curl ... | sh/bash (remote code execution)
+#   - curl -v / --verbose (auth header exposure in output)
 #   - nc -l / ncat (network listeners)
 #   - python/python3 -c ...socket (reverse shells)
 #   - eval ...base64 (obfuscated eval)
@@ -337,6 +338,8 @@ _pattern_unusual_commands() {
     elif [[ "$command" =~ curl.*\|.*sh ]] || \
          [[ "$command" =~ curl.*\|.*bash ]]; then
         pattern_desc="curl piped to shell"
+    elif [[ "$command" =~ curl[[:space:]].*(-v[[:space:]]|--verbose) ]]; then
+        pattern_desc="verbose curl (may expose Authorization headers in output)"
     elif [[ "$command" =~ nc[[:space:]]+-l ]] || \
          [[ "$command" =~ ncat[[:space:]] ]]; then
         pattern_desc="network listener (nc/ncat)"

--- a/scripts/lib/audit-patterns.sh
+++ b/scripts/lib/audit-patterns.sh
@@ -338,7 +338,11 @@ _pattern_unusual_commands() {
     elif [[ "$command" =~ curl.*\|.*sh ]] || \
          [[ "$command" =~ curl.*\|.*bash ]]; then
         pattern_desc="curl piped to shell"
-    elif [[ "$command" =~ curl[[:space:]].*(-v[[:space:]]|--verbose) ]]; then
+    # Note: this must come AFTER the curl|sh/bash check above so pipe-to-shell
+    # (higher severity) takes priority when both patterns match (e.g., curl -v ... | bash)
+    # Matches: curl -v, curl --verbose, curl -sv, curl -kv, curl -vsSL, etc.
+    elif [[ "$command" =~ curl[[:space:]].*(-v[[:space:]]|--verbose) ]] || \
+         [[ "$command" =~ curl[[:space:]]+-[a-zA-Z]*v([[:space:]]|$) ]]; then
         pattern_desc="verbose curl (may expose Authorization headers in output)"
     elif [[ "$command" =~ nc[[:space:]]+-l ]] || \
          [[ "$command" =~ ncat[[:space:]] ]]; then

--- a/scripts/lib/audit-patterns.sh
+++ b/scripts/lib/audit-patterns.sh
@@ -341,8 +341,9 @@ _pattern_unusual_commands() {
     # Note: this must come AFTER the curl|sh/bash check above so pipe-to-shell
     # (higher severity) takes priority when both patterns match (e.g., curl -v ... | bash)
     # Matches: curl -v, curl --verbose, curl -sv, curl -kv, curl -vsSL, etc.
-    elif [[ "$command" =~ curl[[:space:]].*(-v[[:space:]]|--verbose) ]] || \
-         [[ "$command" =~ curl[[:space:]]+-[a-zA-Z]*v([[:space:]]|$) ]]; then
+    elif [[ "$command" =~ curl[[:space:]].*(-v([[:space:]]|$)|--verbose) ]] || \
+         [[ "$command" =~ curl[[:space:]]+-[a-zA-Z]*v([[:space:]]|$) ]] || \
+         [[ "$command" =~ curl[[:space:]].*[[:space:]]-[a-zA-Z]*v([[:space:]]|$) ]]; then
         pattern_desc="verbose curl (may expose Authorization headers in output)"
     elif [[ "$command" =~ nc[[:space:]]+-l ]] || \
          [[ "$command" =~ ncat[[:space:]] ]]; then

--- a/tests/test-audit-system.sh
+++ b/tests/test-audit-system.sh
@@ -1085,7 +1085,29 @@ test_pattern_verbose_curl_long_flag() {
     teardown
 }
 
-# 29. Normal curl (no -v) should NOT be flagged
+# 29. Combined short flags (curl -sv, curl -kv) also detected
+test_pattern_verbose_curl_combined_flags() {
+    log_test "curl -sv (combined flags with -v) also flagged"
+
+    setup
+    source_audit
+    source_audit_patterns
+
+    local now
+    now=$(date +%s)
+
+    local alert_rc=0
+    if audit_check_patterns "network_activity" "Bash" "curl -sv https://api.github.com/user" "" "$now"; then
+        alert_rc=0
+    else
+        alert_rc=1
+    fi
+    assert_equals 0 "$alert_rc" "curl -sv should trigger unusual_commands alert"
+
+    teardown
+}
+
+# 30. Normal curl (no -v) should NOT be flagged
 test_pattern_normal_curl_not_flagged() {
     log_test "Normal curl (no -v) not flagged as unusual"
 
@@ -1158,9 +1180,10 @@ main() {
     run_test test_pattern_no_false_positive_pip
     run_test test_pattern_no_false_positive_maven
 
-    # Verbose curl detection tests (27-29, Issue #246)
+    # Verbose curl detection tests (27-30, Issue #246)
     run_test test_pattern_verbose_curl_detected
     run_test test_pattern_verbose_curl_long_flag
+    run_test test_pattern_verbose_curl_combined_flags
     run_test test_pattern_normal_curl_not_flagged
 
     print_summary

--- a/tests/test-audit-system.sh
+++ b/tests/test-audit-system.sh
@@ -1029,6 +1029,88 @@ test_pattern_no_false_positive_maven() {
     teardown
 }
 
+# 27. Verbose curl flagged as unusual command (Issue #246)
+test_pattern_verbose_curl_detected() {
+    log_test "curl -v / --verbose flagged as unusual command (auth header leak risk)"
+
+    setup
+    source_audit
+    source_audit_patterns
+
+    local now
+    now=$(date +%s)
+
+    # Test curl -v
+    local alert_rc=0
+    if audit_check_patterns "network_activity" "Bash" "curl -v https://api.github.com/user" "" "$now"; then
+        alert_rc=0
+    else
+        alert_rc=1
+    fi
+    assert_equals 0 "$alert_rc" "curl -v should trigger unusual_commands alert"
+
+    # Verify alert content
+    local alert_found=false
+    for f in "$TEST_AUDIT_DIR"/*-alerts.jsonl; do
+        if [[ -f "$f" ]]; then
+            if grep -q "verbose curl" "$f" 2>/dev/null; then
+                alert_found=true
+            fi
+        fi
+    done
+    assert_true "[[ '$alert_found' == 'true' ]]" "Alert should mention 'verbose curl'"
+
+    teardown
+}
+
+# 28. curl --verbose also detected (long flag form)
+test_pattern_verbose_curl_long_flag() {
+    log_test "curl --verbose also flagged"
+
+    setup
+    source_audit
+    source_audit_patterns
+
+    local now
+    now=$(date +%s)
+
+    local alert_rc=0
+    if audit_check_patterns "network_activity" "Bash" "curl --verbose -H 'Authorization: Bearer token' https://api.github.com" "" "$now"; then
+        alert_rc=0
+    else
+        alert_rc=1
+    fi
+    assert_equals 0 "$alert_rc" "curl --verbose should trigger unusual_commands alert"
+
+    teardown
+}
+
+# 29. Normal curl (no -v) should NOT be flagged
+test_pattern_normal_curl_not_flagged() {
+    log_test "Normal curl (no -v) not flagged as unusual"
+
+    setup
+    source_audit
+    source_audit_patterns
+
+    local now
+    now=$(date +%s)
+
+    audit_check_patterns "network_activity" "Bash" "curl -s https://api.github.com/repos" "" "$now" || true
+
+    local unusual_found=false
+    for f in "$TEST_AUDIT_DIR"/*-alerts.jsonl; do
+        if [[ -f "$f" ]]; then
+            if grep -q "verbose curl" "$f" 2>/dev/null; then
+                unusual_found=true
+            fi
+        fi
+    done
+    assert_true "[[ '$unusual_found' == 'false' ]]" "Normal curl should not trigger verbose curl alert"
+
+    teardown
+}
+
 #===============================================================================
 # TEST RUNNER
 #===============================================================================
@@ -1075,6 +1157,11 @@ main() {
     # Additional false positive tests (25-26)
     run_test test_pattern_no_false_positive_pip
     run_test test_pattern_no_false_positive_maven
+
+    # Verbose curl detection tests (27-29, Issue #246)
+    run_test test_pattern_verbose_curl_detected
+    run_test test_pattern_verbose_curl_long_flag
+    run_test test_pattern_normal_curl_not_flagged
 
     print_summary
     return "$TESTS_FAILED"

--- a/tests/test-audit-system.sh
+++ b/tests/test-audit-system.sh
@@ -1085,7 +1085,29 @@ test_pattern_verbose_curl_long_flag() {
     teardown
 }
 
-# 29. Combined short flags (curl -sv, curl -kv) also detected
+# 29. curl -v at end of command (no trailing space) also detected
+test_pattern_verbose_curl_at_end() {
+    log_test "curl URL -v (flag at end of command) also flagged"
+
+    setup
+    source_audit
+    source_audit_patterns
+
+    local now
+    now=$(date +%s)
+
+    local alert_rc=0
+    if audit_check_patterns "network_activity" "Bash" "curl https://api.github.com -v" "" "$now"; then
+        alert_rc=0
+    else
+        alert_rc=1
+    fi
+    assert_equals 0 "$alert_rc" "curl with -v at end should trigger unusual_commands alert"
+
+    teardown
+}
+
+# 30. Combined short flags (curl -sv, curl -kv) also detected
 test_pattern_verbose_curl_combined_flags() {
     log_test "curl -sv (combined flags with -v) also flagged"
 
@@ -1180,9 +1202,10 @@ main() {
     run_test test_pattern_no_false_positive_pip
     run_test test_pattern_no_false_positive_maven
 
-    # Verbose curl detection tests (27-30, Issue #246)
+    # Verbose curl detection tests (27-31, Issue #246)
     run_test test_pattern_verbose_curl_detected
     run_test test_pattern_verbose_curl_long_flag
+    run_test test_pattern_verbose_curl_at_end
     run_test test_pattern_verbose_curl_combined_flags
     run_test test_pattern_normal_curl_not_flagged
 


### PR DESCRIPTION
## Summary

- Adds `curl -v` / `curl --verbose` detection to `_pattern_unusual_commands()` in audit-patterns.sh
- Triggers CRITICAL audit alert when verbose curl is used (exposes Authorization headers in output)
- 3 new tests: short flag, long flag, and false-positive check (normal curl not flagged)

## Context

Real incident: while debugging #245 (DNS pinning), an agent ran `curl -v` against `api.github.com`. The `GITHUB_TOKEN` (`gho_` prefix, injected via env) appeared verbatim in the tool output.

## Test plan

- [x] shellcheck passes
- [x] 29/29 audit system tests pass (3 new)
- [x] Normal curl without -v is NOT flagged (false positive test)
- [x] Authorization header in test is automatically masked by sanitize_secrets

Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)