### PR TITLE
fix: DNS pinning no longer captures subdomains — use host-record instead of address= (#245)

### DIFF
--- a/scripts/lib/dns-filter.sh
+++ b/scripts/lib/dns-filter.sh
@@ -162,7 +162,7 @@ EOF
     # PINNED DNS ENTRIES (host-resolved IPs)
     #
     # If pinned DNS file exists (from host-side resolution), use static
-    # address=/ directives instead of dynamic server=/ forwarding.
+    # host-record= directives instead of dynamic server=/ forwarding.
     # This prevents DNS manipulation attacks inside the container.
     #===========================================================================
     local pinned_count=0
@@ -189,13 +189,11 @@ EOF
             _KAPSIS_PINNED_DOMAINS["$pin_domain"]=1
 
             # Use host-record (exact match) instead of address= (which catches subdomains)
-            # address=/domain/IP makes ALL subdomains resolve to the apex IP (Issue #245)
-            # host-record=domain,IP only pins the exact domain; subdomains fall through
-            # to server=/ forwarders for live resolution
-            # shellcheck disable=SC2086  # Intentional word-split: $pin_ips contains space-separated IPs
-            for ip in $pin_ips; do
-                echo "host-record=${pin_domain},${ip}" >> "$config_file"
-            done
+            # host-record=domain,IP1,IP2 pins only the exact domain; subdomains fall through
+            # to server=/ forwarders for live resolution (Issue #245)
+            # Multiple IPs must be on one line — separate host-record= lines don't accumulate
+            local pin_ip_csv="${pin_ips// /,}"
+            echo "host-record=${pin_domain},${pin_ip_csv}" >> "$config_file"
 
             log_debug "Pinned: $pin_domain -> $pin_ips"
             pinned_count=$((pinned_count + 1))

--- a/scripts/lib/dns-filter.sh
+++ b/scripts/lib/dns-filter.sh
@@ -188,10 +188,13 @@ EOF
             # Track this domain as pinned (skip in dynamic rules later)
             _KAPSIS_PINNED_DOMAINS["$pin_domain"]=1
 
-            # Generate address= directive for each IP
+            # Use host-record (exact match) instead of address= (which catches subdomains)
+            # address=/domain/IP makes ALL subdomains resolve to the apex IP (Issue #245)
+            # host-record=domain,IP only pins the exact domain; subdomains fall through
+            # to server=/ forwarders for live resolution
             # shellcheck disable=SC2086  # Intentional word-split: $pin_ips contains space-separated IPs
             for ip in $pin_ips; do
-                echo "address=/${pin_domain}/${ip}" >> "$config_file"
+                echo "host-record=${pin_domain},${ip}" >> "$config_file"
             done
 
             log_debug "Pinned: $pin_domain -> $pin_ips"

--- a/scripts/lib/dns-pin.sh
+++ b/scripts/lib/dns-pin.sh
@@ -207,7 +207,7 @@ generate_add_host_args() {
 
 # generate_pinned_dnsmasq_entries <pinned-file>
 #
-# Generates dnsmasq address=/ directives from pinned DNS file.
+# Generates dnsmasq host-record= directives from pinned DNS file (Issue #245).
 # Used by dns-filter.sh to create static IP bindings.
 #
 # Arguments:
@@ -236,13 +236,11 @@ generate_pinned_dnsmasq_entries() {
         [[ -z "$domain" || -z "$ips" ]] && continue
 
         # Use host-record (exact match) instead of address= (which catches subdomains)
-        # address=/domain/IP makes ALL subdomains resolve to the apex IP (Issue #245)
-        # host-record=domain,IP only pins the exact domain; subdomains fall through
-        # to server=/ forwarders for live resolution
-        # shellcheck disable=SC2086  # Intentional word-split: $ips contains space-separated IPv4 addresses
-        for ip in $ips; do
-            echo "host-record=${domain},${ip}"
-        done
+        # host-record=domain,IP1,IP2 pins only the exact domain; subdomains fall through
+        # to server=/ forwarders for live resolution (Issue #245)
+        # Multiple IPs must be on one line — separate host-record= lines don't accumulate
+        local ip_csv="${ips// /,}"
+        echo "host-record=${domain},${ip_csv}"
     done < "$pinned_file"
 }
 

--- a/scripts/lib/dns-pin.sh
+++ b/scripts/lib/dns-pin.sh
@@ -235,10 +235,13 @@ generate_pinned_dnsmasq_entries() {
 
         [[ -z "$domain" || -z "$ips" ]] && continue
 
-        # Generate address= directive for each IP
+        # Use host-record (exact match) instead of address= (which catches subdomains)
+        # address=/domain/IP makes ALL subdomains resolve to the apex IP (Issue #245)
+        # host-record=domain,IP only pins the exact domain; subdomains fall through
+        # to server=/ forwarders for live resolution
         # shellcheck disable=SC2086  # Intentional word-split: $ips contains space-separated IPv4 addresses
         for ip in $ips; do
-            echo "address=/${domain}/${ip}"
+            echo "host-record=${domain},${ip}"
         done
     done < "$pinned_file"
 }

--- a/tests/test-dns-pinning.sh
+++ b/tests/test-dns-pinning.sh
@@ -234,7 +234,7 @@ EOF
 }
 
 test_generate_pinned_dnsmasq_entries() {
-    log_test "Testing dnsmasq address=/ entries generation"
+    log_test "Testing dnsmasq host-record entries generation (Issue #245: exact-match, no subdomain capture)"
 
     source "$DNS_PIN_LIB"
 
@@ -249,10 +249,10 @@ EOF
     local entries
     entries=$(generate_pinned_dnsmasq_entries "$temp_file")
 
-    # Check output contains address=/ format
-    assert_contains "$entries" "address=/github.com/1.2.3.4" "Should have github address entry"
-    assert_contains "$entries" "address=/github.com/5.6.7.8" "Should have second github IP"
-    assert_contains "$entries" "address=/gitlab.com/10.20.30.40" "Should have gitlab address entry"
+    # Check output uses host-record= (exact match) not address=/ (catches subdomains)
+    assert_contains "$entries" "host-record=github.com,1.2.3.4" "Should have github host-record entry"
+    assert_contains "$entries" "host-record=github.com,5.6.7.8" "Should have second github IP"
+    assert_contains "$entries" "host-record=gitlab.com,10.20.30.40" "Should have gitlab host-record entry"
 
     rm -f "$temp_file"
 }
@@ -306,9 +306,9 @@ EOF
     # Generate config
     generate_dnsmasq_config
 
-    # Verify pinned domains use address=/ (static IP)
-    assert_file_contains "$temp_config" "address=/github.com/1.2.3.4" "Pinned github should use address=/"
-    assert_file_contains "$temp_config" "address=/gitlab.com/5.6.7.8" "Pinned gitlab should use address=/"
+    # Verify pinned domains use host-record= (exact match, Issue #245)
+    assert_file_contains "$temp_config" "host-record=github.com,1.2.3.4" "Pinned github should use host-record="
+    assert_file_contains "$temp_config" "host-record=gitlab.com,5.6.7.8" "Pinned gitlab should use host-record="
 
     # Verify wildcards still use server=/ (dynamic forwarding)
     assert_file_contains "$temp_config" "server=/.npmjs.org/8.8.8.8" "Wildcard should use server=/"
@@ -792,9 +792,9 @@ EOF
             echo "==="
         ' 2>&1) || true
 
-    # Check for address=/ entry for pinned domain
-    if echo "$output" | grep -q "address=/pinned-test.example/192.0.2.50"; then
-        log_pass "Pinned domain uses address=/ directive"
+    # Check for host-record= entry for pinned domain (Issue #245: exact match only)
+    if echo "$output" | grep -q "host-record=pinned-test.example,192.0.2.50"; then
+        log_pass "Pinned domain uses host-record= directive (exact match)"
     else
         log_warn "Could not verify dnsmasq config (DNS filter may have different behavior in CI)"
     fi

--- a/tests/test-dns-pinning.sh
+++ b/tests/test-dns-pinning.sh
@@ -249,9 +249,9 @@ EOF
     local entries
     entries=$(generate_pinned_dnsmasq_entries "$temp_file")
 
-    # Check output uses host-record= (exact match) not address=/ (catches subdomains)
-    assert_contains "$entries" "host-record=github.com,1.2.3.4" "Should have github host-record entry"
-    assert_contains "$entries" "host-record=github.com,5.6.7.8" "Should have second github IP"
+    # Check output uses host-record= with comma-separated IPs (exact match, Issue #245)
+    # Multiple IPs on one line — separate host-record= lines don't accumulate in dnsmasq
+    assert_contains "$entries" "host-record=github.com,1.2.3.4,5.6.7.8" "Should have github host-record with both IPs"
     assert_contains "$entries" "host-record=gitlab.com,10.20.30.40" "Should have gitlab host-record entry"
 
     rm -f "$temp_file"


### PR DESCRIPTION
## Summary

- Replaces `address=/domain/IP` with `host-record=domain,IP` in dnsmasq config for pinned domains
- `address=` matches domain AND all subdomains; `host-record=` matches only the exact domain
- Subdomains now correctly fall through to `server=/` forwarders for live DNS resolution

## Root Cause

`address=/github.com/20.217.135.5` caused `api.github.com`, `codeload.github.com`, and all other subdomains to resolve to github.com's apex IP. TLS/HTTP hit the wrong server, breaking `gh`, `git`, and API calls.

## Changes

| File | What |
|------|------|
| `scripts/lib/dns-filter.sh` | `address=/` → `host-record=` for pinned entries |
| `scripts/lib/dns-pin.sh` | Same change in `generate_pinned_dnsmasq_entries()` |
| `tests/test-dns-pinning.sh` | Updated assertions to match `host-record=` format |

## Test plan

- [x] shellcheck passes
- [x] 27/27 DNS pinning tests pass
- [x] Tests verify `host-record=` format (not `address=/`)

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)