### PR TITLE
feat(dns): abort launch when DNS pinning failure rate exceeds threshold (fixes #216)

### DIFF
--- a/configs/network-allowlist.yaml
+++ b/configs/network-allowlist.yaml
@@ -169,6 +169,25 @@ network:
     # Sets chmod 444 after DNS setup (agent runs as non-root, cannot override)
     protect_dns_files: true
 
+    # Failure-rate threshold (Issue #216): abort launch before wasting agent runtime
+    # when too many allowlist domains are unreachable (e.g. VPN down, DNS flaky).
+    #
+    # max_failure_rate: fraction 0.0–1.0 — abort if >N% of pinnable domains fail.
+    #   Wildcards (*.example.com) are excluded from the denominator as they cannot
+    #   be pre-resolved by design.
+    #   Default: 0.5 (abort when more than 50% of pinnable domains fail)
+    #
+    # max_failures: absolute count — abort if more than N domains fail regardless
+    #   of percentage (guards against large allowlists masking many failures).
+    #   Default: 10
+    #
+    # Either condition triggers abort; set both to 0 for zero-tolerance.
+    # Override per-run: export KAPSIS_DNS_MAX_FAILURE_RATE_PCT=<0-100>
+    #                   export KAPSIS_DNS_MAX_FAILURES=<count>
+    # Emergency bypass (unsafe): export KAPSIS_DNS_FORCE_LAUNCH=1
+    max_failure_rate: 0.5
+    max_failures: 10
+
   # Allowed ports (documented for reference)
   # Note: Port filtering is NOT enforced - only DNS filtering
   # These are the typical ports that allowed services use

--- a/scripts/launch-agent.sh
+++ b/scripts/launch-agent.sh
@@ -893,6 +893,12 @@ parse_config() {
         NETWORK_DNS_PIN_FALLBACK=$(yq eval '.network.dns_pinning.fallback // "dynamic"' "$CONFIG_FILE" 2>/dev/null || echo "dynamic")
         NETWORK_DNS_PIN_TIMEOUT=$(yq eval '.network.dns_pinning.resolve_timeout // "5"' "$CONFIG_FILE" 2>/dev/null || echo "5")
         NETWORK_DNS_PIN_PROTECT=$(yq eval '.network.dns_pinning.protect_dns_files // "true"' "$CONFIG_FILE" 2>/dev/null || echo "true")
+        # Failure-rate thresholds (Issue #216): env vars take precedence over config
+        local _dns_max_rate
+        _dns_max_rate=$(yq eval '.network.dns_pinning.max_failure_rate // "0.5"' "$CONFIG_FILE" 2>/dev/null || echo "0.5")
+        KAPSIS_DNS_MAX_FAILURE_RATE_PCT="${KAPSIS_DNS_MAX_FAILURE_RATE_PCT:-$(echo "$_dns_max_rate" | awk '{printf "%d", $1 * 100}')}"
+        KAPSIS_DNS_MAX_FAILURES="${KAPSIS_DNS_MAX_FAILURES:-$(yq eval '.network.dns_pinning.max_failures // "10"' "$CONFIG_FILE" 2>/dev/null || echo "10")}"
+        export KAPSIS_DNS_MAX_FAILURE_RATE_PCT KAPSIS_DNS_MAX_FAILURES
 
         # Parse cleanup configuration (Fix #183)
         # Env vars take precedence over YAML via ${VAR:-$(yq ...)} pattern
@@ -2235,11 +2241,10 @@ build_container_command() {
                         fi
                     fi
                 else
-                    if [[ "${NETWORK_DNS_PIN_FALLBACK:-dynamic}" == "abort" ]]; then
-                        log_error "DNS pinning failed with fallback=abort - aborting container launch"
-                        exit 1
-                    fi
-                    log_warn "DNS pinning failed - continuing with dynamic DNS (degraded security)"
+                    # resolve_allowlist_domains returned non-zero:
+                    # either failure-rate threshold exceeded (Issue #216) or fallback=abort.
+                    # The function has already logged the specific reason and remediation steps.
+                    exit 1
                 fi
             fi
 

--- a/scripts/lib/dns-pin.sh
+++ b/scripts/lib/dns-pin.sh
@@ -58,11 +58,16 @@ type log_success &>/dev/null || log_success() { echo "[DNS-PIN] SUCCESS: $*" >&2
 #   $2 - Resolution timeout in seconds (default: 5)
 #   $3 - Fallback behavior: "dynamic" (default) or "abort"
 #
+# Env vars (set by launch-agent.sh from config):
+#   KAPSIS_DNS_MAX_FAILURE_RATE_PCT - Integer 0-100: abort if failure% exceeds this (default: 50)
+#   KAPSIS_DNS_MAX_FAILURES         - Integer: abort if failure count exceeds this (default: 10)
+#   KAPSIS_DNS_FORCE_LAUNCH         - Set to "1" to bypass failure threshold check
+#
 # Output:
 #   domain IP1 IP2 ...
 #   (one line per domain with resolved IPs, space-separated)
 #
-# Returns: 0 on success (even partial), 1 on complete failure with abort mode
+# Returns: 0 on success (even partial), 1 if threshold exceeded or fallback=abort with failures
 resolve_allowlist_domains() {
     local domain_list="$1"
     local timeout="${2:-5}"
@@ -73,6 +78,7 @@ resolve_allowlist_domains() {
     local resolved_count=0
     local failed_count=0
     local wildcard_count=0
+    local -a failed_domains=()
 
     log_debug "Resolving domains with timeout=${timeout}s, fallback=${fallback}"
 
@@ -113,15 +119,64 @@ resolve_allowlist_domains() {
         else
             log_warn "Failed to resolve domain: $domain"
             failed_count=$((failed_count + 1))
+            failed_domains+=("$domain")
         fi
     done
 
     log_info "DNS pinning: resolved $resolved_count domains, $failed_count failed, $wildcard_count wildcards skipped"
 
-    # Handle failures based on fallback mode
-    if [[ "$failed_count" -gt 0 ]] && [[ "$fallback" == "abort" ]]; then
-        log_error "DNS resolution failed with fallback=abort"
-        return 1
+    if [[ "$failed_count" -gt 0 ]]; then
+        # Failure rate threshold check — aborts launch before wasting agent runtime
+        # Wildcards are excluded from the denominator (they can never be pinned by design)
+        local total_pinnable=$(( resolved_count + failed_count ))
+        local fail_rate_pct=0
+        if (( total_pinnable > 0 )); then
+            fail_rate_pct=$(( failed_count * 100 / total_pinnable ))
+        fi
+
+        local max_rate_pct="${KAPSIS_DNS_MAX_FAILURE_RATE_PCT:-50}"
+        local max_abs="${KAPSIS_DNS_MAX_FAILURES:-10}"
+
+        if [[ "${KAPSIS_DNS_FORCE_LAUNCH:-}" != "1" ]]; then
+            local threshold_exceeded=false
+            if (( fail_rate_pct > max_rate_pct )); then
+                log_error "DNS pinning: failure rate ${fail_rate_pct}% exceeds threshold ${max_rate_pct}% (${failed_count}/${total_pinnable} pinnable domains failed)"
+                threshold_exceeded=true
+            elif (( failed_count > max_abs )); then
+                log_error "DNS pinning: ${failed_count} domains failed, exceeds absolute threshold of ${max_abs}"
+                threshold_exceeded=true
+            fi
+
+            if [[ "$threshold_exceeded" == "true" ]]; then
+                local show_count=$(( ${#failed_domains[@]} < 5 ? ${#failed_domains[@]} : 5 ))
+                log_error "Failing domains (showing ${show_count} of ${failed_count}):"
+                for (( i=0; i<show_count; i++ )); do
+                    log_error "  - ${failed_domains[$i]}"
+                done
+                log_error "Container launch aborted — agent would fail mid-task without network access"
+                log_error "Remediation:"
+                log_error "  1. Check VPN/network connectivity and retry"
+                log_error "  2. Remove unreachable domains from allowlist"
+                log_error "  3. Raise threshold: dns_pinning.max_failure_rate in config (current: ${max_rate_pct}%)"
+                log_error "  4. Force bypass (unsafe): export KAPSIS_DNS_FORCE_LAUNCH=1"
+                return 1
+            fi
+        else
+            log_warn "DNS pinning: KAPSIS_DNS_FORCE_LAUNCH=1 — bypassing failure threshold check"
+        fi
+
+        # Handle based on fallback mode (threshold not exceeded or force-bypassed)
+        if [[ "$fallback" == "abort" ]]; then
+            log_error "DNS resolution failed with fallback=abort (${failed_count} domain(s) unresolved)"
+            return 1
+        fi
+
+        # fallback=dynamic: loud warning listing actual failing domains (not just a count)
+        log_warn "DNS pinning: ${failed_count} domain(s) will use dynamic DNS (IPs unverified at launch):"
+        for d in "${failed_domains[@]}"; do
+            log_warn "  - $d"
+        done
+        log_warn "Set dns_pinning.fallback: abort to block launch on any failure"
     fi
 
     return 0


### PR DESCRIPTION
## Summary

Fixes #216. Prevents wasted agent runs (50+ min) when VPN/corporate DNS is broken by aborting launch early when too many allowlist domains fail to resolve.

- **Failure-rate threshold in `resolve_allowlist_domains()`** — after the resolution loop, computes `failed / (resolved + failed)` (wildcards excluded) and aborts if either threshold is exceeded:
  - `max_failure_rate` (default `0.5` → 50%): abort if >50% of pinnable domains fail
  - `max_failures` (default `10`): abort if >N domains fail regardless of percentage (guards large allowlists)
- **Actionable error messages** — first 5 failing domain names are printed with four concrete remediation steps, so operators can act in under 30 seconds
- **Louder dynamic-fallback warning** — when `fallback: dynamic` and failures exist, each failing domain is now listed by name instead of just a silent count (contrarian finding: visibility matters as much as the abort)
- **`KAPSIS_DNS_FORCE_LAUNCH=1` escape hatch** — bypasses the new threshold check only; does not override existing `fallback: abort` behaviour
- **Config-driven** — `launch-agent.sh` reads `dns_pinning.max_failure_rate` and `dns_pinning.max_failures` from YAML; env vars take precedence (standard Kapsis pattern)

## Ensemble brainstorm findings

Two parallel agents (architect + contrarian) informed the design:

| Concern | Resolution |
|---------|-----------|
| Percentages mislead on tiny allowlists (3 domains, 1 fail = 33%) | Keep both rate AND absolute threshold; `max_failures: 10` guards this case |
| `--force` CLI flag trains users to bypass safety | No CLI flag — env var only (`KAPSIS_DNS_FORCE_LAUNCH=1`), harder to invoke accidentally |
| False sense of security (50% pass still broken) | Loud per-domain warning even below threshold; operators see exactly what's degraded |
| Transient DNS hiccup blocks real launches | Defaults (50%, 10 abs) are deliberately permissive; teams can tighten via config |

## Files changed

| File | Change |
|------|--------|
| `scripts/lib/dns-pin.sh` | Track `failed_domains[]` array; add threshold check block after loop; enhance dynamic-fallback warning |
| `scripts/launch-agent.sh` | Parse `max_failure_rate` + `max_failures` from config, export as env vars; simplify failure handler (function now logs reason) |
| `configs/network-allowlist.yaml` | Document `max_failure_rate` and `max_failures` with defaults and override instructions |

## Test plan

- [ ] DNS resolution normal (all succeed): launch proceeds, no new output
- [ ] Partial failure below threshold (e.g. 3/52 fail, rate=5%): launch proceeds, failing domain names logged as warning
- [ ] Partial failure above rate threshold (e.g. 33/52 fail, rate=63%): launch aborts with error listing failing domains and remediation steps
- [ ] Partial failure above absolute threshold (e.g. 15 fail regardless of %): launch aborts
- [ ] `KAPSIS_DNS_FORCE_LAUNCH=1` with threshold breach: bypass warning logged, launch proceeds
- [ ] `fallback: abort` with any failure: still aborts (unchanged behaviour)
- [ ] All-wildcard allowlist: `total_pinnable=0`, no abort, no spurious division-by-zero
- [ ] `max_failure_rate: 0` in config: any single failure aborts (zero-tolerance mode)

https://claude.ai/code/session_01YYZD7adzJWwVSAyR8LuA9M

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYZD7adzJWwVSAyR8LuA9M)_