### PR TITLE
feat(dns): abort launch when DNS failure rate exceeds threshold (#216)

### DIFF
--- a/docs/CONFIG-REFERENCE.md
+++ b/docs/CONFIG-REFERENCE.md
@@ -631,6 +631,19 @@ network:
     # Default: true
     protect_dns_files: true
 
+    # Abort launch if more than this many non-wildcard domains fail to resolve.
+    # -1 disables the absolute count check (default).
+    # Example: max_failures: 5 → abort if more than 5 domains fail.
+    max_failures: -1
+
+    # Abort launch if the fraction of failed non-wildcard domains exceeds this threshold.
+    # Range: 0.0–1.0. -1 disables the rate check.
+    # Wildcards (*.domain.com) are excluded from both numerator and denominator
+    # because they cannot be pre-resolved by design.
+    # Default: 0.5 (abort when more than 50% of resolvable domains fail).
+    # Override at runtime: export KAPSIS_SKIP_DNS_CHECK=true
+    max_failure_rate: 0.5
+
 #===============================================================================
 # GIT HOOKS
 #===============================================================================

--- a/scripts/launch-agent.sh
+++ b/scripts/launch-agent.sh
@@ -2212,16 +2212,18 @@ build_container_command() {
             # This prevents DNS manipulation attacks inside the container
             if [[ "${NETWORK_DNS_PIN_ENABLED:-true}" == "true" ]] && [[ -n "${NETWORK_ALLOWLIST_DOMAINS:-}" ]]; then
                 log_info "DNS pinning: resolving allowlist domains on host..."
-                # Use a temp file to read back resolved/failed counts from the subshell (Issue #216)
+                # Use a temp file to read back resolved/failed counts from the subshell (Issue #216).
+                # Export so the variable is visible inside the $() subshell running resolve_allowlist_domains.
                 local _dns_counts_file
                 _dns_counts_file=$(mktemp)
+                export KAPSIS_DNS_COUNTS_FILE="$_dns_counts_file"
                 local resolved_data
-                if KAPSIS_DNS_COUNTS_FILE="$_dns_counts_file" \
-                   resolved_data=$(resolve_allowlist_domains "$NETWORK_ALLOWLIST_DOMAINS" "${NETWORK_DNS_PIN_TIMEOUT:-5}" "${NETWORK_DNS_PIN_FALLBACK:-dynamic}"); then
+                if resolved_data=$(resolve_allowlist_domains "$NETWORK_ALLOWLIST_DOMAINS" "${NETWORK_DNS_PIN_TIMEOUT:-5}" "${NETWORK_DNS_PIN_FALLBACK:-dynamic}"); then
                     # Read counts written by resolve_allowlist_domains (cross-subshell)
                     local _dns_resolved=0 _dns_failed=0
                     read -r _dns_resolved _dns_failed < "$_dns_counts_file" || true
                     rm -f "$_dns_counts_file"
+                    unset KAPSIS_DNS_COUNTS_FILE
 
                     # Check failure thresholds (Issue #216) — skip when KAPSIS_SKIP_DNS_CHECK is set
                     if [[ "${KAPSIS_SKIP_DNS_CHECK:-false}" == "true" ]]; then
@@ -2262,6 +2264,7 @@ build_container_command() {
                     fi
                 else
                     rm -f "$_dns_counts_file"
+                    unset KAPSIS_DNS_COUNTS_FILE
                     if [[ "${NETWORK_DNS_PIN_FALLBACK:-dynamic}" == "abort" ]]; then
                         log_error "DNS pinning failed with fallback=abort - aborting container launch"
                         exit 1

--- a/scripts/launch-agent.sh
+++ b/scripts/launch-agent.sh
@@ -893,6 +893,8 @@ parse_config() {
         NETWORK_DNS_PIN_FALLBACK=$(yq eval '.network.dns_pinning.fallback // "dynamic"' "$CONFIG_FILE" 2>/dev/null || echo "dynamic")
         NETWORK_DNS_PIN_TIMEOUT=$(yq eval '.network.dns_pinning.resolve_timeout // "5"' "$CONFIG_FILE" 2>/dev/null || echo "5")
         NETWORK_DNS_PIN_PROTECT=$(yq eval '.network.dns_pinning.protect_dns_files // "true"' "$CONFIG_FILE" 2>/dev/null || echo "true")
+        NETWORK_DNS_PIN_MAX_FAILURES=$(yq eval '.network.dns_pinning.max_failures // "-1"' "$CONFIG_FILE" 2>/dev/null || echo "-1")
+        NETWORK_DNS_PIN_MAX_FAILURE_RATE=$(yq eval '.network.dns_pinning.max_failure_rate // "0.5"' "$CONFIG_FILE" 2>/dev/null || echo "0.5")
 
         # Parse cleanup configuration (Fix #183)
         # Env vars take precedence over YAML via ${VAR:-$(yq ...)} pattern
@@ -2210,8 +2212,32 @@ build_container_command() {
             # This prevents DNS manipulation attacks inside the container
             if [[ "${NETWORK_DNS_PIN_ENABLED:-true}" == "true" ]] && [[ -n "${NETWORK_ALLOWLIST_DOMAINS:-}" ]]; then
                 log_info "DNS pinning: resolving allowlist domains on host..."
+                # Use a temp file to read back resolved/failed counts from the subshell (Issue #216)
+                local _dns_counts_file
+                _dns_counts_file=$(mktemp)
                 local resolved_data
-                if resolved_data=$(resolve_allowlist_domains "$NETWORK_ALLOWLIST_DOMAINS" "${NETWORK_DNS_PIN_TIMEOUT:-5}" "${NETWORK_DNS_PIN_FALLBACK:-dynamic}"); then
+                if KAPSIS_DNS_COUNTS_FILE="$_dns_counts_file" \
+                   resolved_data=$(resolve_allowlist_domains "$NETWORK_ALLOWLIST_DOMAINS" "${NETWORK_DNS_PIN_TIMEOUT:-5}" "${NETWORK_DNS_PIN_FALLBACK:-dynamic}"); then
+                    # Read counts written by resolve_allowlist_domains (cross-subshell)
+                    local _dns_resolved=0 _dns_failed=0
+                    read -r _dns_resolved _dns_failed < "$_dns_counts_file" || true
+                    rm -f "$_dns_counts_file"
+
+                    # Check failure thresholds (Issue #216) — skip when KAPSIS_SKIP_DNS_CHECK is set
+                    if [[ "${KAPSIS_SKIP_DNS_CHECK:-false}" == "true" ]]; then
+                        log_warn "KAPSIS_SKIP_DNS_CHECK=true: DNS failure threshold check is disabled"
+                    elif ! check_dns_failure_threshold \
+                            "$_dns_resolved" \
+                            "$_dns_failed" \
+                            "${NETWORK_DNS_PIN_MAX_FAILURES:--1}" \
+                            "${NETWORK_DNS_PIN_MAX_FAILURE_RATE:-0.5}"; then
+                        log_error "Aborting launch: DNS resolution failures exceed threshold."
+                        log_error "  Resolved: $_dns_resolved  Failed: $_dns_failed"
+                        log_error "  Check VPN/network connectivity and retry."
+                        log_error "  To skip this check: export KAPSIS_SKIP_DNS_CHECK=true"
+                        exit 1
+                    fi
+
                     if [[ -n "$resolved_data" ]]; then
                         # Create temp file for pinned DNS (cleaned up in _cleanup_with_completion)
                         DNS_PIN_FILE=$(mktemp)
@@ -2235,6 +2261,7 @@ build_container_command() {
                         fi
                     fi
                 else
+                    rm -f "$_dns_counts_file"
                     if [[ "${NETWORK_DNS_PIN_FALLBACK:-dynamic}" == "abort" ]]; then
                         log_error "DNS pinning failed with fallback=abort - aborting container launch"
                         exit 1

--- a/scripts/lib/dns-pin.sh
+++ b/scripts/lib/dns-pin.sh
@@ -27,6 +27,10 @@
 [[ -n "${_KAPSIS_DNS_PIN_LOADED:-}" ]] && return 0
 _KAPSIS_DNS_PIN_LOADED=1
 
+# If set, resolve_allowlist_domains writes "resolved failed" counts here so callers
+# can read them even when the function runs in a $() subshell.
+: "${KAPSIS_DNS_COUNTS_FILE:=}"
+
 # Source compat.sh for resolve_domain_ips() if not already sourced
 _DNS_PIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if ! type resolve_domain_ips &>/dev/null; then
@@ -118,10 +122,69 @@ resolve_allowlist_domains() {
 
     log_info "DNS pinning: resolved $resolved_count domains, $failed_count failed, $wildcard_count wildcards skipped"
 
+    # Write counts to file so callers can read them across the subshell boundary
+    # (wildcards excluded — they are never resolvable by design)
+    if [[ -n "${KAPSIS_DNS_COUNTS_FILE:-}" ]]; then
+        echo "$resolved_count $failed_count" > "$KAPSIS_DNS_COUNTS_FILE"
+    fi
+
     # Handle failures based on fallback mode
     if [[ "$failed_count" -gt 0 ]] && [[ "$fallback" == "abort" ]]; then
         log_error "DNS resolution failed with fallback=abort"
         return 1
+    fi
+
+    return 0
+}
+
+#===============================================================================
+# DNS FAILURE THRESHOLD CHECK (Issue #216)
+#===============================================================================
+
+# check_dns_failure_threshold <resolved> <failed> [max_failures] [max_failure_rate]
+#
+# Evaluates whether the DNS resolution failure counts exceed configured thresholds.
+# Wildcards are excluded from all arithmetic — they are never resolvable by design.
+#
+# Arguments:
+#   $1 - Number of successfully resolved domains
+#   $2 - Number of failed (non-wildcard) domains
+#   $3 - Max absolute failures allowed (-1 = disabled, default: -1)
+#   $4 - Max failure rate as a decimal 0.0–1.0 (-1 = disabled, default: 0.5)
+#
+# Returns:
+#   0 - Failure counts are within acceptable thresholds (proceed with launch)
+#   1 - Threshold exceeded (caller should abort launch or warn)
+check_dns_failure_threshold() {
+    local resolved="${1:-0}"
+    local failed="${2:-0}"
+    local max_failures="${3:--1}"
+    local max_failure_rate="${4:-0.5}"
+
+    # Nothing failed — always pass
+    if [[ "$failed" -eq 0 ]]; then
+        return 0
+    fi
+
+    local total=$(( resolved + failed ))
+
+    # Absolute count check
+    if [[ "$max_failures" != "-1" ]] && [[ "$failed" -gt "$max_failures" ]]; then
+        log_error "DNS threshold exceeded: $failed domain(s) failed to resolve (max_failures=$max_failures)"
+        return 1
+    fi
+
+    # Rate check — skip if disabled (-1) or total is zero
+    if [[ "$max_failure_rate" != "-1" ]] && [[ "$total" -gt 0 ]]; then
+        # Integer arithmetic: compare failed*100 / total against rate*100
+        local rate_pct=$(( failed * 100 / total ))
+        local threshold_pct
+        # Convert decimal rate to integer percentage (e.g. 0.5 → 50)
+        threshold_pct=$(awk "BEGIN { printf \"%d\", $max_failure_rate * 100 }")
+        if [[ "$rate_pct" -gt "$threshold_pct" ]]; then
+            log_error "DNS threshold exceeded: $failed/$total domains failed ($rate_pct% > ${threshold_pct}% max_failure_rate)"
+            return 1
+        fi
     fi
 
     return 0

--- a/tests/test-dns-threshold.sh
+++ b/tests/test-dns-threshold.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+#===============================================================================
+# Test: DNS Failure Threshold Check (Issue #216)
+#
+# Verifies check_dns_failure_threshold() correctly gates container launch
+# when DNS resolution failures exceed configured limits.
+#
+# All tests run without containers (quick tests only).
+#===============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/test-framework.sh"
+
+DNS_PIN_LIB="$KAPSIS_ROOT/scripts/lib/dns-pin.sh"
+
+#-------------------------------------------------------------------------------
+# Helper: source dns-pin.sh once
+#-------------------------------------------------------------------------------
+_source_dns_pin() {
+    # Reset load guard so we can re-source in test isolation
+    unset _KAPSIS_DNS_PIN_LOADED 2>/dev/null || true
+    source "$DNS_PIN_LIB"
+}
+
+#===============================================================================
+# LIBRARY VALIDATION
+#===============================================================================
+
+test_threshold_function_exists() {
+    log_test "check_dns_failure_threshold function exists in dns-pin.sh"
+
+    _source_dns_pin
+    if declare -F check_dns_failure_threshold >/dev/null; then
+        log_pass "check_dns_failure_threshold is defined"
+    else
+        log_fail "check_dns_failure_threshold not found in dns-pin.sh"
+        _ASSERTION_FAILED=true
+    fi
+}
+
+test_counts_file_var_exists() {
+    log_test "KAPSIS_DNS_COUNTS_FILE variable is declared in dns-pin.sh"
+
+    _source_dns_pin
+    # The variable should exist (even if empty)
+    if [[ -v KAPSIS_DNS_COUNTS_FILE ]]; then
+        log_pass "KAPSIS_DNS_COUNTS_FILE is declared"
+    else
+        log_fail "KAPSIS_DNS_COUNTS_FILE not declared in dns-pin.sh"
+        _ASSERTION_FAILED=true
+    fi
+}
+
+#===============================================================================
+# THRESHOLD LOGIC — RATE-BASED
+#===============================================================================
+
+test_no_failures_always_passes() {
+    log_test "Zero failures always passes regardless of threshold"
+
+    _source_dns_pin
+    assert_command_succeeds \
+        "check_dns_failure_threshold 10 0 -1 0.5" \
+        "0 failures with 10 resolved should pass"
+}
+
+test_rate_below_threshold_passes() {
+    log_test "Failure rate below threshold passes (3/10 = 30% < 50%)"
+
+    _source_dns_pin
+    assert_command_succeeds \
+        "check_dns_failure_threshold 7 3 -1 0.5" \
+        "30% failure rate should pass when threshold is 50%"
+}
+
+test_rate_at_threshold_passes() {
+    log_test "Failure rate exactly at threshold passes (5/10 = 50% not > 50%)"
+
+    _source_dns_pin
+    assert_command_succeeds \
+        "check_dns_failure_threshold 5 5 -1 0.5" \
+        "50% failure rate should pass when threshold is 50% (boundary: strictly greater)"
+}
+
+test_rate_exceeds_threshold_fails() {
+    log_test "Failure rate above threshold aborts (6/10 = 60% > 50%)"
+
+    _source_dns_pin
+    assert_command_fails \
+        "check_dns_failure_threshold 4 6 -1 0.5" \
+        "60% failure rate should fail when threshold is 50%"
+}
+
+test_issue_216_scenario() {
+    log_test "Issue #216 scenario: 33/52 domains failed (63%) > 50% threshold"
+
+    _source_dns_pin
+    assert_command_fails \
+        "check_dns_failure_threshold 19 33 -1 0.5" \
+        "63% failure rate should fail (the exact issue #216 case)"
+}
+
+test_rate_disabled_skips_check() {
+    log_test "Rate check disabled with -1 skips rate evaluation"
+
+    _source_dns_pin
+    # 40/50 = 80% failures, but rate check is disabled
+    assert_command_succeeds \
+        "check_dns_failure_threshold 10 40 -1 -1" \
+        "Rate check disabled (-1) should pass even with 80% failure rate"
+}
+
+test_strict_threshold_zero() {
+    log_test "max_failure_rate=0.0 fails on any single failure"
+
+    _source_dns_pin
+    assert_command_fails \
+        "check_dns_failure_threshold 9 1 -1 0.0" \
+        "Any failure should abort when max_failure_rate=0.0"
+}
+
+test_permissive_threshold_one() {
+    log_test "max_failure_rate=1.0 allows all domains to fail"
+
+    _source_dns_pin
+    # 10/10 = 100%, threshold is 100%; strictly greater comparison means equal passes
+    assert_command_succeeds \
+        "check_dns_failure_threshold 0 10 -1 1.0" \
+        "All failures should pass when max_failure_rate=1.0"
+}
+
+#===============================================================================
+# THRESHOLD LOGIC — ABSOLUTE COUNT
+#===============================================================================
+
+test_absolute_below_limit_passes() {
+    log_test "Absolute failures below max_failures passes"
+
+    _source_dns_pin
+    assert_command_succeeds \
+        "check_dns_failure_threshold 45 4 5 -1" \
+        "4 failures with max_failures=5 should pass"
+}
+
+test_absolute_at_limit_passes() {
+    log_test "Absolute failures at max_failures passes (boundary: strictly greater)"
+
+    _source_dns_pin
+    assert_command_succeeds \
+        "check_dns_failure_threshold 45 5 5 -1" \
+        "5 failures with max_failures=5 should pass"
+}
+
+test_absolute_exceeds_limit_fails() {
+    log_test "Absolute failures exceeding max_failures aborts"
+
+    _source_dns_pin
+    assert_command_fails \
+        "check_dns_failure_threshold 44 6 5 -1" \
+        "6 failures with max_failures=5 should fail"
+}
+
+test_absolute_disabled_skips_check() {
+    log_test "Absolute count check disabled with -1"
+
+    _source_dns_pin
+    assert_command_succeeds \
+        "check_dns_failure_threshold 0 100 -1 -1" \
+        "max_failures=-1 should skip count check entirely"
+}
+
+#===============================================================================
+# COMBINED THRESHOLDS
+#===============================================================================
+
+test_both_thresholds_rate_triggers() {
+    log_test "Both thresholds set — rate threshold triggers"
+
+    _source_dns_pin
+    # 6/10 = 60% > 50%, absolute 6 <= 10
+    assert_command_fails \
+        "check_dns_failure_threshold 4 6 10 0.5" \
+        "Rate threshold (60% > 50%) should trigger even when absolute is fine"
+}
+
+test_both_thresholds_absolute_triggers() {
+    log_test "Both thresholds set — absolute count triggers first"
+
+    _source_dns_pin
+    # 3/100 = 3% (fine on rate), but 3 > 2 on absolute
+    assert_command_fails \
+        "check_dns_failure_threshold 97 3 2 0.5" \
+        "Absolute threshold (3 > 2) should trigger even when rate is fine"
+}
+
+#===============================================================================
+# GLOBALS POPULATED BY resolve_allowlist_domains
+#===============================================================================
+
+test_counts_file_written_after_resolution() {
+    log_test "KAPSIS_DNS_COUNTS_FILE is written by resolve_allowlist_domains"
+
+    _source_dns_pin
+
+    # Feed a mix: one IP passthrough (resolved), one unresolvable domain (failed)
+    local counts_file
+    counts_file=$(mktemp)
+
+    local _resolved _failed
+    KAPSIS_DNS_COUNTS_FILE="$counts_file" \
+        resolve_allowlist_domains \
+            "1.2.3.4,this-domain-should-not-exist-xyz-kapsis-test.invalid" \
+            1 dynamic >/dev/null 2>&1 || true
+
+    read -r _resolved _failed < "$counts_file" || true
+    rm -f "$counts_file"
+
+    if [[ "$_resolved" -eq 1 ]] && [[ "$_failed" -eq 1 ]]; then
+        log_pass "Counts file written correctly: resolved=$_resolved failed=$_failed"
+    else
+        log_fail "Expected resolved=1 failed=1, got resolved=$_resolved failed=$_failed"
+        _ASSERTION_FAILED=true
+    fi
+}
+
+#===============================================================================
+# MAIN
+#===============================================================================
+
+main() {
+    print_test_header "DNS Failure Threshold Tests (Issue #216)"
+
+    run_test test_threshold_function_exists
+    run_test test_counts_file_var_exists
+
+    run_test test_no_failures_always_passes
+    run_test test_rate_below_threshold_passes
+    run_test test_rate_at_threshold_passes
+    run_test test_rate_exceeds_threshold_fails
+    run_test test_issue_216_scenario
+    run_test test_rate_disabled_skips_check
+    run_test test_strict_threshold_zero
+    run_test test_permissive_threshold_one
+
+    run_test test_absolute_below_limit_passes
+    run_test test_absolute_at_limit_passes
+    run_test test_absolute_exceeds_limit_fails
+    run_test test_absolute_disabled_skips_check
+
+    run_test test_both_thresholds_rate_triggers
+    run_test test_both_thresholds_absolute_triggers
+
+    run_test test_counts_file_written_after_resolution
+
+    print_summary
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Fixes #216. When host DNS is flaky (VPN reconnecting, corporate DNS down), Kapsis now aborts launch instead of proceeding with a partially broken network that will waste the entire agent run.

- Adds `max_failure_rate` (default `0.5`) and `max_failures` (default disabled) config options under `network.dns_pinning`
- Abort message tells the user exactly how many domains failed and points to the `KAPSIS_SKIP_DNS_CHECK=true` escape hatch
- Uses a temp-file side-channel (`KAPSIS_DNS_COUNTS_FILE`) to share resolved/failed counts across the `$()` subshell boundary — no changes to the existing stdout protocol of `resolve_allowlist_domains`

## The issue #216 scenario

```
DNS pinning: resolved 19 domains, 33 failed, 9 wildcards skipped
```

33/52 non-wildcard domains = **63%** → exceeds the 50% default → launch aborted with:

```
ERROR: DNS threshold exceeded: 33/52 domains failed (63% > 50% max_failure_rate)
ERROR: Aborting launch: DNS resolution failures exceed threshold.
ERROR:   Resolved: 19  Failed: 33
ERROR:   Check VPN/network connectivity and retry.
ERROR:   To skip this check: export KAPSIS_SKIP_DNS_CHECK=true
```

## Ensemble brainstorm highlights

Three perspectives were evaluated before implementation:

| Perspective | Key insight adopted |
|-------------|-------------------|
| Architect | Threshold check lives in `dns-pin.sh`; skip override lives in `launch-agent.sh` |
| Pragmatist | Keep `resolve_allowlist_domains` stdout protocol untouched; pure helper function for threshold logic |
| Contrarian | Wildcards are excluded from rate denominator — documented explicitly; CDN domain jitter doesn't skew the count |

## Configuration

```yaml
network:
  dns_pinning:
    # Abort if >50% of non-wildcard domains fail to resolve (default)
    max_failure_rate: 0.5

    # Optionally abort on an absolute count instead (disabled by default)
    # max_failures: 10

# Skip both checks at runtime (e.g. known-flaky CI environment):
# export KAPSIS_SKIP_DNS_CHECK=true
```

## Files changed

| File | Change |
|------|--------|
| `scripts/lib/dns-pin.sh` | `check_dns_failure_threshold()` helper + `KAPSIS_DNS_COUNTS_FILE` mechanism |
| `scripts/launch-agent.sh` | Parse new config keys; temp-file counts; threshold check + abort |
| `docs/CONFIG-REFERENCE.md` | Document `max_failures` and `max_failure_rate` with denominator note |
| `tests/test-dns-threshold.sh` | 17 quick tests — all passing |

## Test plan

- [x] Run `./tests/test-dns-threshold.sh` — 17/17 pass
- [x] Run `./tests/run-all-tests.sh --quick` — no regressions
- [x] `bash -n` syntax check on all modified scripts
- [ ] Manual: launch with a broken VPN, verify abort message appears before container starts
- [ ] Manual: verify `KAPSIS_SKIP_DNS_CHECK=true` bypasses the check with a prominent warning

https://claude.ai/code/session_014BHX171pu8pY4Y6hytjFnZ

---
_Generated by [Claude Code](https://claude.ai/code/session_014BHX171pu8pY4Y6hytjFnZ)_