### PR TITLE
fix(gist): add missing kapsis-gist-hook.sh to container image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -530,6 +530,7 @@ COPY scripts/lib/compat.sh /opt/kapsis/lib/compat.sh
 RUN mkdir -p /opt/kapsis/hooks/agent-adapters
 COPY scripts/hooks/kapsis-status-hook.sh /opt/kapsis/hooks/kapsis-status-hook.sh
 COPY scripts/hooks/kapsis-stop-hook.sh /opt/kapsis/hooks/kapsis-stop-hook.sh
+COPY scripts/hooks/kapsis-gist-hook.sh /opt/kapsis/hooks/kapsis-gist-hook.sh
 COPY scripts/hooks/tool-phase-mapping.sh /opt/kapsis/hooks/tool-phase-mapping.sh
 COPY scripts/hooks/agent-adapters/claude-adapter.sh /opt/kapsis/hooks/agent-adapters/claude-adapter.sh
 COPY scripts/hooks/agent-adapters/codex-adapter.sh /opt/kapsis/hooks/agent-adapters/codex-adapter.sh

--- a/scripts/hooks/kapsis-gist-hook.sh
+++ b/scripts/hooks/kapsis-gist-hook.sh
@@ -183,7 +183,7 @@ esac
 # Write deterministic gist
 if [[ "$skip" != "true" && -n "$gist" ]]; then
     mkdir -p "$GIST_DIR" 2>/dev/null || true
-    printf '%s\n' "$gist" > "$GIST_FILE"
+    printf '%s\n' "$gist" > "$GIST_FILE" 2>/dev/null || true
 fi
 
 # ─── LLM Gist upgrade (opt-in: KAPSIS_GIST_LLM=true) ────────────────────────

--- a/tests/test-status-hooks.sh
+++ b/tests/test-status-hooks.sh
@@ -436,6 +436,63 @@ test_inject_claude_idempotent() {
     cleanup_inject_test_env
 }
 
