### PR TITLE
feat(gist): wire KAPSIS_GIST_LLM flags to YAML config

### DIFF
--- a/docs/CONFIG-REFERENCE.md
+++ b/docs/CONFIG-REFERENCE.md
@@ -153,6 +153,19 @@ agent:
   # Default: false (opt-in for safe rollout)
   inject_gist: false
 
+  # Enable LLM-based gist upgrade (requires inject_gist: true)
+  # When true, uses claude-haiku to generate a richer activity summary after each tool call.
+  # Runs asynchronously (hook exits immediately; LLM writes gist.txt in background).
+  # Throttled to one LLM call per gist_llm_interval seconds; git commit and Write tool
+  # calls always bypass the throttle (high-signal events).
+  # Default: false (opt-in — adds Haiku API call per throttle window)
+  gist_llm: false
+
+  # Throttle interval for LLM gist upgrade (seconds between LLM calls)
+  # High-signal tool calls (git commit, Write) always bypass this interval.
+  # Default: 60
+  gist_llm_interval: 60
+
 #===============================================================================
 # FILESYSTEM MOUNTS
 #===============================================================================

--- a/scripts/launch-agent.sh
+++ b/scripts/launch-agent.sh
@@ -761,6 +761,9 @@ parse_config() {
         AGENT_WORKDIR=$(yq -r '.agent.workdir // "/workspace"' "$CONFIG_FILE")
         # Gist instruction injection (default: false for safe rollout)
         INJECT_GIST=$(yq -r '.agent.inject_gist // "false"' "$CONFIG_FILE")
+        # LLM gist upgrade layer (default: false — adds per-tool Haiku API call)
+        GIST_LLM=$(yq -r '.agent.gist_llm // "false"' "$CONFIG_FILE")
+        GIST_LLM_INTERVAL=$(yq -r '.agent.gist_llm_interval // "60"' "$CONFIG_FILE")
         RESOURCE_MEMORY=$(yq -r '.resources.memory // "8g"' "$CONFIG_FILE")
         RESOURCE_CPUS=$(yq -r '.resources.cpus // "4"' "$CONFIG_FILE")
         SANDBOX_UPPER_BASE=$(yq -r '.sandbox.upper_dir_base // "~/.ai-sandboxes"' "$CONFIG_FILE")
@@ -1776,6 +1779,8 @@ generate_env_vars() {
     ENV_VARS+=("-e" "KAPSIS_STATUS_AGENT_ID=${AGENT_ID}")
     ENV_VARS+=("-e" "KAPSIS_STATUS_BRANCH=${BRANCH:-}")
     ENV_VARS+=("-e" "KAPSIS_INJECT_GIST=${INJECT_GIST:-false}")
+    ENV_VARS+=("-e" "KAPSIS_GIST_LLM=${GIST_LLM:-false}")
+    ENV_VARS+=("-e" "KAPSIS_GIST_LLM_INTERVAL=${GIST_LLM_INTERVAL:-60}")
 
     # Audit environment variables
     if [[ "${KAPSIS_AUDIT_ENABLED:-${KAPSIS_DEFAULT_AUDIT_ENABLED}}" == "true" ]]; then

--- a/scripts/lib/config-verifier.sh
+++ b/scripts/lib/config-verifier.sh
@@ -336,6 +336,28 @@ validate_launch_config() {
         fi
     fi
 
+    # Validate agent.gist_llm if present
+    local gist_llm
+    gist_llm=$(yq -r '.agent.gist_llm // ""' "$config_file" 2>/dev/null)
+    if [[ -n "$gist_llm" && "$gist_llm" != "null" ]]; then
+        if [[ "$gist_llm" == "true" || "$gist_llm" == "false" ]]; then
+            log_pass "Valid agent.gist_llm: $gist_llm"
+        else
+            log_error "Invalid agent.gist_llm: $gist_llm (must be true/false)"
+        fi
+    fi
+
+    # Validate agent.gist_llm_interval if present
+    local gist_llm_interval
+    gist_llm_interval=$(yq -r '.agent.gist_llm_interval // ""' "$config_file" 2>/dev/null)
+    if [[ -n "$gist_llm_interval" && "$gist_llm_interval" != "null" ]]; then
+        if [[ "$gist_llm_interval" =~ ^[1-9][0-9]*$ ]]; then
+            log_pass "Valid agent.gist_llm_interval: $gist_llm_interval"
+        else
+            log_error "Invalid agent.gist_llm_interval: $gist_llm_interval (must be a positive integer)"
+        fi
+    fi
+
     # Validate lsp_servers if present
     validate_lsp_config "$config_file"
 


### PR DESCRIPTION
## Summary

- Add `agent.gist_llm` (boolean, default `false`) to YAML config — enables the LLM-based gist upgrade layer (Haiku) without needing to set env vars directly
- Add `agent.gist_llm_interval` (positive integer, default `60`) to YAML config — controls the per-agent throttle window in seconds
- `launch-agent.sh`: reads both keys via `yq` and passes them as `KAPSIS_GIST_LLM` / `KAPSIS_GIST_LLM_INTERVAL` env vars into the container
- `config-verifier.sh`: validates `gist_llm` is `true`/`false` and `gist_llm_interval` is a positive integer
- `docs/CONFIG-REFERENCE.md`: documents both keys alongside the existing `inject_gist` key

Follows on from #287 (v2.21.7) which introduced the gist hook but left `KAPSIS_GIST_LLM` / `KAPSIS_GIST_LLM_INTERVAL` env-var-only.

## Test plan

- [x] `bash tests/test-status-hooks.sh` — 59/59 passing (no changes to test scope; existing LLM throttle tests cover the feature)
- [ ] Set `agent.gist_llm: true` in a config file and launch an agent — verify `KAPSIS_GIST_LLM=true` appears in container env
- [ ] Set `agent.gist_llm_interval: 30` — verify `KAPSIS_GIST_LLM_INTERVAL=30` in container env
- [ ] Set `agent.gist_llm: banana` — verify config-verifier rejects it with an error

🤖 Generated with [Claude Code](https://claude.com/claude-code)