### PR TITLE
fix(dns): abort launch when DNS failure rate exceeds threshold (Issue #216)

### DIFF
--- a/configs/network-allowlist.yaml
+++ b/configs/network-allowlist.yaml
@@ -169,6 +169,18 @@ network:
     # Sets chmod 444 after DNS setup (agent runs as non-root, cannot override)
     protect_dns_files: true
 
+    # Issue #216: Abort launch when too many domains fail to resolve.
+    # Both thresholds are disabled by default (empty = no check).
+    # Either threshold exceeding its limit triggers abort (OR logic).
+    # Denominator: resolved + failed only (wildcards are excluded).
+    # Override: set KAPSIS_SKIP_DNS_CHECK=true to bypass.
+    #
+    # Abort if more than N% of non-wildcard domains fail to resolve:
+    # max_failure_rate: 0.5   # 0.0–1.0; e.g. 0.5 = abort when >50% fail
+    #
+    # Abort if more than N domains fail to resolve (absolute count):
+    # max_failures: 10
+
   # Allowed ports (documented for reference)
   # Note: Port filtering is NOT enforced - only DNS filtering
   # These are the typical ports that allowed services use

--- a/scripts/launch-agent.sh
+++ b/scripts/launch-agent.sh
@@ -893,6 +893,10 @@ parse_config() {
         NETWORK_DNS_PIN_FALLBACK=$(yq eval '.network.dns_pinning.fallback // "dynamic"' "$CONFIG_FILE" 2>/dev/null || echo "dynamic")
         NETWORK_DNS_PIN_TIMEOUT=$(yq eval '.network.dns_pinning.resolve_timeout // "5"' "$CONFIG_FILE" 2>/dev/null || echo "5")
         NETWORK_DNS_PIN_PROTECT=$(yq eval '.network.dns_pinning.protect_dns_files // "true"' "$CONFIG_FILE" 2>/dev/null || echo "true")
+        # Issue #216: failure-rate threshold — empty string = disabled (opt-in only)
+        NETWORK_DNS_PIN_MAX_FAILURE_RATE=$(yq eval '.network.dns_pinning.max_failure_rate // ""' "$CONFIG_FILE" 2>/dev/null || echo "")
+        NETWORK_DNS_PIN_MAX_FAILURES=$(yq eval '.network.dns_pinning.max_failures // ""' "$CONFIG_FILE" 2>/dev/null || echo "")
+        KAPSIS_SKIP_DNS_CHECK="${KAPSIS_SKIP_DNS_CHECK:-false}"
 
         # Parse cleanup configuration (Fix #183)
         # Env vars take precedence over YAML via ${VAR:-$(yq ...)} pattern
@@ -2212,6 +2216,27 @@ build_container_command() {
                 log_info "DNS pinning: resolving allowlist domains on host..."
                 local resolved_data
                 if resolved_data=$(resolve_allowlist_domains "$NETWORK_ALLOWLIST_DOMAINS" "${NETWORK_DNS_PIN_TIMEOUT:-5}" "${NETWORK_DNS_PIN_FALLBACK:-dynamic}"); then
+                    # Issue #216: extract the KAPSIS_DNS_STATS sentinel emitted by resolve_allowlist_domains
+                    # (it travels via stdout through the $() subshell) then strip it before writing the pin file
+                    local dns_stats_line dns_resolved dns_failed
+                    dns_stats_line=$(echo "$resolved_data" | grep '^KAPSIS_DNS_STATS ' || true)
+                    resolved_data=$(echo "$resolved_data" | grep -v '^KAPSIS_DNS_STATS ')
+
+                    # Evaluate failure-rate threshold when either limit is configured
+                    if [[ -n "$dns_stats_line" ]]; then
+                        dns_resolved=$(echo "$dns_stats_line" | grep -o 'resolved=[0-9]*' | cut -d= -f2)
+                        dns_failed=$(echo "$dns_stats_line" | grep -o 'failed=[0-9]*' | cut -d= -f2)
+                        if ! check_dns_threshold \
+                                "${dns_resolved:-0}" "${dns_failed:-0}" \
+                                "${NETWORK_DNS_PIN_MAX_FAILURE_RATE:-}" \
+                                "${NETWORK_DNS_PIN_MAX_FAILURES:-}" \
+                                "${KAPSIS_SKIP_DNS_CHECK:-false}"; then
+                            log_error "Aborting launch: DNS resolution quality is below the configured threshold."
+                            log_error "  Check your VPN/network and retry, or set KAPSIS_SKIP_DNS_CHECK=true to bypass."
+                            exit 7
+                        fi
+                    fi
+
                     if [[ -n "$resolved_data" ]]; then
                         # Create temp file for pinned DNS (cleaned up in _cleanup_with_completion)
                         DNS_PIN_FILE=$(mktemp)
@@ -2834,6 +2859,7 @@ main() {
     #   4 = Mount failure (virtio-fs drop)
     #   5 = Agent completed but process hung (stuck child process)
     #   6 = Commit failure (agent produced work but git commit failed)
+    #   7 = DNS resolution failure rate exceeded threshold (Issue #216) — pre-launch abort
     if [[ "$EXIT_CODE" -eq 4 ]]; then
         # Mount failure detected via sentinel (Issue #248)
         FINAL_EXIT_CODE=4

--- a/scripts/lib/config-verifier.sh
+++ b/scripts/lib/config-verifier.sh
@@ -532,6 +532,28 @@ validate_network_config() {
         fi
     fi
 
+    # Validate max_failure_rate (Issue #216): must be a float in [0.0, 1.0]
+    local dns_pin_max_rate
+    dns_pin_max_rate=$(yq -r '.network.dns_pinning.max_failure_rate // "null"' "$config_file" 2>/dev/null)
+    if [[ "$dns_pin_max_rate" != "null" ]]; then
+        if awk "BEGIN{exit ($dns_pin_max_rate >= 0 && $dns_pin_max_rate <= 1) ? 0 : 1}" 2>/dev/null; then
+            log_pass "Valid dns_pinning.max_failure_rate: $dns_pin_max_rate"
+        else
+            log_error "Invalid dns_pinning.max_failure_rate: $dns_pin_max_rate (must be 0.0–1.0)"
+        fi
+    fi
+
+    # Validate max_failures (Issue #216): must be a non-negative integer
+    local dns_pin_max_failures
+    dns_pin_max_failures=$(yq -r '.network.dns_pinning.max_failures // "null"' "$config_file" 2>/dev/null)
+    if [[ "$dns_pin_max_failures" != "null" ]]; then
+        if [[ "$dns_pin_max_failures" =~ ^[0-9]+$ ]]; then
+            log_pass "Valid dns_pinning.max_failures: $dns_pin_max_failures"
+        else
+            log_error "Invalid dns_pinning.max_failures: $dns_pin_max_failures (must be a non-negative integer)"
+        fi
+    fi
+
     return 0
 }
 

--- a/scripts/lib/dns-pin.sh
+++ b/scripts/lib/dns-pin.sh
@@ -118,6 +118,10 @@ resolve_allowlist_domains() {
 
     log_info "DNS pinning: resolved $resolved_count domains, $failed_count failed, $wildcard_count wildcards skipped"
 
+    # Emit stats sentinel for caller to extract failure counts through the subshell boundary
+    # Format chosen to be unparseable as a domain IP line (prefix prevents confusion)
+    echo "KAPSIS_DNS_STATS resolved=${resolved_count} failed=${failed_count} wildcards=${wildcard_count}"
+
     # Handle failures based on fallback mode
     if [[ "$failed_count" -gt 0 ]] && [[ "$fallback" == "abort" ]]; then
         log_error "DNS resolution failed with fallback=abort"
@@ -315,6 +319,54 @@ validate_pinned_entry() {
             fi
         done
     done
+
+    return 0
+}
+
+# check_dns_threshold <resolved> <failed> <max_failure_rate> <max_failures> <skip_check>
+#
+# Evaluates whether DNS resolution quality is acceptable for container launch (Issue #216).
+# Called after resolve_allowlist_domains; both thresholds use OR logic — either breach aborts.
+#
+# Arguments:
+#   $1 - resolved_count (non-wildcard domains that resolved)
+#   $2 - failed_count   (non-wildcard domains that failed)
+#   $3 - max_failure_rate  (0.0–1.0 fraction; empty = disabled)
+#   $4 - max_failures      (absolute integer count; empty = disabled)
+#   $5 - skip_check        ("true" = bypass all threshold checks)
+#
+# Returns: 0 = OK to launch, 1 = threshold exceeded (caller should abort)
+check_dns_threshold() {
+    local resolved="${1:-0}"
+    local failed="${2:-0}"
+    local max_rate="${3:-}"
+    local max_abs="${4:-}"
+    local skip="${5:-false}"
+
+    [[ "$skip" == "true" ]] && return 0
+    [[ "$failed" -eq 0 ]] && return 0
+    [[ -z "$max_rate" && -z "$max_abs" ]] && return 0
+
+    local total=$(( resolved + failed ))
+    [[ "$total" -eq 0 ]] && return 0
+
+    # Absolute failures threshold (OR logic with rate threshold)
+    if [[ -n "$max_abs" ]] && [[ "$failed" -gt "$max_abs" ]]; then
+        log_error "DNS threshold exceeded: $failed failed domain(s) > max_failures=${max_abs}"
+        log_error "  Remedy: check your VPN/network, or set KAPSIS_SKIP_DNS_CHECK=true to bypass"
+        return 1
+    fi
+
+    # Failure rate threshold — use awk to avoid bc dependency and handle floats
+    if [[ -n "$max_rate" ]]; then
+        if awk "BEGIN{exit ($failed / $total > $max_rate) ? 0 : 1}"; then
+            local pct
+            pct=$(awk "BEGIN{printf \"%.0f\", $failed / $total * 100}")
+            log_error "DNS threshold exceeded: ${pct}% failed (${failed}/${total}) > max_failure_rate=${max_rate}"
+            log_error "  Remedy: check your VPN/network, or set KAPSIS_SKIP_DNS_CHECK=true to bypass"
+            return 1
+        fi
+    fi
 
     return 0
 }

--- a/tests/test-dns-pinning.sh
+++ b/tests/test-dns-pinning.sh
@@ -627,6 +627,209 @@ EOF
 }
 
 #===============================================================================
+# DNS FAILURE THRESHOLD TESTS (Issue #216, no container required)
+#===============================================================================
+
+test_check_dns_threshold_disabled_by_default() {
+    log_test "Testing check_dns_threshold: no threshold configured = always OK"
+
+    source "$DNS_PIN_LIB"
+
+    # No thresholds set — should always pass regardless of failure counts
+    assert_command_succeeds \
+        "check_dns_threshold 5 33 '' '' 'false'" \
+        "Should pass when no thresholds configured (33 failures, no limits)"
+}
+
+test_check_dns_threshold_skip_check_bypasses() {
+    log_test "Testing check_dns_threshold: KAPSIS_SKIP_DNS_CHECK=true bypasses all limits"
+
+    source "$DNS_PIN_LIB"
+
+    assert_command_succeeds \
+        "check_dns_threshold 0 52 '0.1' '1' 'true'" \
+        "Should pass when skip=true even with extreme failure counts"
+}
+
+test_check_dns_threshold_no_failures_always_ok() {
+    log_test "Testing check_dns_threshold: zero failures always OK"
+
+    source "$DNS_PIN_LIB"
+
+    assert_command_succeeds \
+        "check_dns_threshold 52 0 '0.1' '1' 'false'" \
+        "Should pass with zero failed domains regardless of thresholds"
+}
+
+test_check_dns_threshold_rate_exceeded() {
+    log_test "Testing check_dns_threshold: failure rate exceeds max_failure_rate"
+
+    source "$DNS_PIN_LIB"
+
+    # 33 of 43 = ~77% failed, threshold is 50%
+    assert_command_fails \
+        "check_dns_threshold 10 33 '0.5' '' 'false'" \
+        "Should abort when 77% failed > 50% threshold"
+}
+
+test_check_dns_threshold_rate_not_exceeded() {
+    log_test "Testing check_dns_threshold: failure rate below max_failure_rate"
+
+    source "$DNS_PIN_LIB"
+
+    # 5 of 20 = 25% failed, threshold is 50% — should pass
+    assert_command_succeeds \
+        "check_dns_threshold 15 5 '0.5' '' 'false'" \
+        "Should pass when 25% failed < 50% threshold"
+}
+
+test_check_dns_threshold_abs_exceeded() {
+    log_test "Testing check_dns_threshold: absolute failures exceed max_failures"
+
+    source "$DNS_PIN_LIB"
+
+    assert_command_fails \
+        "check_dns_threshold 10 11 '' '10' 'false'" \
+        "Should abort when 11 failed > max_failures=10"
+}
+
+test_check_dns_threshold_abs_not_exceeded() {
+    log_test "Testing check_dns_threshold: absolute failures within max_failures"
+
+    source "$DNS_PIN_LIB"
+
+    assert_command_succeeds \
+        "check_dns_threshold 10 10 '' '10' 'false'" \
+        "Should pass when failed == max_failures (not strictly greater)"
+}
+
+test_check_dns_threshold_or_logic() {
+    log_test "Testing check_dns_threshold: OR logic — either threshold triggers abort"
+
+    source "$DNS_PIN_LIB"
+
+    # Rate threshold not exceeded (10%), but absolute threshold exceeded (11 > 5)
+    assert_command_fails \
+        "check_dns_threshold 100 11 '0.5' '5' 'false'" \
+        "Should abort when abs threshold exceeded even if rate is fine"
+
+    # Absolute threshold not exceeded (3 <= 10), but rate threshold exceeded (60% > 50%)
+    assert_command_fails \
+        "check_dns_threshold 2 3 '0.5' '10' 'false'" \
+        "Should abort when rate threshold exceeded even if abs is fine"
+}
+
+test_dns_stats_sentinel_emitted_by_resolve() {
+    log_test "Testing resolve_allowlist_domains emits KAPSIS_DNS_STATS sentinel"
+
+    source "$DNS_PIN_LIB"
+
+    # An all-wildcard list resolves zero real domains; sentinel should still appear
+    local output
+    output=$(resolve_allowlist_domains "*.github.com,*.gitlab.com" 2 "dynamic" 2>/dev/null)
+
+    if echo "$output" | grep -q '^KAPSIS_DNS_STATS '; then
+        log_pass "KAPSIS_DNS_STATS sentinel emitted"
+    else
+        log_fail "Expected KAPSIS_DNS_STATS sentinel in output, got: $output"
+        return 1
+    fi
+}
+
+test_dns_stats_sentinel_stripped_from_pin_file() {
+    log_test "Testing KAPSIS_DNS_STATS sentinel is stripped before writing pin file"
+
+    source "$DNS_PIN_LIB"
+
+    local temp_file
+    temp_file=$(mktemp)
+
+    # Simulate what launch-agent.sh does: resolve, strip sentinel, write pin file
+    local resolved_data
+    resolved_data=$(resolve_allowlist_domains "github.com" 5 "dynamic" 2>/dev/null) || true
+
+    local cleaned
+    cleaned=$(echo "$resolved_data" | grep -v '^KAPSIS_DNS_STATS ')
+
+    write_pinned_dns_file "$temp_file" "$cleaned"
+
+    if grep -q 'KAPSIS_DNS_STATS' "$temp_file"; then
+        log_fail "Sentinel should not appear in the written pin file"
+        rm -f "$temp_file"
+        return 1
+    else
+        log_pass "Sentinel correctly absent from pin file"
+    fi
+
+    rm -f "$temp_file"
+}
+
+test_config_validation_max_failure_rate_valid() {
+    log_test "Testing config validation accepts valid max_failure_rate"
+
+    if ! command -v yq &>/dev/null; then
+        log_skip "yq not installed"
+        return 0
+    fi
+
+    local test_config
+    test_config=$(mktemp).yaml
+
+    cat > "$test_config" << 'EOF'
+network:
+  mode: filtered
+  dns_pinning:
+    enabled: true
+    fallback: dynamic
+    max_failure_rate: 0.5
+    max_failures: 10
+EOF
+
+    local output
+    output=$("$CONFIG_VERIFIER" "$test_config" 2>&1) || true
+
+    if echo "$output" | grep -q "Invalid dns_pinning.max_failure_rate\|Invalid dns_pinning.max_failures"; then
+        log_fail "Validation rejected valid threshold values: $output"
+    else
+        log_pass "Valid max_failure_rate and max_failures accepted"
+    fi
+
+    rm -f "$test_config"
+}
+
+test_config_validation_max_failure_rate_invalid() {
+    log_test "Testing config validation rejects out-of-range max_failure_rate"
+
+    if ! command -v yq &>/dev/null; then
+        log_skip "yq not installed"
+        return 0
+    fi
+
+    local test_config
+    test_config=$(mktemp).yaml
+
+    cat > "$test_config" << 'EOF'
+network:
+  mode: filtered
+  dns_pinning:
+    enabled: true
+    max_failure_rate: 1.5
+    max_failures: -1
+EOF
+
+    local output
+    output=$("$CONFIG_VERIFIER" "$test_config" 2>&1) || true
+
+    if echo "$output" | grep -q "Invalid dns_pinning.max_failure_rate"; then
+        log_pass "Out-of-range max_failure_rate rejected"
+    else
+        log_warn "Expected validation error for max_failure_rate=1.5"
+    fi
+
+    rm -f "$test_config"
+}
+
+#===============================================================================
 # CONTAINER TESTS (require Podman)
 #===============================================================================
 
@@ -835,6 +1038,20 @@ main() {
     run_test test_resolve_returns_valid_ipv4_or_empty
     run_test test_add_host_args_format
     run_test test_pinned_file_parsing_robust
+
+    # DNS failure threshold tests (Issue #216)
+    run_test test_check_dns_threshold_disabled_by_default
+    run_test test_check_dns_threshold_skip_check_bypasses
+    run_test test_check_dns_threshold_no_failures_always_ok
+    run_test test_check_dns_threshold_rate_exceeded
+    run_test test_check_dns_threshold_rate_not_exceeded
+    run_test test_check_dns_threshold_abs_exceeded
+    run_test test_check_dns_threshold_abs_not_exceeded
+    run_test test_check_dns_threshold_or_logic
+    run_test test_dns_stats_sentinel_emitted_by_resolve
+    run_test test_dns_stats_sentinel_stripped_from_pin_file
+    run_test test_config_validation_max_failure_rate_valid
+    run_test test_config_validation_max_failure_rate_invalid
 
     # Container tests
     run_test test_pinned_file_mounted_readonly


### PR DESCRIPTION
## Summary

Fixes #216. When host DNS is flaky (VPN reconnecting, corporate DNS degraded), Kapsis previously launched the container with partial DNS anyway — resulting in wasted agent runs (the triggering case: 33/52 domains failed, container ran for 50 minutes before hitting network errors).

This PR adds a configurable failure-rate threshold that aborts launch early with a clear diagnosis.

## Changes

- **`scripts/lib/dns-pin.sh`** — emit a `KAPSIS_DNS_STATS resolved=N failed=N wildcards=N` sentinel line at the end of `resolve_allowlist_domains` stdout, so failure counts survive the `$()` subshell boundary. Add `check_dns_threshold()` helper that evaluates `max_failure_rate` (fraction) and `max_failures` (absolute count) with OR logic.
- **`scripts/launch-agent.sh`** — parse the two new config keys; strip the sentinel before writing the pin file; call `check_dns_threshold`; exit 7 on breach. Exit code 7 added to the documented table.
- **`scripts/lib/config-verifier.sh`** — validate new fields (`max_failure_rate` 0.0–1.0, `max_failures` non-negative integer).
- **`configs/network-allowlist.yaml`** — document new options (commented-out by default = **no behaviour change for existing users**).
- **`tests/test-dns-pinning.sh`** — 12 new unit tests covering every threshold path.

## Design decisions (from ensemble brainstorm)

| Decision | Choice | Rationale |
|----------|--------|-----------|
| Denominator | `resolved + failed` only | Wildcards are intentionally unpinnable; including them inflates the apparent failure pool |
| Threshold logic | OR — either limit triggers abort | Both are safety bounds, not a two-factor gate |
| Default | disabled (empty = no check) | Zero regression for existing `dynamic` fallback users |
| Subshell comms | `KAPSIS_DNS_STATS` sentinel on stdout | Survives `$()` without temp files or signature changes |
| Override | `KAPSIS_SKIP_DNS_CHECK=true` | Env var is easier than a new `--force` flag (avoids touching 2800-line arg parser) |
| Exit code | 7 | Codes 0–6 already documented; 7 is the next free slot |

## Usage

```yaml
# agent-sandbox.yaml or configs/network-allowlist.yaml
network:
  dns_pinning:
    max_failure_rate: 0.5   # abort if >50% of non-wildcard domains fail
    max_failures: 10        # abort if >10 domains fail (OR logic)
```

```
$ KAPSIS_SKIP_DNS_CHECK=true ./scripts/launch-agent.sh ...   # bypass check
```

## Test plan

- [x] All 39 DNS pinning tests pass (`KAPSIS_QUICK_TESTS=1 bash tests/test-dns-pinning.sh`)
- [x] All 12 new threshold tests pass
- [x] Syntax check: `bash -n` on all modified files
- [x] Existing behaviour unchanged when neither threshold is set

https://claude.ai/code/session_015HgeD5H9R9TV4MZdvNqHud

---
_Generated by [Claude Code](https://claude.ai/code/session_015HgeD5H9R9TV4MZdvNqHud)_