+test_inject_claude_with_gist_enabled() {
+    setup_inject_test_env
+    export KAPSIS_STATUS_AGENT_ID="test-agent-gist"
+    export KAPSIS_INJECT_GIST="true"
+
+    # Create mock gist hook (must be executable for injection to proceed)
+    touch "$KAPSIS_ROOT/hooks/kapsis-gist-hook.sh"
+    chmod +x "$KAPSIS_ROOT/hooks/kapsis-gist-hook.sh"
+
+    source "$LIB_DIR/inject-status-hooks.sh"
+    inject_claude_hooks >/dev/null 2>&1
+
+    local content
+    content=$(cat "$TEST_HOME/.claude/settings.local.json")
+
+    # Gist hook must appear in settings
+    assert_contains "$content" "kapsis-gist-hook.sh" "Gist hook should be injected when KAPSIS_INJECT_GIST=true"
+
+    # Two PostToolUse entries: gist hook (first) + status hook (second)
+    local hook_count
+    hook_count=$(jq '.hooks.PostToolUse | length' "$TEST_HOME/.claude/settings.local.json")
+    assert_equals "2" "$hook_count" "Should have 2 PostToolUse entries (gist + status)"
+
+    # Gist hook must come before status hook so status reads the current gist.
+    # Check ordering by comparing line positions in the serialized JSON.
+    local gist_line status_line
+    gist_line=$(grep -n "kapsis-gist-hook.sh" "$TEST_HOME/.claude/settings.local.json" | head -1 | cut -d: -f1)
+    status_line=$(grep -n "kapsis-status-hook.sh" "$TEST_HOME/.claude/settings.local.json" | head -1 | cut -d: -f1)
+    assert_true "[[ ${gist_line:-99} -lt ${status_line:-100} ]]" "Gist hook should appear before status hook in JSON"
+
+    unset KAPSIS_INJECT_GIST
+    cleanup_inject_test_env
+}
+
+test_inject_claude_gist_disabled_when_hook_missing() {
+    setup_inject_test_env
+    export KAPSIS_STATUS_AGENT_ID="test-agent-gist-missing"
+    export KAPSIS_INJECT_GIST="true"
+    # Intentionally do NOT create the gist hook file
+
+    source "$LIB_DIR/inject-status-hooks.sh"
+    inject_claude_hooks >/dev/null 2>&1
+
+    local content
+    content=$(cat "$TEST_HOME/.claude/settings.local.json")
+
+    # Gist hook must NOT appear when the hook file is missing
+    assert_not_contains "$content" "kapsis-gist-hook.sh" \
+        "Gist hook should not be injected when hook file is absent"
+
+    # Status hook must still be injected
+    assert_contains "$content" "kapsis-status-hook.sh" "Status hook should still be injected"
+
+    unset KAPSIS_INJECT_GIST
+    cleanup_inject_test_env
+}
+
 test_inject_codex_creates_config_if_missing() {
     # Requires mikefarah/yq (supports eval --inplace); skip if only Python yq available
     if ! echo 'x: 1' | yq eval '.x' 2>/dev/null | grep -q '^1'; then
@@ -1443,6 +1500,8 @@ run_tests() {
     run_test test_inject_claude_creates_settings_if_missing
     run_test test_inject_claude_merges_with_existing
     run_test test_inject_claude_idempotent
+    run_test test_inject_claude_with_gist_enabled
+    run_test test_inject_claude_gist_disabled_when_hook_missing
     run_test test_inject_codex_creates_config_if_missing
     run_test test_inject_codex_merges_with_existing
     run_test test_inject_codex_idempotent


### PR DESCRIPTION
## Summary

Fixes #202 — `inject_gist: true` is a no-op because `kapsis-gist-hook.sh` was never copied into the container image.

### Root cause

`inject_claude_hooks()` in `inject-status-hooks.sh` guards against a missing hook file before injecting it:

```bash
local GIST_HOOK="${KAPSIS_HOOK_DIR}/kapsis-gist-hook.sh"
if [[ "$inject_gist" == "true" && ! -x "$GIST_HOOK" ]]; then
    log_error "Gist hook not found or not executable: ..."
    inject_gist="false"   # ← silently disabled
fi
```

The `Containerfile` copied every other hook into `/opt/kapsis/hooks/` — `kapsis-status-hook.sh`, `kapsis-stop-hook.sh`, `tool-phase-mapping.sh`, agent adapters — but **never** `kapsis-gist-hook.sh`. So the file was always missing inside the container, the guard always fired, and `KAPSIS_INJECT_GIST=true` was silently downgraded to `false` at runtime.

### Ensemble brainstorm (architect / contrarian / defender)

| Lens | Finding |
|------|---------|
| **Architect** | Single `COPY` line is the minimal, targeted fix. Existing `chmod 755 /opt/kapsis/hooks/*.sh` glob already makes it executable. |
| **Contrarian** | Even with the hook present, an unguarded `printf ... > "$GIST_FILE"` under `set -euo pipefail` exits non-zero when `/workspace/.kapsis/` can't be created (e.g. macOS overlay edge case), causing the hook to report failure on every tool use. Worth hardening. |
| **Defender / test gap** | `inject_claude_hooks` tests never set `KAPSIS_INJECT_GIST=true`, so gist injection into Claude Code settings had zero test coverage. |

### Changes

- **`Containerfile`** — add the missing `COPY scripts/hooks/kapsis-gist-hook.sh /opt/kapsis/hooks/kapsis-gist-hook.sh`
- **`scripts/hooks/kapsis-gist-hook.sh`** — guard the `printf > $GIST_FILE` write with `|| true` so the hook always exits 0 even when the workspace directory is unexpectedly non-writable
- **`tests/test-status-hooks.sh`** — add two new tests:
  - `test_inject_claude_with_gist_enabled`: verifies the hook is injected and appears before the status hook when `KAPSIS_INJECT_GIST=true` and the hook file is present
  - `test_inject_claude_gist_disabled_when_hook_missing`: verifies graceful degradation (no gist hook in JSON, status hook still injected) when hook file is absent

## Test plan

- [x] `bash tests/test-status-hooks.sh` — 61/61 pass (was 59 before)
- [x] `tests/run-all-tests.sh --quick` — all quick test suites pass (0 failures)
- [ ] Full container build validation (`./scripts/build-image.sh`) to confirm the new COPY layer resolves at `/opt/kapsis/hooks/kapsis-gist-hook.sh` and `chmod 755` covers it

https://claude.ai/code/session_01AtEfQyJR6nop5bLwFdZjJQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtEfQyJR6nop5bLwFdZjJQ)_