### PR TITLE
fix(compat): surface post-zombie-kill start failure as log_warn with remediation hint

### DIFF
--- a/scripts/lib/compat.sh
+++ b/scripts/lib/compat.sh
@@ -345,7 +345,6 @@ _recover_podman_ssh_tunnel() {
     local probe_timeout="${1:-10}"
     local max_retries="${2:-2}"
     local retry_delay="${3:-3}"
-    local machine="${KAPSIS_PODMAN_MACHINE:-podman-machine-default}"
 
     # Validate inputs — cap at sane upper bounds
     if ! [[ "$max_retries" =~ ^[0-9]+$ ]] || (( max_retries > 5 )); then

--- a/scripts/lib/compat.sh
+++ b/scripts/lib/compat.sh
@@ -328,6 +328,7 @@ _recover_podman_ssh_tunnel() {
     local probe_timeout="${1:-10}"
     local max_retries="${2:-2}"
     local retry_delay="${3:-3}"
+    local machine="${KAPSIS_PODMAN_MACHINE:-podman-machine-default}"
 
     # Validate inputs — cap at sane upper bounds
     if ! [[ "$max_retries" =~ ^[0-9]+$ ]] || (( max_retries > 5 )); then
@@ -345,15 +346,14 @@ _recover_podman_ssh_tunnel() {
 
     # Tunnel is stale — attempt recovery via stop + start
     if [[ -n "$_KAPSIS_TIMEOUT_CMD" ]]; then
-        "$_KAPSIS_TIMEOUT_CMD" 30 podman machine stop podman-machine-default &>/dev/null || true
-        if ! "$_KAPSIS_TIMEOUT_CMD" 60 podman machine start podman-machine-default 2>/dev/null; then
-            # Log start failure for diagnosis (visible with KAPSIS_DEBUG=1)
-            declare -f log_debug &>/dev/null && log_debug "podman machine start failed during SSH recovery"
+        "$_KAPSIS_TIMEOUT_CMD" 30 podman machine stop "$machine" &>/dev/null || true
+        if ! "$_KAPSIS_TIMEOUT_CMD" 60 podman machine start "$machine" 2>/dev/null; then
+            declare -f log_warn &>/dev/null && log_warn "podman machine start failed for '$machine' during SSH tunnel recovery — run: podman machine stop && podman machine start $machine"
         fi
     else
-        podman machine stop podman-machine-default &>/dev/null || true
-        if ! podman machine start podman-machine-default 2>/dev/null; then
-            declare -f log_debug &>/dev/null && log_debug "podman machine start failed during SSH recovery"
+        podman machine stop "$machine" &>/dev/null || true
+        if ! podman machine start "$machine" 2>/dev/null; then
+            declare -f log_warn &>/dev/null && log_warn "podman machine start failed for '$machine' during SSH tunnel recovery — run: podman machine stop && podman machine start $machine"
         fi
     fi
 


### PR DESCRIPTION
## Summary

Fixes #296.

After `_kill_vfkit_zombie` hard-kills vfkit and `podman machine start` subsequently fails inside `_recover_podman_ssh_tunnel`, the failure was logged at `log_debug` level — invisible unless `KAPSIS_DEBUG=1`. The user would eventually see a generic "SSH probe timeout" after all retries burned, with no clue that machine start itself had failed.

**Changes in `scripts/lib/compat.sh`:**
- Promoted both `log_debug` → `log_warn` in the two branches of `_recover_podman_ssh_tunnel` (timeout-cmd present / absent)
- Added machine name and actionable remediation hint to the message: `"podman machine start failed for 'podman-machine-default' during SSH tunnel recovery — run: podman machine stop && podman machine start podman-machine-default"`
- Extracted the hardcoded `"podman-machine-default"` string into a `local machine` variable that respects `KAPSIS_PODMAN_MACHINE` (consistent with `podman-health.sh`)

**`scripts/lib/podman-health.sh` not changed** — the `_podman_machine_restart` failure is already surfaced at `log_error` by its caller `maybe_autoheal_podman_vm`.

## Ensemble brainstorm notes

Two perspectives were evaluated before implementing:
- **Architect**: `log_warn` is correct (not `log_error`) because the outer retry loop hasn't been exhausted yet — a warn signals "recovery attempt failed, watch out" without prematurely declaring total failure.
- **Contrarian**: No false-alarm risk — a `podman machine start` failure here is always a real problem that warrants user attention; suppressing it to debug is exactly what caused the original issue.

## Test plan

- [ ] Simulate zombie recovery on macOS (applehv): `pkill -STOP -f vfkit`, trigger `_recover_podman_ssh_tunnel`, observe `[WARN]` message appears in normal output without `KAPSIS_DEBUG=1`
- [ ] Confirm `KAPSIS_PODMAN_MACHINE=my-vm` env var propagates into the warning message correctly
- [ ] Run quick tests: `./tests/run-all-tests.sh --quick`

https://claude.ai/code/session_01UR7Jg2uFCKwN9xZCRdLfG8

---
_Generated by [Claude Code](https://claude.ai/code/session_01UR7Jg2uFCKwN9xZCRdLfG8)_