### PR TITLE
fix(worktree): surface git worktree add error in logs when dir not created (#282)

### DIFF
--- a/scripts/worktree-manager.sh
+++ b/scripts/worktree-manager.sh
@@ -36,6 +36,9 @@ source "$WORKTREE_SCRIPT_DIR/lib/constants.sh"
 
 # Note: logging functions are provided by lib/logging.sh
 
+# Last git error output — reset before each run_git call, read by create_worktree
+_KAPSIS_LAST_GIT_ERR=""
+
 #===============================================================================
 # GIT COMMAND HELPER
 #
@@ -48,6 +51,7 @@ source "$WORKTREE_SCRIPT_DIR/lib/constants.sh"
 run_git() {
     local git_output
     local git_exit_code
+    _KAPSIS_LAST_GIT_ERR=""
 
     # Capture both stdout and stderr
     git_output=$("$@" 2>&1) && git_exit_code=0 || git_exit_code=$?

--- a/scripts/worktree-manager.sh
+++ b/scripts/worktree-manager.sh
@@ -58,9 +58,10 @@ run_git() {
         log_debug "git output: $git_output"
     fi
 
-    # Log failure if non-zero exit
+    # Log failure if non-zero exit; expose for callers via module-level var (Fix #282)
     if [[ $git_exit_code -ne 0 ]]; then
         log_debug "git command failed with exit code: $git_exit_code"
+        _KAPSIS_LAST_GIT_ERR="$git_output"
     fi
 
     return $git_exit_code
@@ -356,6 +357,10 @@ create_worktree() {
     # Verify worktree was actually created
     if [[ ! -d "$worktree_path" ]]; then
         log_error "Worktree directory was not created: $worktree_path"
+        # Surface the actual git error instead of leaving the user to guess (Fix #282)
+        if [[ -n "${_KAPSIS_LAST_GIT_ERR:-}" ]]; then
+            log_error "git worktree add error: $_KAPSIS_LAST_GIT_ERR"
+        fi
         log_error ""
 
         # Check if another worktree has this branch (Fix #1: enhanced diagnostics)


### PR DESCRIPTION
## Problem

When `git worktree add` fails during agent launch, the error is silently discarded. `run_git` captures stderr into a local variable and logs it only at `DEBUG` level — invisible in normal operation. The verification block then prints a generic 3-bullet list with no actual root cause.

Closes #282

## Fix

`run_git` now sets a module-level `_KAPSIS_LAST_GIT_ERR` variable whenever a git command fails. The "worktree directory was not created" error block reads this variable and logs it at `ERROR` level.

**Before:**
```
ERROR: Worktree directory was not created: /path/to/worktree
ERROR:
ERROR: This can happen when:
ERROR:   1. The branch is already checked out in the main repository
ERROR:   2. There's a git lock file preventing operations
ERROR:   3. Insufficient disk space or permissions
```

**After:**
```
ERROR: Worktree directory was not created: /path/to/worktree
ERROR: git worktree add error: fatal: '/dev/sda1': no space left on device
ERROR:
ERROR: This can happen when:
...
```

## Files changed

- `scripts/worktree-manager.sh` — 6 lines

## Test plan

- [ ] `bash -n scripts/worktree-manager.sh` passes
- [ ] Trigger a worktree creation failure (e.g. full disk, branch already checked out) and verify the actual git error appears in logs at ERROR level

https://claude.ai/code/session_01BGr5iZkgBCFL1ht3ougQ8g

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGr5iZkgBCFL1ht3ougQ8g)_