### PR TITLE
fix(gist): auto-gist hook + stop hook fix (kapsis#285)

### DIFF
--- a/scripts/hooks/kapsis-gist-hook.sh
+++ b/scripts/hooks/kapsis-gist-hook.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+#===============================================================================
+# Kapsis Gist Hook - Automatic PostToolUse gist writer
+#
+# Fires on every PostToolUse event. Pattern-matches the tool call to derive
+# a short activity summary and writes it to /workspace/.kapsis/gist.txt,
+# allowing the status pipeline (kapsis-status-hook.sh, kapsis-stop-hook.sh)
+# to surface a non-null gist in the status JSON without any agent cooperation.
+#
+# Usage:
+#   This script is called automatically by the agent's hook system.
+#   It reads JSON from stdin and always exits 0 (never blocks the agent).
+#
+# Environment Variables:
+#   KAPSIS_STATUS_AGENT_ID   - Required: Agent ID (validates hook context)
+#   KAPSIS_INJECT_GIST       - Must be "true" to activate (opt-in flag)
+#   KAPSIS_GIST_FILE         - Override default gist file path (for testing)
+#   KAPSIS_HOME              - Kapsis installation directory (default: /opt/kapsis)
+#===============================================================================
+
+set -euo pipefail
+
+KAPSIS_HOME="${KAPSIS_HOME:-/opt/kapsis}"
+
+# Guard 1: Only run inside a Kapsis agent session
+_safe_agent_id="${KAPSIS_STATUS_AGENT_ID:-}"
+if [[ -z "$_safe_agent_id" ]]; then
+    exit 0
+fi
+if ! [[ "$_safe_agent_id" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+    exit 0
+fi
+
+# Guard 2: Only run when gist feature is enabled
+if [[ "${KAPSIS_INJECT_GIST:-false}" != "true" ]]; then
+    exit 0
+fi
+
+# Env-overridable gist file path (mirrors KAPSIS_GIST_FILE in status.sh)
+GIST_FILE="${KAPSIS_GIST_FILE:-/workspace/.kapsis/gist.txt}"
+GIST_DIR="$(dirname "$GIST_FILE")"
+
+#===============================================================================
+# JSON Parsing
+#===============================================================================
+
+# Extract a field from JSON using python3 (always available in container).
+# Supports nested keys like 'tool_input.command'.
+json_get() {
+    local json="$1"
+    local field="$2"
+    local default="${3:-}"
+
+    local value
+    value=$(echo "$json" | python3 -c "
+import json, sys
+try:
+    data = json.load(sys.stdin)
+    keys = '$field'.split('.')
+    result = data
+    for key in keys:
+        if isinstance(result, dict):
+            result = result.get(key, '')
+        else:
+            result = ''
+            break
+    print(result if result is not None else '')
+except Exception:
+    print('')
+" 2>/dev/null) || value="$default"
+
+    echo "${value:-$default}"
+}
+
+#===============================================================================
+# Main
+#===============================================================================
+
+# Read stdin (hook input from Claude Code)
+input=$(cat)
+
+# Extract tool information
+tool_name=$(json_get "$input" "tool_name" "")
+command=""
+file_path=""
+
+if [[ "$tool_name" == "Bash" ]]; then
+    command=$(json_get "$input" "tool_input.command" "")
+elif [[ "$tool_name" =~ ^(Edit|Write)$ ]]; then
+    file_path=$(json_get "$input" "tool_input.file_path" "")
+    [[ -z "$file_path" ]] && file_path=$(json_get "$input" "tool_input.path" "")
+fi
+
+# Derive deterministic gist from tool + input
+gist=""
+skip=false
+
+case "$tool_name" in
+    Bash)
+        if [[ "$command" =~ git[[:space:]]+commit ]]; then
+            # Extract -m message using shlex.split for robust quote handling
+            msg=$(printf '%s' "$command" | python3 -c "
+import shlex, sys
+try:
+    args = shlex.split(sys.stdin.read())
+    for i, arg in enumerate(args):
+        if arg in ('-m', '--message') and i + 1 < len(args):
+            print(args[i + 1][:60])
+            break
+        elif arg.startswith('-m') and len(arg) > 2:
+            print(arg[2:][:60])
+            break
+except Exception:
+    pass
+" 2>/dev/null || echo "")
+            gist="Committing: ${msg:-changes}"
+
+        elif [[ "$command" =~ git[[:space:]]+push ]]; then
+            gist="Pushing changes to remote"
+
+        elif [[ "$command" =~ (mvn|gradle)[[:space:]].*test|pytest|go[[:space:]]+test|npm[[:space:]]+test|jest ]]; then
+            gist="Running tests"
+
+        elif [[ "$command" =~ (mvn|gradle)[[:space:]].*(compile|build|package|install)|go[[:space:]]+build|npm.*(build|run[[:space:]]+build) ]]; then
+            gist="Building project"
+
+        else
+            # Fallback: only write on first ever call (don't overwrite a meaningful gist)
+            if [[ ! -f "$GIST_FILE" ]]; then
+                first_word="${command%%[[:space:]]*}"
+                first_word="${first_word##*/}"   # strip path prefix (e.g. /usr/bin/curl → curl)
+                gist="Running: ${first_word:0:40}"
+            else
+                skip=true
+            fi
+        fi
+        ;;
+
+    Edit)
+        [[ -n "$file_path" ]] && gist="Editing: $(basename "$file_path")"
+        ;;
+
+    Write)
+        [[ -n "$file_path" ]] && gist="Writing: $(basename "$file_path")"
+        ;;
+
+    *)
+        # Read, Glob, Grep, and all other tools: preserve existing gist unchanged
+        skip=true
+        ;;
+esac
+
+# Write deterministic gist
+if [[ "$skip" != "true" && -n "$gist" ]]; then
+    mkdir -p "$GIST_DIR" 2>/dev/null || true
+    printf '%s\n' "$gist" > "$GIST_FILE"
+fi
+
+exit 0

--- a/scripts/hooks/kapsis-gist-hook.sh
+++ b/scripts/hooks/kapsis-gist-hook.sh
@@ -156,4 +156,47 @@ if [[ "$skip" != "true" && -n "$gist" ]]; then
     printf '%s\n' "$gist" > "$GIST_FILE"
 fi
 
+# ─── LLM Gist upgrade (opt-in: KAPSIS_GIST_LLM=true) ────────────────────────
+if [[ "${KAPSIS_GIST_LLM:-false}" == "true" ]] && command -v claude &>/dev/null; then
+    GIST_LLM_STAMP="${GIST_DIR}/gist.last_llm_run"
+    GIST_LLM_INTERVAL="${KAPSIS_GIST_LLM_INTERVAL:-60}"
+
+    # High-signal tools always bypass the throttle
+    is_high_signal=false
+    [[ "$tool_name" == "Bash" && "$command" =~ git[[:space:]]+commit ]] && is_high_signal=true
+    [[ "$tool_name" == "Write" ]] && is_high_signal=true
+
+    # Time gate: check stamp mtime
+    should_run_llm=false
+    if $is_high_signal; then
+        should_run_llm=true
+    elif [[ ! -f "$GIST_LLM_STAMP" ]]; then
+        should_run_llm=true
+    else
+        last=$(stat -f %m "$GIST_LLM_STAMP" 2>/dev/null || stat -c %Y "$GIST_LLM_STAMP" 2>/dev/null || echo 0)
+        now=$(date +%s)
+        if (( now - last >= GIST_LLM_INTERVAL )); then should_run_llm=true; fi
+    fi
+
+    if $should_run_llm; then
+        tool_result=$(json_get "$input" "tool_result" "")
+        tool_input_str=$(json_get "$input" "tool_input" "")
+        prompt="In one sentence (max 80 chars), what is this AI coding agent doing? Start with a verb. Be specific.
+Tool: $tool_name  Input: ${tool_input_str:0:200}  Output: ${tool_result:0:400}"
+
+        gist_llm=$(timeout 8 claude --print --model claude-haiku-4-5-20251001 <<< "$prompt" 2>/dev/null) || gist_llm=""
+
+        if [[ -n "$gist_llm" ]]; then
+            mkdir -p "$GIST_DIR" 2>/dev/null || true
+            tmp=$(mktemp "${GIST_DIR}/.gist.tmp.XXXXXX" 2>/dev/null) || tmp=""
+            if [[ -n "$tmp" ]]; then
+                printf '%s\n' "${gist_llm:0:200}" > "$tmp"
+                mv "$tmp" "$GIST_FILE"
+                touch "$GIST_LLM_STAMP"
+            fi
+        fi
+        # On failure: deterministic gist (written above) stays
+    fi
+fi
+
 exit 0

--- a/scripts/hooks/kapsis-gist-hook.sh
+++ b/scripts/hooks/kapsis-gist-hook.sh
@@ -16,6 +16,9 @@
 #   KAPSIS_INJECT_GIST       - Must be "true" to activate (opt-in flag)
 #   KAPSIS_GIST_FILE         - Override default gist file path (for testing)
 #   KAPSIS_HOME              - Kapsis installation directory (default: /opt/kapsis)
+#   KAPSIS_GIST_LLM          - Set "true" to enable LLM upgrade layer
+#   KAPSIS_GIST_LLM_INTERVAL - Throttle interval in seconds (default: 60)
+#   KAPSIS_GIST_LLM_SYNC     - Set "true" for synchronous LLM calls (testing only)
 #===============================================================================
 
 set -euo pipefail
@@ -46,13 +49,14 @@ GIST_DIR="$(dirname "$GIST_FILE")"
 
 # Extract a field from JSON using python3 (always available in container).
 # Supports nested keys like 'tool_input.command'.
+# Dict/list values are serialized as JSON (not Python repr).
 json_get() {
     local json="$1"
     local field="$2"
     local default="${3:-}"
 
     local value
-    value=$(echo "$json" | python3 -c "
+    value=$(printf '%s\n' "$json" | python3 -c "
 import json, sys
 try:
     data = json.load(sys.stdin)
@@ -64,7 +68,12 @@ try:
         else:
             result = ''
             break
-    print(result if result is not None else '')
+    if result is None or result == '':
+        print('')
+    elif isinstance(result, (dict, list)):
+        print(json.dumps(result, ensure_ascii=False))
+    else:
+        print(result)
 except Exception:
     print('')
 " 2>/dev/null) || value="$default"
@@ -113,20 +122,33 @@ try:
 except Exception:
     pass
 " 2>/dev/null || echo "")
-            gist="Committing: ${msg:-changes}"
+            # Append ellipsis when the message was truncated
+            if [[ "${#msg}" -ge 60 ]]; then
+                gist="Committing: ${msg}…"
+            else
+                gist="Committing: ${msg:-changes}"
+            fi
 
         elif [[ "$command" =~ git[[:space:]]+push ]]; then
             gist="Pushing changes to remote"
 
-        elif [[ "$command" =~ (mvn|gradle)[[:space:]].*test|pytest|go[[:space:]]+test|npm[[:space:]]+test|jest ]]; then
+        elif [[ "$command" =~ (mvn|gradlew?)[[:space:]].*test ]] \
+             || [[ "$command" =~ (^|[[:space:]])(pytest|go[[:space:]]+test|npm[[:space:]]+test|jest)([[:space:]]|$) ]]; then
             gist="Running tests"
 
-        elif [[ "$command" =~ (mvn|gradle)[[:space:]].*(compile|build|package|install)|go[[:space:]]+build|npm.*(build|run[[:space:]]+build) ]]; then
+        elif [[ "$command" =~ (mvn|gradlew?)[[:space:]].*(compile|build|package|install) ]] \
+             || [[ "$command" =~ (^|[[:space:]])go[[:space:]]+build([[:space:]]|$) ]] \
+             || [[ "$command" =~ (^|[[:space:]])npm[[:space:]]*(build|run[[:space:]]+build)([[:space:]]|$) ]]; then
             gist="Building project"
 
         else
-            # Fallback: only write on first ever call (don't overwrite a meaningful gist)
-            if [[ ! -f "$GIST_FILE" ]]; then
+            # Fallback: write if no gist exists yet, or existing is stale (>5 min)
+            _gist_age=0
+            if [[ -f "$GIST_FILE" ]]; then
+                _gist_mtime=$(stat -f %m "$GIST_FILE" 2>/dev/null || stat -c %Y "$GIST_FILE" 2>/dev/null || echo 0)
+                _gist_age=$(( $(date +%s) - _gist_mtime ))
+            fi
+            if [[ ! -f "$GIST_FILE" || "$_gist_age" -ge 300 ]]; then
                 first_word="${command%%[[:space:]]*}"
                 first_word="${first_word##*/}"   # strip path prefix (e.g. /usr/bin/curl → curl)
                 gist="Running: ${first_word:0:40}"
@@ -137,11 +159,19 @@ except Exception:
         ;;
 
     Edit)
-        [[ -n "$file_path" ]] && gist="Editing: $(basename "$file_path")"
+        if [[ -n "$file_path" ]]; then
+            gist="Editing: ${file_path##*/}"
+        else
+            skip=true
+        fi
         ;;
 
     Write)
-        [[ -n "$file_path" ]] && gist="Writing: $(basename "$file_path")"
+        if [[ -n "$file_path" ]]; then
+            gist="Writing: ${file_path##*/}"
+        else
+            skip=true
+        fi
         ;;
 
     *)
@@ -179,23 +209,37 @@ if [[ "${KAPSIS_GIST_LLM:-false}" == "true" ]] && command -v claude &>/dev/null;
     fi
 
     if $should_run_llm; then
-        tool_result=$(json_get "$input" "tool_result" "")
-        tool_input_str=$(json_get "$input" "tool_input" "")
-        prompt="In one sentence (max 80 chars), what is this AI coding agent doing? Start with a verb. Be specific.
-Tool: $tool_name  Input: ${tool_input_str:0:200}  Output: ${tool_result:0:400}"
+        _tool_result=$(json_get "$input" "tool_result" "")
+        _tool_input_str=$(json_get "$input" "tool_input" "")
+        _prompt="In one sentence (max 80 chars), what is this AI coding agent doing? Start with a verb. Be specific.
+Tool: $tool_name  Input: ${_tool_input_str:0:200}  Output: ${_tool_result:0:400}"
 
-        gist_llm=$(timeout 8 claude --print --model claude-haiku-4-5-20251001 <<< "$prompt" 2>/dev/null) || gist_llm=""
+        # Run LLM asynchronously — hook exits with deterministic gist while LLM runs in background.
+        # The 5-second hook timeout applies to this process; backgrounding avoids the conflict with
+        # the internal 8-second LLM timeout. Set KAPSIS_GIST_LLM_SYNC=true for synchronous mode
+        # (useful for testing).
+        _do_llm_write() {
+            local _gist_llm
+            _gist_llm=$(timeout 8 claude --print --model claude-haiku-4-5-20251001 <<< "$_prompt" 2>/dev/null) || _gist_llm=""
 
-        if [[ -n "$gist_llm" ]]; then
-            mkdir -p "$GIST_DIR" 2>/dev/null || true
-            tmp=$(mktemp "${GIST_DIR}/.gist.tmp.XXXXXX" 2>/dev/null) || tmp=""
-            if [[ -n "$tmp" ]]; then
-                printf '%s\n' "${gist_llm:0:200}" > "$tmp"
-                mv "$tmp" "$GIST_FILE"
-                touch "$GIST_LLM_STAMP"
+            if [[ -n "$_gist_llm" ]]; then
+                mkdir -p "$GIST_DIR" 2>/dev/null || true
+                local _tmp
+                _tmp=$(mktemp "${GIST_DIR}/.gist.tmp.XXXXXX" 2>/dev/null) || _tmp=""
+                if [[ -n "$_tmp" ]]; then
+                    printf '%s\n' "${_gist_llm:0:200}" > "$_tmp"
+                    mv "$_tmp" "$GIST_FILE"
+                    touch "$GIST_LLM_STAMP"
+                fi
             fi
+        }
+
+        if [[ "${KAPSIS_GIST_LLM_SYNC:-false}" == "true" ]]; then
+            _do_llm_write
+        else
+            ( _do_llm_write ) &
+            disown 2>/dev/null || true
         fi
-        # On failure: deterministic gist (written above) stays
     fi
 fi
 

--- a/scripts/hooks/kapsis-stop-hook.sh
+++ b/scripts/hooks/kapsis-stop-hook.sh
@@ -132,6 +132,11 @@ main() {
         if type status_reinit_from_env &>/dev/null; then
             status_reinit_from_env
 
+            # Read agent gist before writing final status (kapsis#285 — Bug 1 fix)
+            if type status_read_gist_file &>/dev/null; then
+                status_read_gist_file
+            fi
+
             if [[ -n "$exit_code" && "$exit_code" != "0" ]]; then
                 status_phase "running" 85 "Agent completed with errors"
                 log_info "Agent completed with error: $error_message"

--- a/scripts/lib/inject-status-hooks.sh
+++ b/scripts/lib/inject-status-hooks.sh
@@ -68,6 +68,14 @@ inject_claude_hooks() {
     local tmp_file
     tmp_file=$(mktemp)
 
+    # Determine whether to inject gist hook (opt-in, file must exist and be executable)
+    local GIST_HOOK="${KAPSIS_HOOK_DIR}/kapsis-gist-hook.sh"
+    local inject_gist="${KAPSIS_INJECT_GIST:-false}"
+    if [[ "$inject_gist" == "true" && ! -x "$GIST_HOOK" ]]; then
+        log_warn "Gist hook not found or not executable: $GIST_HOOK -- skipping gist hook injection"
+        inject_gist="false"
+    fi
+
     # Attribution: only merge when the env vars are defined (set — including the
     # empty string, which is a valid "disable" per Claude Code's spec). When
     # unset, leave any existing user-configured attribution untouched.
@@ -79,6 +87,8 @@ inject_claude_hooks() {
     if jq \
         --arg status_hook "$STATUS_HOOK" \
         --arg stop_hook "$STOP_HOOK" \
+        --arg gist_hook "$GIST_HOOK" \
+        --arg inject_gist "$inject_gist" \
         --arg attr_commit "${KAPSIS_ATTRIBUTION_COMMIT:-}" \
         --arg attr_pr "${KAPSIS_ATTRIBUTION_PR:-}" \
         --arg attr_commit_set "$attr_commit_set" \
@@ -96,6 +106,16 @@ inject_claude_hooks() {
                 "matcher": "*",
                 "hooks": [{"type": "command", "command": $status_hook, "timeout": 5}]
             }]
+        else . end |
+
+        # Add gist hook to PostToolUse if KAPSIS_INJECT_GIST=true and not already present
+        if $inject_gist == "true" then
+            if ([.hooks.PostToolUse[].hooks[]? | select(.command == $gist_hook)] | length) == 0 then
+                .hooks.PostToolUse += [{
+                    "matcher": "*",
+                    "hooks": [{"type": "command", "command": $gist_hook, "timeout": 5}]
+                }]
+            else . end
         else . end |
 
         # Ensure Stop array exists

--- a/scripts/lib/inject-status-hooks.sh
+++ b/scripts/lib/inject-status-hooks.sh
@@ -27,6 +27,7 @@ if [[ -f "${KAPSIS_LIB:-/opt/kapsis/lib}/logging.sh" ]]; then
 else
     log_info() { echo "[INFO] $*"; }
     log_warn() { echo "[WARN] $*" >&2; }
+    log_error() { echo "[ERROR] $*" >&2; }
     log_debug() { :; }
     log_success() { echo "[OK] $*"; }
 fi
@@ -72,7 +73,7 @@ inject_claude_hooks() {
     local GIST_HOOK="${KAPSIS_HOOK_DIR}/kapsis-gist-hook.sh"
     local inject_gist="${KAPSIS_INJECT_GIST:-false}"
     if [[ "$inject_gist" == "true" && ! -x "$GIST_HOOK" ]]; then
-        log_warn "Gist hook not found or not executable: $GIST_HOOK -- skipping gist hook injection"
+        log_error "Gist hook not found or not executable: $GIST_HOOK -- KAPSIS_INJECT_GIST=true but gist hook will NOT be injected"
         inject_gist="false"
     fi
 
@@ -100,22 +101,24 @@ inject_claude_hooks() {
         # Ensure PostToolUse array exists
         .hooks.PostToolUse //= [] |
 
-        # Add status hook to PostToolUse if not already present
+        # Add gist hook to PostToolUse FIRST if KAPSIS_INJECT_GIST=true and not already present.
+        # Gist must fire before the status hook so that status_read_gist_file() reads the
+        # current gist (not the previous one).
+        if $inject_gist == "true" then
+            if ([.hooks.PostToolUse[].hooks[]? | select(.command == $gist_hook)] | length) == 0 then
+                .hooks.PostToolUse += [{
+                    "matcher": "*",
+                    "hooks": [{"type": "command", "command": $gist_hook, "timeout": 10}]
+                }]
+            else . end
+        else . end |
+
+        # Add status hook to PostToolUse after gist hook if not already present
         if ([.hooks.PostToolUse[].hooks[]? | select(.command == $status_hook)] | length) == 0 then
             .hooks.PostToolUse += [{
                 "matcher": "*",
                 "hooks": [{"type": "command", "command": $status_hook, "timeout": 5}]
             }]
-        else . end |
-
-        # Add gist hook to PostToolUse if KAPSIS_INJECT_GIST=true and not already present
-        if $inject_gist == "true" then
-            if ([.hooks.PostToolUse[].hooks[]? | select(.command == $gist_hook)] | length) == 0 then
-                .hooks.PostToolUse += [{
-                    "matcher": "*",
-                    "hooks": [{"type": "command", "command": $gist_hook, "timeout": 5}]
-                }]
-            else . end
         else . end |
 
         # Ensure Stop array exists

--- a/tests/test-status-hooks.sh
+++ b/tests/test-status-hooks.sh
@@ -1059,7 +1059,10 @@ test_gist_hook_bash_fallback_first_run() {
         bash "$HOOKS_DIR/kapsis-gist-hook.sh" 2>/dev/null || true
 
     assert_file_exists "$tmp_gist" "gist.txt should be written on first Bash call"
-    assert_contains "$(cat "$tmp_gist")" "Running:" "fallback gist should have 'Running:' prefix"
+    local content
+    content=$(cat "$tmp_gist")
+    assert_contains "$content" "Running:" "fallback gist should have 'Running:' prefix"
+    assert_contains "$content" "curl" "fallback gist should contain extracted command name"
 
     rm -rf "$tmp_dir"
 }
@@ -1172,17 +1175,21 @@ test_inject_gist_hook_not_injected_when_disabled() {
 # LLM Gist Throttle Tests
 #===============================================================================
 
-# Helper: create a mock claude binary that records invocations
+# Helper: create a mock claude binary that records invocations.
+# Uses a quoted heredoc + separate files for output/exit_code so that
+# special characters in $output or $exit_code cannot break the generated script.
 _make_mock_claude() {
     local mock_dir="$1"
     local exit_code="${2:-0}"
     local output="${3:-LLM result text}"
     mkdir -p "$mock_dir"
-    cat > "$mock_dir/claude" << EOF
+    printf '%s\n' "$output" > "$mock_dir/claude_output"
+    printf '%d\n' "$exit_code" > "$mock_dir/claude_exitcode"
+    cat > "$mock_dir/claude" << 'EOF'
 #!/usr/bin/env bash
-touch "\$(dirname "\$0")/../llm_called_marker"
-echo "$output"
-exit $exit_code
+touch "$(dirname "$0")/../llm_called_marker"
+cat "$(dirname "$0")/claude_output"
+exit "$(cat "$(dirname "$0")/claude_exitcode")"
 EOF
     chmod +x "$mock_dir/claude"
 }
@@ -1232,13 +1239,15 @@ test_gist_llm_high_signal_bypasses_gate() {
 
     local input='{"tool_name":"Bash","tool_input":{"command":"git commit -m \"fix: null gist\""}}'
 
+    # KAPSIS_GIST_LLM_SYNC=true: synchronous mode so the test can inspect results immediately.
+    # Stamp path is derived from dirname(KAPSIS_GIST_FILE) — no separate env var needed.
     PATH="$mock_dir:$PATH" \
     KAPSIS_STATUS_AGENT_ID="test-llm-high" \
     KAPSIS_INJECT_GIST=true \
     KAPSIS_GIST_LLM=true \
+    KAPSIS_GIST_LLM_SYNC=true \
     KAPSIS_GIST_LLM_INTERVAL=3600 \
     KAPSIS_GIST_FILE="$gist_file" \
-    KAPSIS_GIST_FILE_DIR="$tmp_dir" \
     bash "$HOOKS_DIR/kapsis-gist-hook.sh" <<< "$input" 2>/dev/null
 
     # LLM must have been called despite fresh stamp (git commit = high-signal)
@@ -1267,6 +1276,7 @@ test_gist_llm_fallback_on_failure() {
     KAPSIS_STATUS_AGENT_ID="test-llm-fail" \
     KAPSIS_INJECT_GIST=true \
     KAPSIS_GIST_LLM=true \
+    KAPSIS_GIST_LLM_SYNC=true \
     KAPSIS_GIST_FILE="$gist_file" \
     bash "$HOOKS_DIR/kapsis-gist-hook.sh" <<< "$input" 2>/dev/null
 
@@ -1295,11 +1305,82 @@ test_gist_llm_stamp_created_on_success() {
     KAPSIS_STATUS_AGENT_ID="test-llm-stamp" \
     KAPSIS_INJECT_GIST=true \
     KAPSIS_GIST_LLM=true \
+    KAPSIS_GIST_LLM_SYNC=true \
     KAPSIS_GIST_FILE="$gist_file" \
     bash "$HOOKS_DIR/kapsis-gist-hook.sh" <<< "$input" 2>/dev/null
 
     # Stamp file must be created after successful LLM call
     assert_file_exists "$stamp_file" "Stamp file should be created after successful LLM call"
+
+    rm -rf "$tmp_dir"
+}
+
+#===============================================================================
+# Test: Stop Hook Bug 1 fix — reads gist before writing final status
+#===============================================================================
+
+test_stop_hook_reads_gist_before_completion() {
+    local tmp_dir kapsis_home marker
+    tmp_dir=$(mktemp -d)
+    kapsis_home="${tmp_dir}/kapsis"
+    marker="${tmp_dir}/gist_read_called"
+
+    # Provide a mock status.sh that records status_read_gist_file calls
+    mkdir -p "${kapsis_home}/lib"
+    cat > "${kapsis_home}/lib/status.sh" << EOF
+status_reinit_from_env() { :; }
+status_phase() { :; }
+status_read_gist_file() { touch '$marker'; }
+EOF
+
+    KAPSIS_HOME="$kapsis_home" \
+    KAPSIS_STATUS_AGENT_ID="test-stop-gist" \
+    KAPSIS_STATUS_PROJECT="test-project" \
+    bash "$HOOKS_DIR/kapsis-stop-hook.sh" <<< '{}' 2>/dev/null || true
+
+    assert_file_exists "$marker" \
+        "stop hook should call status_read_gist_file before writing final status (kapsis#285 Bug 1)"
+
+    rm -rf "$tmp_dir"
+}
+
+#===============================================================================
+# Test: Gist Hook edge cases
+#===============================================================================
+
+# Edit tool with tool_input.path key instead of tool_input.file_path
+test_gist_hook_edit_with_path_key() {
+    local content
+    content=$(_run_gist_hook '{"tool_name":"Edit","tool_input":{"path":"/workspace/src/Foo.java"}}')
+    assert_contains "$content" "Editing:" "gist should contain 'Editing:' when using .path key"
+    assert_contains "$content" "Foo.java" "gist should contain file basename from .path key"
+}
+
+# Agent ID regex guard rejects invalid formats in the gist hook
+test_gist_hook_skips_when_agent_id_invalid() {
+    local tmp_dir tmp_gist exit_code
+    tmp_dir=$(mktemp -d)
+    tmp_gist="$tmp_dir/.kapsis/gist.txt"
+    mkdir -p "$tmp_dir/.kapsis"
+    exit_code=0
+
+    printf '%s' '{"tool_name":"Bash","tool_input":{"command":"git commit -m \"test\""}}' | \
+        KAPSIS_STATUS_AGENT_ID="../evil" \
+        KAPSIS_INJECT_GIST="true" \
+        KAPSIS_GIST_FILE="$tmp_gist" \
+        bash "$HOOKS_DIR/kapsis-gist-hook.sh" 2>/dev/null || exit_code=$?
+
+    assert_equals "0" "$exit_code" "gist hook should exit 0 with path-traversal agent_id"
+    assert_false "[[ -f '$tmp_gist' ]]" "gist.txt should not be written with path-traversal agent_id"
+
+    # Also test special chars
+    printf '%s' '{"tool_name":"Bash","tool_input":{"command":"git commit -m \"test\""}}' | \
+        KAPSIS_STATUS_AGENT_ID="agent;rm-rf" \
+        KAPSIS_INJECT_GIST="true" \
+        KAPSIS_GIST_FILE="$tmp_gist" \
+        bash "$HOOKS_DIR/kapsis-gist-hook.sh" 2>/dev/null || true
+
+    assert_false "[[ -f '$tmp_gist' ]]" "gist.txt should not be written with special-char agent_id"
 
     rm -rf "$tmp_dir"
 }
@@ -1341,6 +1422,7 @@ run_tests() {
     run_test test_agent_id_invalid_special_chars_skips
     run_test test_agent_id_valid_formats_accepted
     run_test test_stop_hook_agent_id_validation
+    run_test test_stop_hook_reads_gist_before_completion
 
     log_info "=== Hook Injection (inject-status-hooks.sh) ==="
     run_test test_inject_claude_creates_settings_if_missing
@@ -1381,6 +1463,8 @@ run_tests() {
     run_test test_gist_hook_bash_fallback_no_overwrite
     run_test test_gist_hook_skips_when_agent_id_missing
     run_test test_gist_hook_skips_when_inject_gist_false
+    run_test test_gist_hook_edit_with_path_key
+    run_test test_gist_hook_skips_when_agent_id_invalid
 
     log_info "=== Gist Hook Injection ==="
     run_test test_inject_gist_hook_injected_when_enabled

--- a/tests/test-status-hooks.sh
+++ b/tests/test-status-hooks.sh
@@ -1169,6 +1169,142 @@ test_inject_gist_hook_not_injected_when_disabled() {
 }
 
 #===============================================================================
+# LLM Gist Throttle Tests
+#===============================================================================
+
+# Helper: create a mock claude binary that records invocations
+_make_mock_claude() {
+    local mock_dir="$1"
+    local exit_code="${2:-0}"
+    local output="${3:-LLM result text}"
+    mkdir -p "$mock_dir"
+    cat > "$mock_dir/claude" << EOF
+#!/usr/bin/env bash
+touch "\$(dirname "\$0")/../llm_called_marker"
+echo "$output"
+exit $exit_code
+EOF
+    chmod +x "$mock_dir/claude"
+}
+
+test_gist_llm_time_gate_blocks() {
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    local gist_file="${tmp_dir}/gist.txt"
+    local stamp_file="${tmp_dir}/gist.last_llm_run"
+    local mock_dir="${tmp_dir}/bin"
+
+    _make_mock_claude "$mock_dir"
+
+    # Create a fresh stamp file (set mtime to "now")
+    touch "$stamp_file"
+
+    # Use a Read tool event (non-high-signal) so deterministic gist is skipped
+    local input='{"tool_name":"Read","tool_input":{"file_path":"/workspace/foo.java"}}'
+
+    PATH="$mock_dir:$PATH" \
+    KAPSIS_STATUS_AGENT_ID="test-llm-gate" \
+    KAPSIS_INJECT_GIST=true \
+    KAPSIS_GIST_LLM=true \
+    KAPSIS_GIST_LLM_INTERVAL=3600 \
+    KAPSIS_GIST_FILE="$gist_file" \
+    bash "$HOOKS_DIR/kapsis-gist-hook.sh" <<< "$input" 2>/dev/null
+
+    # LLM must NOT have been called (stamp is fresh)
+    assert_false "[[ -f '${tmp_dir}/llm_called_marker' ]]" "LLM should be blocked by time gate"
+    # No gist written (Read tool + throttled)
+    assert_false "[[ -f '$gist_file' ]]" "No gist should be written when gate blocks"
+
+    rm -rf "$tmp_dir"
+}
+
+test_gist_llm_high_signal_bypasses_gate() {
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    local gist_file="${tmp_dir}/gist.txt"
+    local stamp_file="${tmp_dir}/gist.last_llm_run"
+    local mock_dir="${tmp_dir}/bin"
+
+    _make_mock_claude "$mock_dir" 0 "Committing the null-gist fix"
+
+    # Create a fresh stamp file — throttle would normally block
+    touch "$stamp_file"
+
+    local input='{"tool_name":"Bash","tool_input":{"command":"git commit -m \"fix: null gist\""}}'
+
+    PATH="$mock_dir:$PATH" \
+    KAPSIS_STATUS_AGENT_ID="test-llm-high" \
+    KAPSIS_INJECT_GIST=true \
+    KAPSIS_GIST_LLM=true \
+    KAPSIS_GIST_LLM_INTERVAL=3600 \
+    KAPSIS_GIST_FILE="$gist_file" \
+    KAPSIS_GIST_FILE_DIR="$tmp_dir" \
+    bash "$HOOKS_DIR/kapsis-gist-hook.sh" <<< "$input" 2>/dev/null
+
+    # LLM must have been called despite fresh stamp (git commit = high-signal)
+    assert_true "[[ -f '${tmp_dir}/llm_called_marker' ]]" "LLM should be called for high-signal git commit"
+    # Gist file should contain LLM output (overwriting deterministic)
+    assert_file_exists "$gist_file" "Gist file should exist after LLM call"
+    local content
+    content=$(cat "$gist_file")
+    assert_contains "$content" "Committing the null-gist fix" "Gist should contain LLM output"
+
+    rm -rf "$tmp_dir"
+}
+
+test_gist_llm_fallback_on_failure() {
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    local gist_file="${tmp_dir}/gist.txt"
+    local mock_dir="${tmp_dir}/bin"
+
+    # Mock claude exits with failure
+    _make_mock_claude "$mock_dir" 1 ""
+
+    local input='{"tool_name":"Bash","tool_input":{"command":"git commit -m \"fix: null gist\""}}'
+
+    PATH="$mock_dir:$PATH" \
+    KAPSIS_STATUS_AGENT_ID="test-llm-fail" \
+    KAPSIS_INJECT_GIST=true \
+    KAPSIS_GIST_LLM=true \
+    KAPSIS_GIST_FILE="$gist_file" \
+    bash "$HOOKS_DIR/kapsis-gist-hook.sh" <<< "$input" 2>/dev/null
+
+    # Deterministic gist must be preserved when LLM fails
+    assert_file_exists "$gist_file" "Gist file should exist (deterministic fallback)"
+    local content
+    content=$(cat "$gist_file")
+    assert_contains "$content" "Committing:" "Deterministic gist should be preserved on LLM failure"
+
+    rm -rf "$tmp_dir"
+}
+
+test_gist_llm_stamp_created_on_success() {
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    local gist_file="${tmp_dir}/gist.txt"
+    local stamp_file="${tmp_dir}/gist.last_llm_run"
+    local mock_dir="${tmp_dir}/bin"
+
+    _make_mock_claude "$mock_dir" 0 "Writing the gist hook implementation"
+
+    # No existing stamp — first run
+    local input='{"tool_name":"Write","tool_input":{"file_path":"/workspace/foo.sh"}}'
+
+    PATH="$mock_dir:$PATH" \
+    KAPSIS_STATUS_AGENT_ID="test-llm-stamp" \
+    KAPSIS_INJECT_GIST=true \
+    KAPSIS_GIST_LLM=true \
+    KAPSIS_GIST_FILE="$gist_file" \
+    bash "$HOOKS_DIR/kapsis-gist-hook.sh" <<< "$input" 2>/dev/null
+
+    # Stamp file must be created after successful LLM call
+    assert_file_exists "$stamp_file" "Stamp file should be created after successful LLM call"
+
+    rm -rf "$tmp_dir"
+}
+
+#===============================================================================
 # Run Tests
 #===============================================================================
 run_tests() {
@@ -1249,6 +1385,12 @@ run_tests() {
     log_info "=== Gist Hook Injection ==="
     run_test test_inject_gist_hook_injected_when_enabled
     run_test test_inject_gist_hook_not_injected_when_disabled
+
+    log_info "=== Gist Hook LLM Throttle ==="
+    run_test test_gist_llm_time_gate_blocks
+    run_test test_gist_llm_high_signal_bypasses_gate
+    run_test test_gist_llm_fallback_on_failure
+    run_test test_gist_llm_stamp_created_on_success
 
     print_summary
 }

--- a/tests/test-status-hooks.sh
+++ b/tests/test-status-hooks.sh
@@ -892,6 +892,283 @@ test_progress_phase_mapping() {
 }
 
 #===============================================================================
+# Test: Gist Hook (kapsis-gist-hook.sh)
+#===============================================================================
+
+# Helper: run the gist hook with given JSON input, returns gist.txt content (or empty)
+_run_gist_hook() {
+    local json="$1"
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    mkdir -p "$tmp_dir/.kapsis"
+
+    printf '%s' "$json" | \
+        KAPSIS_STATUS_AGENT_ID="test-gist-agent" \
+        KAPSIS_INJECT_GIST="true" \
+        KAPSIS_GIST_FILE="$tmp_dir/.kapsis/gist.txt" \
+        bash "$HOOKS_DIR/kapsis-gist-hook.sh" 2>/dev/null || true
+
+    if [[ -f "$tmp_dir/.kapsis/gist.txt" ]]; then
+        cat "$tmp_dir/.kapsis/gist.txt"
+    fi
+    rm -rf "$tmp_dir"
+}
+
+test_gist_hook_git_commit() {
+    local tmp_dir tmp_gist
+    tmp_dir=$(mktemp -d)
+    tmp_gist="$tmp_dir/.kapsis/gist.txt"
+    mkdir -p "$tmp_dir/.kapsis"
+
+    printf '%s' '{"tool_name":"Bash","tool_input":{"command":"git commit -m \"fix: null check in UserService\""}}' | \
+        KAPSIS_STATUS_AGENT_ID="test123" \
+        KAPSIS_INJECT_GIST="true" \
+        KAPSIS_GIST_FILE="$tmp_gist" \
+        bash "$HOOKS_DIR/kapsis-gist-hook.sh" 2>/dev/null || true
+
+    assert_file_exists "$tmp_gist" "gist.txt should be written on git commit"
+    local content
+    content=$(cat "$tmp_gist")
+    assert_contains "$content" "Committing:" "gist should contain 'Committing:' prefix"
+    assert_contains "$content" "fix: null check" "gist should contain commit message"
+
+    rm -rf "$tmp_dir"
+}
+
+test_gist_hook_git_push() {
+    local tmp_dir tmp_gist
+    tmp_dir=$(mktemp -d)
+    tmp_gist="$tmp_dir/.kapsis/gist.txt"
+    mkdir -p "$tmp_dir/.kapsis"
+
+    printf '%s' '{"tool_name":"Bash","tool_input":{"command":"git push origin main"}}' | \
+        KAPSIS_STATUS_AGENT_ID="test123" \
+        KAPSIS_INJECT_GIST="true" \
+        KAPSIS_GIST_FILE="$tmp_gist" \
+        bash "$HOOKS_DIR/kapsis-gist-hook.sh" 2>/dev/null || true
+
+    assert_file_exists "$tmp_gist" "gist.txt should be written on git push"
+    assert_contains "$(cat "$tmp_gist")" "Pushing changes to remote" "gist should describe push"
+
+    rm -rf "$tmp_dir"
+}
+
+test_gist_hook_edit() {
+    local tmp_dir tmp_gist
+    tmp_dir=$(mktemp -d)
+    tmp_gist="$tmp_dir/.kapsis/gist.txt"
+    mkdir -p "$tmp_dir/.kapsis"
+
+    printf '%s' '{"tool_name":"Edit","tool_input":{"file_path":"/workspace/src/UserService.java"}}' | \
+        KAPSIS_STATUS_AGENT_ID="test123" \
+        KAPSIS_INJECT_GIST="true" \
+        KAPSIS_GIST_FILE="$tmp_gist" \
+        bash "$HOOKS_DIR/kapsis-gist-hook.sh" 2>/dev/null || true
+
+    assert_file_exists "$tmp_gist" "gist.txt should be written on Edit"
+    local content
+    content=$(cat "$tmp_gist")
+    assert_contains "$content" "Editing:" "gist should contain 'Editing:' prefix"
+    assert_contains "$content" "UserService.java" "gist should contain file basename"
+
+    rm -rf "$tmp_dir"
+}
+
+test_gist_hook_write() {
+    local tmp_dir tmp_gist
+    tmp_dir=$(mktemp -d)
+    tmp_gist="$tmp_dir/.kapsis/gist.txt"
+    mkdir -p "$tmp_dir/.kapsis"
+
+    printf '%s' '{"tool_name":"Write","tool_input":{"file_path":"/workspace/src/Config.java"}}' | \
+        KAPSIS_STATUS_AGENT_ID="test123" \
+        KAPSIS_INJECT_GIST="true" \
+        KAPSIS_GIST_FILE="$tmp_gist" \
+        bash "$HOOKS_DIR/kapsis-gist-hook.sh" 2>/dev/null || true
+
+    assert_file_exists "$tmp_gist" "gist.txt should be written on Write"
+    local content
+    content=$(cat "$tmp_gist")
+    assert_contains "$content" "Writing:" "gist should contain 'Writing:' prefix"
+    assert_contains "$content" "Config.java" "gist should contain file basename"
+
+    rm -rf "$tmp_dir"
+}
+
+test_gist_hook_running_tests_mvn() {
+    local content
+    content=$(_run_gist_hook '{"tool_name":"Bash","tool_input":{"command":"mvn test -pl auth-module"}}')
+    assert_contains "$content" "Running tests" "gist should say 'Running tests' for mvn test"
+}
+
+test_gist_hook_running_tests_pytest() {
+    local content
+    content=$(_run_gist_hook '{"tool_name":"Bash","tool_input":{"command":"pytest tests/ -v"}}')
+    assert_contains "$content" "Running tests" "gist should say 'Running tests' for pytest"
+}
+
+test_gist_hook_no_overwrite_on_read() {
+    local tmp_dir tmp_gist
+    tmp_dir=$(mktemp -d)
+    tmp_gist="$tmp_dir/.kapsis/gist.txt"
+    mkdir -p "$tmp_dir/.kapsis"
+
+    printf 'Building: authentication module\n' > "$tmp_gist"
+
+    printf '%s' '{"tool_name":"Read","tool_input":{"file_path":"/workspace/src/Auth.java"}}' | \
+        KAPSIS_STATUS_AGENT_ID="test123" \
+        KAPSIS_INJECT_GIST="true" \
+        KAPSIS_GIST_FILE="$tmp_gist" \
+        bash "$HOOKS_DIR/kapsis-gist-hook.sh" 2>/dev/null || true
+
+    assert_equals "Building: authentication module" "$(cat "$tmp_gist")" "gist.txt should be unchanged after Read"
+
+    rm -rf "$tmp_dir"
+}
+
+test_gist_hook_no_overwrite_on_grep() {
+    local tmp_dir tmp_gist
+    tmp_dir=$(mktemp -d)
+    tmp_gist="$tmp_dir/.kapsis/gist.txt"
+    mkdir -p "$tmp_dir/.kapsis"
+
+    printf 'Running tests\n' > "$tmp_gist"
+
+    printf '%s' '{"tool_name":"Grep","tool_input":{"pattern":"TODO"}}' | \
+        KAPSIS_STATUS_AGENT_ID="test123" \
+        KAPSIS_INJECT_GIST="true" \
+        KAPSIS_GIST_FILE="$tmp_gist" \
+        bash "$HOOKS_DIR/kapsis-gist-hook.sh" 2>/dev/null || true
+
+    assert_equals "Running tests" "$(cat "$tmp_gist")" "gist.txt should be unchanged after Grep"
+
+    rm -rf "$tmp_dir"
+}
+
+test_gist_hook_bash_fallback_first_run() {
+    local tmp_dir tmp_gist
+    tmp_dir=$(mktemp -d)
+    tmp_gist="$tmp_dir/.kapsis/gist.txt"
+    mkdir -p "$tmp_dir/.kapsis"
+
+    # No pre-existing gist.txt — first run should write fallback
+    printf '%s' '{"tool_name":"Bash","tool_input":{"command":"curl -s https://api.example.com"}}' | \
+        KAPSIS_STATUS_AGENT_ID="test123" \
+        KAPSIS_INJECT_GIST="true" \
+        KAPSIS_GIST_FILE="$tmp_gist" \
+        bash "$HOOKS_DIR/kapsis-gist-hook.sh" 2>/dev/null || true
+
+    assert_file_exists "$tmp_gist" "gist.txt should be written on first Bash call"
+    assert_contains "$(cat "$tmp_gist")" "Running:" "fallback gist should have 'Running:' prefix"
+
+    rm -rf "$tmp_dir"
+}
+
+test_gist_hook_bash_fallback_no_overwrite() {
+    local tmp_dir tmp_gist
+    tmp_dir=$(mktemp -d)
+    tmp_gist="$tmp_dir/.kapsis/gist.txt"
+    mkdir -p "$tmp_dir/.kapsis"
+
+    printf 'Committing: fix: auth bug\n' > "$tmp_gist"
+
+    # Unrecognized Bash command when gist already exists — should NOT overwrite
+    printf '%s' '{"tool_name":"Bash","tool_input":{"command":"ls -la /workspace"}}' | \
+        KAPSIS_STATUS_AGENT_ID="test123" \
+        KAPSIS_INJECT_GIST="true" \
+        KAPSIS_GIST_FILE="$tmp_gist" \
+        bash "$HOOKS_DIR/kapsis-gist-hook.sh" 2>/dev/null || true
+
+    assert_equals "Committing: fix: auth bug" "$(cat "$tmp_gist")" "gist.txt should not be overwritten by unrecognized Bash"
+
+    rm -rf "$tmp_dir"
+}
+
+test_gist_hook_skips_when_agent_id_missing() {
+    local tmp_dir tmp_gist exit_code
+    tmp_dir=$(mktemp -d)
+    tmp_gist="$tmp_dir/.kapsis/gist.txt"
+    mkdir -p "$tmp_dir/.kapsis"
+    exit_code=0
+
+    printf '%s' '{"tool_name":"Bash","tool_input":{"command":"git commit -m \"test\""}}' | \
+        env -u KAPSIS_STATUS_AGENT_ID \
+        KAPSIS_INJECT_GIST="true" \
+        KAPSIS_GIST_FILE="$tmp_gist" \
+        bash "$HOOKS_DIR/kapsis-gist-hook.sh" 2>/dev/null || exit_code=$?
+
+    assert_equals "0" "$exit_code" "gist hook should exit 0 without agent_id"
+    assert_false "[[ -f '$tmp_gist' ]]" "gist.txt should not be written without agent_id"
+
+    rm -rf "$tmp_dir"
+}
+
+test_gist_hook_skips_when_inject_gist_false() {
+    local tmp_dir tmp_gist exit_code
+    tmp_dir=$(mktemp -d)
+    tmp_gist="$tmp_dir/.kapsis/gist.txt"
+    mkdir -p "$tmp_dir/.kapsis"
+    exit_code=0
+
+    printf '%s' '{"tool_name":"Bash","tool_input":{"command":"git commit -m \"test\""}}' | \
+        KAPSIS_STATUS_AGENT_ID="test123" \
+        KAPSIS_INJECT_GIST="false" \
+        KAPSIS_GIST_FILE="$tmp_gist" \
+        bash "$HOOKS_DIR/kapsis-gist-hook.sh" 2>/dev/null || exit_code=$?
+
+    assert_equals "0" "$exit_code" "gist hook should exit 0 when KAPSIS_INJECT_GIST=false"
+    assert_false "[[ -f '$tmp_gist' ]]" "gist.txt should not be written when gist disabled"
+
+    rm -rf "$tmp_dir"
+}
+
+#===============================================================================
+# Test: Gist Hook Injection into settings.local.json
+#===============================================================================
+
+test_inject_gist_hook_injected_when_enabled() {
+    setup_inject_test_env
+    export KAPSIS_STATUS_AGENT_ID="test-gist-hook-1"
+    export KAPSIS_INJECT_GIST="true"
+
+    # Create mock gist hook
+    touch "$KAPSIS_ROOT/hooks/kapsis-gist-hook.sh"
+    chmod +x "$KAPSIS_ROOT/hooks/kapsis-gist-hook.sh"
+
+    source "$LIB_DIR/inject-status-hooks.sh"
+    inject_claude_hooks >/dev/null 2>&1
+
+    local hook_count
+    hook_count=$(jq '.hooks.PostToolUse | length' "$TEST_HOME/.claude/settings.local.json")
+    assert_equals "2" "$hook_count" "Should have 2 PostToolUse entries (status + gist) when KAPSIS_INJECT_GIST=true"
+
+    local content
+    content=$(cat "$TEST_HOME/.claude/settings.local.json")
+    assert_contains "$content" "kapsis-gist-hook.sh" "settings should contain gist hook path"
+
+    cleanup_inject_test_env
+}
+
+test_inject_gist_hook_not_injected_when_disabled() {
+    setup_inject_test_env
+    export KAPSIS_STATUS_AGENT_ID="test-gist-hook-2"
+    unset KAPSIS_INJECT_GIST
+
+    source "$LIB_DIR/inject-status-hooks.sh"
+    inject_claude_hooks >/dev/null 2>&1
+
+    local hook_count
+    hook_count=$(jq '.hooks.PostToolUse | length' "$TEST_HOME/.claude/settings.local.json")
+    assert_equals "1" "$hook_count" "Should have 1 PostToolUse entry (status only) when KAPSIS_INJECT_GIST not set"
+
+    local content
+    content=$(cat "$TEST_HOME/.claude/settings.local.json")
+    assert_not_contains "$content" "kapsis-gist-hook.sh" "settings should not contain gist hook when disabled"
+
+    cleanup_inject_test_env
+}
+
+#===============================================================================
 # Run Tests
 #===============================================================================
 run_tests() {
@@ -954,6 +1231,24 @@ run_tests() {
     log_info "=== Agent Type Inference ==="
     run_test test_agent_type_inference_from_image_name
     run_test test_agent_type_normalization_priority
+
+    log_info "=== Gist Hook (kapsis-gist-hook.sh) ==="
+    run_test test_gist_hook_git_commit
+    run_test test_gist_hook_git_push
+    run_test test_gist_hook_edit
+    run_test test_gist_hook_write
+    run_test test_gist_hook_running_tests_mvn
+    run_test test_gist_hook_running_tests_pytest
+    run_test test_gist_hook_no_overwrite_on_read
+    run_test test_gist_hook_no_overwrite_on_grep
+    run_test test_gist_hook_bash_fallback_first_run
+    run_test test_gist_hook_bash_fallback_no_overwrite
+    run_test test_gist_hook_skips_when_agent_id_missing
+    run_test test_gist_hook_skips_when_inject_gist_false
+
+    log_info "=== Gist Hook Injection ==="
+    run_test test_inject_gist_hook_injected_when_enabled
+    run_test test_inject_gist_hook_not_injected_when_disabled
 
     print_summary
 }


### PR DESCRIPTION
## Summary

Fixes the `gist` field always being `null` in Kapsis status JSONs (kapsis#285).

Two root causes fixed:
- **Bug 1**: `kapsis-stop-hook.sh` never called `status_read_gist_file()` — the gist written as the agent's final action was always dropped at the stop event
- **Bug 2/3**: Agents were supposed to write `gist.txt` themselves (via CLAUDE.md instructions), but that file gets reverted by `git restore` and agents don't reliably comply

### Commit 1 — `fix(gist): deterministic gist hook; stop hook reads gist on completion`

- **New `scripts/hooks/kapsis-gist-hook.sh`**: PostToolUse hook that derives a one-line activity summary from `tool_name` + `tool_input` automatically. No agent cooperation or CLAUDE.md injection needed.
  - `git commit` → `"Committing: <extracted -m message>"`
  - `git push` → `"Pushing changes to remote"`
  - `mvn/gradle test`, `pytest`, `go test`, `jest` → `"Running tests"`
  - build commands → `"Building project"`
  - `Edit` → `"Editing: <basename>"`
  - `Write` → `"Writing: <basename>"`
  - First-run Bash fallback → `"Running: <first_word>"`
  - Read/Glob/Grep and other tools → preserve existing gist unchanged
  - Guards: `KAPSIS_STATUS_AGENT_ID` (hook context) + `KAPSIS_INJECT_GIST=true` (opt-in)
  - `KAPSIS_GIST_FILE` env override for test isolation
- **Fixed `scripts/hooks/kapsis-stop-hook.sh`**: call `status_read_gist_file()` after `status_reinit_from_env` so the final gist is captured in the stop event
- **Updated `scripts/lib/inject-status-hooks.sh`**: inject gist hook as second PostToolUse entry when `KAPSIS_INJECT_GIST=true` (idempotent)
- 14 new tests

### Commit 2 — `feat(gist): LLM gist upgrade with 60s throttle and high-signal override`

Optional LLM layer (`KAPSIS_GIST_LLM=true`) on top of the deterministic hook:
- Calls `claude-haiku-4-5-20251001 --print` to generate a natural-language sentence describing what the agent is doing
- 60s throttle via mtime of `gist.last_llm_run` (configurable via `KAPSIS_GIST_LLM_INTERVAL`)
- High-signal events (`git commit`, `Write` tool) always bypass throttle
- Atomic write: `mktemp` + `mv` on same filesystem
- Graceful fallback: `$(cmd) || gist_llm=""` — failed/timeout LLM call never corrupts the deterministic gist
- 4 new tests (throttle gate, high-signal bypass, fallback, stamp creation)

## Test plan

- [ ] `bash tests/test-status-hooks.sh` — 56/56 pass
- [ ] Smoke test:
  ```bash
  echo '{"tool_name":"Bash","tool_input":{"command":"git commit -m \"fix: null check\""}}' | \
    KAPSIS_STATUS_AGENT_ID=test123 KAPSIS_INJECT_GIST=true KAPSIS_GIST_FILE=/tmp/test-gist.txt \
    bash scripts/hooks/kapsis-gist-hook.sh && cat /tmp/test-gist.txt
  # → Committing: fix: null check
  ```
- [ ] Stop hook: `echo '{}' | KAPSIS_STATUS_AGENT_ID="" bash scripts/hooks/kapsis-stop-hook.sh` exits 0

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)