### PR TITLE
fix(gc): warn on stale worktrees at preflight; age-GC error/failed phases (#283)

### DIFF
--- a/scripts/preflight-check.sh
+++ b/scripts/preflight-check.sh
@@ -298,6 +298,42 @@ check_orphan_volumes() {
     return 0
 }
 
+# Check for stale/corrupted registered worktrees (Fix #283)
+check_stale_worktrees() {
+    local project_path="${1:-.}"
+
+    # Only meaningful for git repos
+    if ! git -C "$project_path" rev-parse --git-dir &>/dev/null 2>&1; then
+        return 0
+    fi
+
+    log_info "Checking for stale registered worktrees..."
+
+    # Detect worktrees registered in git but missing or corrupted on disk
+    local stale_count=0
+    stale_count=$(git -C "$project_path" worktree prune --dry-run 2>&1 | grep -c "^Removing" || true)
+
+    if [[ "$stale_count" -gt 0 ]]; then
+        preflight_warn "$stale_count stale worktree(s) registered in git but missing/corrupted on disk"
+        preflight_warn "  Run: git -C $project_path worktree prune"
+    fi
+
+    # Warn when total worktree count is high (subtract 1 for the main worktree)
+    local wt_total=0
+    wt_total=$(git -C "$project_path" worktree list --porcelain 2>/dev/null | grep -c "^worktree " || true)
+    local wt_count=$(( wt_total > 1 ? wt_total - 1 : 0 ))
+    local warn_threshold="${KAPSIS_WORKTREE_COUNT_WARN:-20}"
+
+    if [[ "$wt_count" -gt "$warn_threshold" ]]; then
+        preflight_warn "$wt_count worktrees registered for this project — risk of disk exhaustion"
+        preflight_warn "  Run: kapsis cleanup --worktrees --project $(basename "$project_path")"
+    elif [[ "$stale_count" -eq 0 ]]; then
+        preflight_ok "Worktrees OK ($wt_count registered)"
+    fi
+
+    return 0
+}
+
 # Check available disk space (Fix #191)
 check_disk_space() {
     local warn_mb="${KAPSIS_DISK_WARN_MB:-2048}"    # 2GB default
@@ -356,6 +392,7 @@ preflight_check() {
         check_git_status "$project_path" || true
         check_branch_conflict "$project_path" "$target_branch" || true
         check_existing_worktree "$project_path" "$agent_id" || true
+        check_stale_worktrees "$project_path" || true
     fi
 
     if [[ -n "$spec_file" ]]; then

--- a/scripts/worktree-manager.sh
+++ b/scripts/worktree-manager.sh
@@ -907,13 +907,32 @@ gc_stale_worktrees() {
         local worktree_path="${KAPSIS_WORKTREE_BASE}/${project_name}-${agent_id}"
         [[ -d "$worktree_path" ]] || continue
 
-        # Only clean completed agents
+        # Clean completed agents immediately; age-GC error/failed/killed worktrees (Fix #283)
         local phase
         phase=$(jq -r '.phase // empty' "$status_file" 2>/dev/null) || continue
         if [[ "$phase" == "complete" ]]; then
             log_info "GC: Cleaning stale worktree for completed agent $agent_id"
             cleanup_worktree "$project_path" "$agent_id"
             ((cleaned++)) || true
+        elif [[ "$phase" == "error" || "$phase" == "failed" || "$phase" == "killed" ]]; then
+            local max_age_hours="${KAPSIS_CLEANUP_WORKTREE_MAX_AGE_HOURS:-${KAPSIS_DEFAULT_CLEANUP_WORKTREE_MAX_AGE_HOURS:-168}}"
+            if [[ "$max_age_hours" -gt 0 ]] 2>/dev/null; then
+                if ! declare -f get_dir_mtime &>/dev/null; then
+                    [[ -f "$WORKTREE_SCRIPT_DIR/lib/compat.sh" ]] && source "$WORKTREE_SCRIPT_DIR/lib/compat.sh" || true
+                fi
+                if declare -f get_dir_mtime &>/dev/null; then
+                    local mtime age_secs max_age_secs age_hours
+                    mtime=$(get_dir_mtime "$worktree_path") || continue
+                    age_secs=$(( $(date +%s) - mtime ))
+                    max_age_secs=$(( max_age_hours * 3600 ))
+                    if [[ "$age_secs" -gt "$max_age_secs" ]]; then
+                        age_hours=$(( age_secs / 3600 ))
+                        log_info "GC: Cleaning ${phase} worktree for agent $agent_id (${age_hours}h old, max: ${max_age_hours}h)"
+                        cleanup_worktree "$project_path" "$agent_id"
+                        ((cleaned++)) || true
+                    fi
+                fi
+            fi
         fi
     done
 


### PR DESCRIPTION
## Problem

Preserved worktrees accumulate indefinitely with no GC, causing disk exhaustion. Two gaps:

1. No preflight warning when stale/corrupted worktrees are registered in git (detectable via `git worktree prune --dry-run`)
2. `gc_stale_worktrees` only cleaned `phase == "complete"` agents — worktrees from failed/errored/killed runs were never pruned by the status-file path

Closes #283

## Fix

### 1. New `check_stale_worktrees()` preflight check (`preflight-check.sh`)

- Runs `git worktree prune --dry-run` and warns when any stale/corrupted registered worktrees are found, with the remediation command
- Warns when total registered worktree count exceeds `KAPSIS_WORKTREE_COUNT_WARN` (default 20), directing to `kapsis cleanup --worktrees`
- Wired into `preflight_check()` alongside the existing branch checks — would have caught the 57-worktree scenario on the next launch

### 2. Age-GC for `error`/`failed`/`killed` phases (`worktree-manager.sh`)

- `gc_stale_worktrees` now applies `max_age_hours` (default 168h / 7 days) to worktrees whose status file shows a terminal-failure phase
- `compat.sh` is lazy-sourced for `get_dir_mtime` only when needed (same pattern as `gc_stale_worktrees_by_age`)

## Files changed

- `scripts/preflight-check.sh` — +36 lines (new function + 1-line wiring)
- `scripts/worktree-manager.sh` — +22 lines (GC extension)

## Test plan

- [ ] `bash -n scripts/preflight-check.sh scripts/worktree-manager.sh` passes
- [ ] Create a stale worktree registration, run preflight, verify warning appears
- [ ] Set a status file with `phase=error` on an old worktree dir, trigger GC, verify cleanup

https://claude.ai/code/session_01BGr5iZkgBCFL1ht3ougQ8g

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGr5iZkgBCFL1ht3ougQ8g)_