### PR TITLE
fix: surface worktree errors, GC failed worktrees, recover zombie Podman VM [SUPERSEDED]

### DIFF
--- a/scripts/lib/compat.sh
+++ b/scripts/lib/compat.sh
@@ -343,15 +343,28 @@ _recover_podman_ssh_tunnel() {
         return 0
     fi
 
-    # Tunnel is stale — attempt recovery via stop + start
+    # Tunnel is stale — attempt recovery via stop + start.
+    # For zombie VMs where all podman commands hang, kill the vfkit hypervisor
+    # directly when machine stop times out (Issue #273).
+    local _stop_ok=true
     if [[ -n "$_KAPSIS_TIMEOUT_CMD" ]]; then
-        "$_KAPSIS_TIMEOUT_CMD" 30 podman machine stop podman-machine-default &>/dev/null || true
+        "$_KAPSIS_TIMEOUT_CMD" 30 podman machine stop podman-machine-default &>/dev/null || _stop_ok=false
+        if [[ "$_stop_ok" == "false" ]]; then
+            declare -f log_warn &>/dev/null && log_warn "podman machine stop timed out — killing vfkit hypervisor (zombie VM recovery)"
+            pkill -9 -f vfkit &>/dev/null || true
+            sleep 3
+        fi
         if ! "$_KAPSIS_TIMEOUT_CMD" 60 podman machine start podman-machine-default 2>/dev/null; then
             # Log start failure for diagnosis (visible with KAPSIS_DEBUG=1)
             declare -f log_debug &>/dev/null && log_debug "podman machine start failed during SSH recovery"
         fi
     else
-        podman machine stop podman-machine-default &>/dev/null || true
+        podman machine stop podman-machine-default &>/dev/null || _stop_ok=false
+        if [[ "$_stop_ok" == "false" ]]; then
+            declare -f log_warn &>/dev/null && log_warn "podman machine stop failed — killing vfkit hypervisor (zombie VM recovery)"
+            pkill -9 -f vfkit &>/dev/null || true
+            sleep 3
+        fi
         if ! podman machine start podman-machine-default 2>/dev/null; then
             declare -f log_debug &>/dev/null && log_debug "podman machine start failed during SSH recovery"
         fi

--- a/scripts/preflight-check.sh
+++ b/scripts/preflight-check.sh
@@ -298,6 +298,42 @@ check_orphan_volumes() {
     return 0
 }
 
+# Check for stale/corrupted registered worktrees (Fix #283)
+check_stale_worktrees() {
+    local project_path="${1:-.}"
+
+    # Only meaningful for git repos
+    if ! git -C "$project_path" rev-parse --git-dir &>/dev/null 2>&1; then
+        return 0
+    fi
+
+    log_info "Checking for stale registered worktrees..."
+
+    # Detect worktrees registered in git but missing or corrupted on disk
+    local stale_count=0
+    stale_count=$(git -C "$project_path" worktree prune --dry-run 2>&1 | grep -c "^Removing" || true)
+
+    if [[ "$stale_count" -gt 0 ]]; then
+        preflight_warn "$stale_count stale worktree(s) registered in git but missing/corrupted on disk"
+        preflight_warn "  Run: git -C $project_path worktree prune"
+    fi
+
+    # Warn when total worktree count is high (subtract 1 for the main worktree)
+    local wt_total=0
+    wt_total=$(git -C "$project_path" worktree list --porcelain 2>/dev/null | grep -c "^worktree " || true)
+    local wt_count=$(( wt_total > 1 ? wt_total - 1 : 0 ))
+    local warn_threshold="${KAPSIS_WORKTREE_COUNT_WARN:-20}"
+
+    if [[ "$wt_count" -gt "$warn_threshold" ]]; then
+        preflight_warn "$wt_count worktrees registered for this project — risk of disk exhaustion"
+        preflight_warn "  Run: kapsis cleanup --worktrees --project $(basename "$project_path")"
+    elif [[ "$stale_count" -eq 0 ]]; then
+        preflight_ok "Worktrees OK ($wt_count registered)"
+    fi
+
+    return 0
+}
+
 # Check available disk space (Fix #191)
 check_disk_space() {
     local warn_mb="${KAPSIS_DISK_WARN_MB:-2048}"    # 2GB default
@@ -356,6 +392,7 @@ preflight_check() {
         check_git_status "$project_path" || true
         check_branch_conflict "$project_path" "$target_branch" || true
         check_existing_worktree "$project_path" "$agent_id" || true
+        check_stale_worktrees "$project_path" || true
     fi
 
     if [[ -n "$spec_file" ]]; then

--- a/scripts/worktree-manager.sh
+++ b/scripts/worktree-manager.sh
@@ -58,9 +58,10 @@ run_git() {
         log_debug "git output: $git_output"
     fi
 
-    # Log failure if non-zero exit
+    # Log failure if non-zero exit; expose for callers via module-level var (Fix #282)
     if [[ $git_exit_code -ne 0 ]]; then
         log_debug "git command failed with exit code: $git_exit_code"
+        _KAPSIS_LAST_GIT_ERR="$git_output"
     fi
 
     return $git_exit_code
@@ -356,6 +357,10 @@ create_worktree() {
     # Verify worktree was actually created
     if [[ ! -d "$worktree_path" ]]; then
         log_error "Worktree directory was not created: $worktree_path"
+        # Surface the actual git error instead of leaving the user to guess (Fix #282)
+        if [[ -n "${_KAPSIS_LAST_GIT_ERR:-}" ]]; then
+            log_error "git worktree add error: $_KAPSIS_LAST_GIT_ERR"
+        fi
         log_error ""
 
         # Check if another worktree has this branch (Fix #1: enhanced diagnostics)
@@ -907,13 +912,32 @@ gc_stale_worktrees() {
         local worktree_path="${KAPSIS_WORKTREE_BASE}/${project_name}-${agent_id}"
         [[ -d "$worktree_path" ]] || continue
 
-        # Only clean completed agents
+        # Clean completed agents immediately; age-GC error/failed/killed worktrees (Fix #283)
         local phase
         phase=$(jq -r '.phase // empty' "$status_file" 2>/dev/null) || continue
         if [[ "$phase" == "complete" ]]; then
             log_info "GC: Cleaning stale worktree for completed agent $agent_id"
             cleanup_worktree "$project_path" "$agent_id"
             ((cleaned++)) || true
+        elif [[ "$phase" == "error" || "$phase" == "failed" || "$phase" == "killed" ]]; then
+            local max_age_hours="${KAPSIS_CLEANUP_WORKTREE_MAX_AGE_HOURS:-${KAPSIS_DEFAULT_CLEANUP_WORKTREE_MAX_AGE_HOURS:-168}}"
+            if [[ "$max_age_hours" -gt 0 ]] 2>/dev/null; then
+                if ! declare -f get_dir_mtime &>/dev/null; then
+                    [[ -f "$WORKTREE_SCRIPT_DIR/lib/compat.sh" ]] && source "$WORKTREE_SCRIPT_DIR/lib/compat.sh" || true
+                fi
+                if declare -f get_dir_mtime &>/dev/null; then
+                    local mtime age_secs max_age_secs age_hours
+                    mtime=$(get_dir_mtime "$worktree_path") || continue
+                    age_secs=$(( $(date +%s) - mtime ))
+                    max_age_secs=$(( max_age_hours * 3600 ))
+                    if [[ "$age_secs" -gt "$max_age_secs" ]]; then
+                        age_hours=$(( age_secs / 3600 ))
+                        log_info "GC: Cleaning ${phase} worktree for agent $agent_id (${age_hours}h old, max: ${max_age_hours}h)"
+                        cleanup_worktree "$project_path" "$agent_id"
+                        ((cleaned++)) || true
+                    fi
+                fi
+            fi
         fi
     done
 


### PR DESCRIPTION
**Superseded by separate PRs per issue:**

- #293 — fix #282: surface `git worktree add` error in logs
- #294 — fix #283: preflight stale-worktree warning + age-GC for error/failed phases
- #295 — fix #273: zombie Podman VM recovery via vfkit kill on stop timeout

Closing this combined PR in favour of the three above.