### PR TITLE
feat(dns): abort launch when DNS failure rate exceeds threshold (fix #216)

### DIFF
--- a/configs/network-allowlist.yaml
+++ b/configs/network-allowlist.yaml
@@ -169,6 +169,17 @@ network:
     # Sets chmod 444 after DNS setup (agent runs as non-root, cannot override)
     protect_dns_files: true
 
+    # Abort container launch when too many domains fail to resolve on the host.
+    # Prevents wasting a long agent run when VPN/DNS is broken at launch time.
+    # Both thresholds are checked independently; either can trigger an abort.
+    # Override at runtime with: KAPSIS_SKIP_DNS_CHECK=true
+    #
+    # Abort if more than N% of domains fail to resolve (fraction 0.0-1.0):
+    # max_failure_rate: 0.5
+    #
+    # Abort if more than N domains fail to resolve (absolute count):
+    # max_failures: 10
+
   # Allowed ports (documented for reference)
   # Note: Port filtering is NOT enforced - only DNS filtering
   # These are the typical ports that allowed services use

--- a/scripts/launch-agent.sh
+++ b/scripts/launch-agent.sh
@@ -893,6 +893,8 @@ parse_config() {
         NETWORK_DNS_PIN_FALLBACK=$(yq eval '.network.dns_pinning.fallback // "dynamic"' "$CONFIG_FILE" 2>/dev/null || echo "dynamic")
         NETWORK_DNS_PIN_TIMEOUT=$(yq eval '.network.dns_pinning.resolve_timeout // "5"' "$CONFIG_FILE" 2>/dev/null || echo "5")
         NETWORK_DNS_PIN_PROTECT=$(yq eval '.network.dns_pinning.protect_dns_files // "true"' "$CONFIG_FILE" 2>/dev/null || echo "true")
+        NETWORK_DNS_MAX_FAILURE_RATE=$(yq eval '.network.dns_pinning.max_failure_rate // ""' "$CONFIG_FILE" 2>/dev/null || echo "")
+        NETWORK_DNS_MAX_FAILURES=$(yq eval '.network.dns_pinning.max_failures // ""' "$CONFIG_FILE" 2>/dev/null || echo "")
 
         # Parse cleanup configuration (Fix #183)
         # Env vars take precedence over YAML via ${VAR:-$(yq ...)} pattern
@@ -2210,8 +2212,16 @@ build_container_command() {
             # This prevents DNS manipulation attacks inside the container
             if [[ "${NETWORK_DNS_PIN_ENABLED:-true}" == "true" ]] && [[ -n "${NETWORK_ALLOWLIST_DOMAINS:-}" ]]; then
                 log_info "DNS pinning: resolving allowlist domains on host..."
-                local resolved_data
-                if resolved_data=$(resolve_allowlist_domains "$NETWORK_ALLOWLIST_DOMAINS" "${NETWORK_DNS_PIN_TIMEOUT:-5}" "${NETWORK_DNS_PIN_FALLBACK:-dynamic}"); then
+                local resolved_data dns_pin_rc
+                dns_pin_rc=0
+                resolved_data=$(resolve_allowlist_domains \
+                    "$NETWORK_ALLOWLIST_DOMAINS" \
+                    "${NETWORK_DNS_PIN_TIMEOUT:-5}" \
+                    "${NETWORK_DNS_PIN_FALLBACK:-dynamic}" \
+                    "${NETWORK_DNS_MAX_FAILURE_RATE:-}" \
+                    "${NETWORK_DNS_MAX_FAILURES:-}") || dns_pin_rc=$?
+
+                if [[ "$dns_pin_rc" -eq 0 ]]; then
                     if [[ -n "$resolved_data" ]]; then
                         # Create temp file for pinned DNS (cleaned up in _cleanup_with_completion)
                         DNS_PIN_FILE=$(mktemp)
@@ -2234,7 +2244,17 @@ build_container_command() {
                             CONTAINER_CMD+=("-e" "KAPSIS_DNS_PIN_ENABLED=true")
                         fi
                     fi
+                elif [[ "$dns_pin_rc" -eq 2 ]]; then
+                    # Threshold exceeded (max_failure_rate or max_failures)
+                    if [[ "${KAPSIS_SKIP_DNS_CHECK:-false}" == "true" ]]; then
+                        log_warn "DNS failure threshold exceeded but KAPSIS_SKIP_DNS_CHECK=true — proceeding with degraded security"
+                    else
+                        log_error "Aborting container launch due to high DNS resolution failure rate."
+                        log_error "Set KAPSIS_SKIP_DNS_CHECK=true to bypass this check."
+                        exit 1
+                    fi
                 else
+                    # rc=1: fallback=abort or other partial failure
                     if [[ "${NETWORK_DNS_PIN_FALLBACK:-dynamic}" == "abort" ]]; then
                         log_error "DNS pinning failed with fallback=abort - aborting container launch"
                         exit 1

--- a/scripts/lib/config-verifier.sh
+++ b/scripts/lib/config-verifier.sh
@@ -532,6 +532,26 @@ validate_network_config() {
         fi
     fi
 
+    local dns_pin_max_rate
+    dns_pin_max_rate=$(yq -r '.network.dns_pinning.max_failure_rate // "null"' "$config_file" 2>/dev/null)
+    if [[ "$dns_pin_max_rate" != "null" ]]; then
+        if awk -v v="$dns_pin_max_rate" 'BEGIN { exit (v ~ /^[0-9]*\.?[0-9]+$/ && v+0 >= 0 && v+0 <= 1) ? 0 : 1 }' 2>/dev/null; then
+            log_pass "Valid dns_pinning.max_failure_rate: $dns_pin_max_rate"
+        else
+            log_error "Invalid dns_pinning.max_failure_rate: $dns_pin_max_rate (must be a number between 0.0 and 1.0)"
+        fi
+    fi
+
+    local dns_pin_max_failures
+    dns_pin_max_failures=$(yq -r '.network.dns_pinning.max_failures // "null"' "$config_file" 2>/dev/null)
+    if [[ "$dns_pin_max_failures" != "null" ]]; then
+        if [[ "$dns_pin_max_failures" =~ ^[0-9]+$ ]] && [[ "$dns_pin_max_failures" -gt 0 ]]; then
+            log_pass "Valid dns_pinning.max_failures: $dns_pin_max_failures"
+        else
+            log_error "Invalid dns_pinning.max_failures: $dns_pin_max_failures (must be a positive integer)"
+        fi
+    fi
+
     return 0
 }
 

--- a/scripts/lib/dns-pin.sh
+++ b/scripts/lib/dns-pin.sh
@@ -48,7 +48,7 @@ type log_success &>/dev/null || log_success() { echo "[DNS-PIN] SUCCESS: $*" >&2
 # DOMAIN RESOLUTION
 #===============================================================================
 
-# resolve_allowlist_domains <comma-domains> [timeout] [fallback]
+# resolve_allowlist_domains <comma-domains> [timeout] [fallback] [max_failure_rate] [max_failures]
 #
 # Resolves comma-separated domains to IP addresses on the host.
 # Skips wildcards (emitting security warning) and returns pinned mappings.
@@ -57,16 +57,25 @@ type log_success &>/dev/null || log_success() { echo "[DNS-PIN] SUCCESS: $*" >&2
 #   $1 - Comma-separated list of domains (from KAPSIS_DNS_ALLOWLIST)
 #   $2 - Resolution timeout in seconds (default: 5)
 #   $3 - Fallback behavior: "dynamic" (default) or "abort"
+#   $4 - Max failure rate as fraction 0.0-1.0, e.g. "0.5" (50%); empty = no check
+#        Falls back to KAPSIS_DNS_MAX_FAILURE_RATE env var if arg is empty.
+#   $5 - Max absolute failure count, e.g. "10"; empty = no check
+#        Falls back to KAPSIS_DNS_MAX_FAILURES env var if arg is empty.
 #
 # Output:
 #   domain IP1 IP2 ...
 #   (one line per domain with resolved IPs, space-separated)
 #
-# Returns: 0 on success (even partial), 1 on complete failure with abort mode
+# Returns:
+#   0 - success (even partial)
+#   1 - any failure with fallback=abort
+#   2 - DNS failure threshold exceeded (max_failure_rate or max_failures)
 resolve_allowlist_domains() {
     local domain_list="$1"
     local timeout="${2:-5}"
     local fallback="${3:-dynamic}"
+    local max_failure_rate="${4:-${KAPSIS_DNS_MAX_FAILURE_RATE:-}}"
+    local max_failures="${5:-${KAPSIS_DNS_MAX_FAILURES:-}}"
 
     [[ -z "$domain_list" ]] && return 0
 
@@ -117,6 +126,34 @@ resolve_allowlist_domains() {
     done
 
     log_info "DNS pinning: resolved $resolved_count domains, $failed_count failed, $wildcard_count wildcards skipped"
+
+    # Threshold-based abort check — returns 2 so callers can distinguish from fallback=abort (1).
+    # Both max_failure_rate and max_failures are checked independently; either can trigger.
+    if [[ "$failed_count" -gt 0 ]] && [[ -n "$max_failure_rate" || -n "$max_failures" ]]; then
+        local total_count=$(( resolved_count + failed_count ))
+
+        # Absolute failure count threshold
+        if [[ -n "$max_failures" ]] && (( failed_count > max_failures )); then
+            log_error "DNS resolution failure threshold exceeded: $failed_count/$total_count domains failed (max allowed: $max_failures)"
+            log_error "Check VPN/network connectivity and retry."
+            log_error "Override: set KAPSIS_SKIP_DNS_CHECK=true to bypass this check"
+            return 2
+        fi
+
+        # Failure rate threshold (float comparison via awk; awk exits 0 when threshold exceeded)
+        if [[ -n "$max_failure_rate" ]] && (( total_count > 0 )); then
+            if awk -v f="$failed_count" -v t="$total_count" -v m="$max_failure_rate" \
+                   'BEGIN { exit (f/t > m) ? 0 : 1 }'; then
+                local pct max_pct
+                pct=$(awk -v f="$failed_count" -v t="$total_count" 'BEGIN { printf "%.0f", (f/t)*100 }')
+                max_pct=$(awk -v m="$max_failure_rate" 'BEGIN { printf "%.0f", m*100 }')
+                log_error "DNS resolution failure rate ${pct}% exceeds threshold ${max_pct}%: $failed_count/$total_count domains failed"
+                log_error "Check VPN/network connectivity and retry."
+                log_error "Override: set KAPSIS_SKIP_DNS_CHECK=true to bypass this check"
+                return 2
+            fi
+        fi
+    fi
 
     # Handle failures based on fallback mode
     if [[ "$failed_count" -gt 0 ]] && [[ "$fallback" == "abort" ]]; then

--- a/tests/test-dns-pinning.sh
+++ b/tests/test-dns-pinning.sh
@@ -627,6 +627,206 @@ EOF
 }
 
 #===============================================================================
+# THRESHOLD TESTS (Issue #216 — abort launch when DNS failure rate too high)
+#===============================================================================
+
+test_threshold_max_failures_triggers_exit2() {
+    log_test "Testing resolve_allowlist_domains returns 2 when max_failures exceeded"
+
+    source "$DNS_PIN_LIB"
+
+    # Use all-invalid domains so every one fails, max_failures=1
+    local rc=0
+    resolve_allowlist_domains \
+        "this-will-not-resolve-xyz123.invalid,also-not-real-abc987.invalid" \
+        2 "dynamic" "" "1" >/dev/null 2>&1 || rc=$?
+
+    if [[ "$rc" -eq 2 ]]; then
+        log_pass "Exit code 2 returned when failures exceed max_failures"
+    elif [[ "$rc" -eq 0 ]]; then
+        log_skip "All domains resolved unexpectedly (DNS returns 0.0.0.0 for all?) — skipping"
+    else
+        log_fail "Expected exit code 2, got: $rc"
+        return 1
+    fi
+}
+
+test_threshold_max_failure_rate_triggers_exit2() {
+    log_test "Testing resolve_allowlist_domains returns 2 when max_failure_rate exceeded"
+
+    source "$DNS_PIN_LIB"
+
+    # 2 invalid domains out of 2 = 100% failure rate; threshold 0.4 (40%) should trigger
+    local rc=0
+    resolve_allowlist_domains \
+        "this-will-not-resolve-xyz123.invalid,also-not-real-abc987.invalid" \
+        2 "dynamic" "0.4" "" >/dev/null 2>&1 || rc=$?
+
+    if [[ "$rc" -eq 2 ]]; then
+        log_pass "Exit code 2 returned when failure rate exceeds max_failure_rate"
+    elif [[ "$rc" -eq 0 ]]; then
+        log_skip "All domains resolved unexpectedly (DNS returns 0.0.0.0 for all?) — skipping"
+    else
+        log_fail "Expected exit code 2, got: $rc"
+        return 1
+    fi
+}
+
+test_threshold_under_limit_returns_0() {
+    log_test "Testing resolve_allowlist_domains returns 0 when failures stay under threshold"
+
+    source "$DNS_PIN_LIB"
+
+    # max_failures=100 — even if some domains fail, 2 failures won't exceed 100
+    local rc=0
+    resolve_allowlist_domains \
+        "this-will-not-resolve-xyz123.invalid,also-not-real-abc987.invalid" \
+        2 "dynamic" "" "100" >/dev/null 2>&1 || rc=$?
+
+    if [[ "$rc" -eq 0 ]]; then
+        log_pass "Exit code 0 returned when failures are under max_failures threshold"
+    elif [[ "$rc" -eq 2 ]]; then
+        log_fail "Threshold triggered unexpectedly — more than 100 failures?"
+        return 1
+    else
+        log_fail "Unexpected exit code: $rc"
+        return 1
+    fi
+}
+
+test_threshold_env_var_max_failures() {
+    log_test "Testing KAPSIS_DNS_MAX_FAILURES env var is respected"
+
+    source "$DNS_PIN_LIB"
+
+    export KAPSIS_DNS_MAX_FAILURES=1
+    local rc=0
+    # Pass no positional threshold args — function should pick up the env var
+    resolve_allowlist_domains \
+        "this-will-not-resolve-xyz123.invalid,also-not-real-abc987.invalid" \
+        2 "dynamic" >/dev/null 2>&1 || rc=$?
+    unset KAPSIS_DNS_MAX_FAILURES
+
+    if [[ "$rc" -eq 2 ]]; then
+        log_pass "KAPSIS_DNS_MAX_FAILURES env var triggers exit code 2"
+    elif [[ "$rc" -eq 0 ]]; then
+        log_skip "All domains resolved unexpectedly — skipping"
+    else
+        log_fail "Expected exit code 2, got: $rc"
+        return 1
+    fi
+}
+
+test_threshold_env_var_max_failure_rate() {
+    log_test "Testing KAPSIS_DNS_MAX_FAILURE_RATE env var is respected"
+
+    source "$DNS_PIN_LIB"
+
+    export KAPSIS_DNS_MAX_FAILURE_RATE=0.1
+    local rc=0
+    resolve_allowlist_domains \
+        "this-will-not-resolve-xyz123.invalid,also-not-real-abc987.invalid" \
+        2 "dynamic" >/dev/null 2>&1 || rc=$?
+    unset KAPSIS_DNS_MAX_FAILURE_RATE
+
+    if [[ "$rc" -eq 2 ]]; then
+        log_pass "KAPSIS_DNS_MAX_FAILURE_RATE env var triggers exit code 2"
+    elif [[ "$rc" -eq 0 ]]; then
+        log_skip "All domains resolved unexpectedly — skipping"
+    else
+        log_fail "Expected exit code 2, got: $rc"
+        return 1
+    fi
+}
+
+test_threshold_no_limit_set_returns_0() {
+    log_test "Testing resolve_allowlist_domains returns 0 with no threshold configured"
+
+    source "$DNS_PIN_LIB"
+
+    # No threshold args and no env vars — failures are silently tolerated (existing behavior)
+    unset KAPSIS_DNS_MAX_FAILURES KAPSIS_DNS_MAX_FAILURE_RATE
+    local rc=0
+    resolve_allowlist_domains \
+        "this-will-not-resolve-xyz123.invalid" \
+        2 "dynamic" "" "" >/dev/null 2>&1 || rc=$?
+
+    if [[ "$rc" -eq 0 ]]; then
+        log_pass "No threshold — failures tolerated, exit code 0"
+    elif [[ "$rc" -eq 2 ]]; then
+        log_fail "Threshold triggered when none was configured"
+        return 1
+    else
+        log_fail "Unexpected exit code: $rc"
+        return 1
+    fi
+}
+
+test_config_validation_max_failure_rate_valid() {
+    log_test "Testing config validation accepts valid max_failure_rate values"
+
+    if ! command -v yq &>/dev/null; then
+        log_skip "yq not installed"
+        return 0
+    fi
+
+    local test_config
+    test_config=$(mktemp).yaml
+    cat > "$test_config" << 'EOF'
+network:
+  mode: filtered
+  dns_pinning:
+    enabled: true
+    max_failure_rate: 0.5
+    max_failures: 10
+EOF
+
+    local output
+    output=$("$CONFIG_VERIFIER" "$test_config" 2>&1) || true
+
+    if echo "$output" | grep -q "Invalid dns_pinning.max_failure_rate\|Invalid dns_pinning.max_failures"; then
+        log_fail "Valid values rejected by config verifier: $output"
+        rm -f "$test_config"
+        return 1
+    else
+        log_pass "Valid max_failure_rate and max_failures accepted"
+    fi
+
+    rm -f "$test_config"
+}
+
+test_config_validation_max_failure_rate_invalid() {
+    log_test "Testing config validation rejects invalid max_failure_rate values"
+
+    if ! command -v yq &>/dev/null; then
+        log_skip "yq not installed"
+        return 0
+    fi
+
+    local test_config
+    test_config=$(mktemp).yaml
+    cat > "$test_config" << 'EOF'
+network:
+  mode: filtered
+  dns_pinning:
+    enabled: true
+    max_failure_rate: 1.5
+    max_failures: -1
+EOF
+
+    local output
+    output=$("$CONFIG_VERIFIER" "$test_config" 2>&1) || true
+
+    if echo "$output" | grep -q "Invalid dns_pinning.max_failure_rate"; then
+        log_pass "Invalid max_failure_rate (>1.0) correctly rejected"
+    else
+        log_warn "Expected validation error for max_failure_rate=1.5"
+    fi
+
+    rm -f "$test_config"
+}
+
+#===============================================================================
 # CONTAINER TESTS (require Podman)
 #===============================================================================
 
@@ -835,6 +1035,16 @@ main() {
     run_test test_resolve_returns_valid_ipv4_or_empty
     run_test test_add_host_args_format
     run_test test_pinned_file_parsing_robust
+
+    # Threshold tests (Issue #216)
+    run_test test_threshold_max_failures_triggers_exit2
+    run_test test_threshold_max_failure_rate_triggers_exit2
+    run_test test_threshold_under_limit_returns_0
+    run_test test_threshold_env_var_max_failures
+    run_test test_threshold_env_var_max_failure_rate
+    run_test test_threshold_no_limit_set_returns_0
+    run_test test_config_validation_max_failure_rate_valid
+    run_test test_config_validation_max_failure_rate_invalid
 
     # Container tests
     run_test test_pinned_file_mounted_readonly


### PR DESCRIPTION
## Summary

Fixes #216.

When host DNS is flaky (VPN reconnecting, corporate DNS temporarily down), Kapsis previously launched containers with a partially-broken network — causing agent runs to fail mid-task after potentially hours of wasted work. The fix adds a **threshold-based abort** that detects the broken network _before_ launching.

- Add `max_failure_rate` (fraction 0.0–1.0) and `max_failures` (absolute count) thresholds to `resolve_allowlist_domains()` in `dns-pin.sh`
- `resolve_allowlist_domains` now returns exit code **2** when a threshold is exceeded (distinct from the existing `fallback=abort` exit code 1), so `launch-agent.sh` can differentiate the two cases cleanly
- `launch-agent.sh` captures the exit code with `|| dns_pin_rc=$?` instead of the if-subshell pattern, parses the two new YAML keys, and aborts with a clear error on code 2
- `KAPSIS_SKIP_DNS_CHECK=true` env var bypasses the threshold check as an escape hatch
- Both thresholds also read from env vars (`KAPSIS_DNS_MAX_FAILURE_RATE` / `KAPSIS_DNS_MAX_FAILURES`) when not passed as positional args
- Config verifier validates the new fields
- `network-allowlist.yaml` documents the new commented-out options

## Ensemble brainstorm

**Architect**: Exit code 2 cleanly separates "threshold exceeded" from "fallback=abort" (code 1) without changing the stdout contract of `resolve_allowlist_domains`. The `|| dns_pin_rc=$?` pattern avoids a subshell that would swallow globals. `KAPSIS_SKIP_DNS_CHECK=true` as the bypass is simpler than a `--force` CLI flag and easier to wire into CI overrides.

**Contrarian challenge → accepted**: Globals set inside `$(...)` don't propagate — confirmed this is not an issue here because only the exit code needs to propagate, not state. Also challenged whether `awk` is available everywhere — confirmed it is (busybox awk is sufficient for the arithmetic).

## Changes

| File | Change |
|------|--------|
| `scripts/lib/dns-pin.sh` | Add `max_failure_rate` / `max_failures` params + exit code 2 |
| `scripts/launch-agent.sh` | Parse new config vars, handle exit code 2, add `KAPSIS_SKIP_DNS_CHECK` escape hatch |
| `scripts/lib/config-verifier.sh` | Validate new `dns_pinning` fields |
| `configs/network-allowlist.yaml` | Document new options (commented out by default) |
| `tests/test-dns-pinning.sh` | 8 new quick tests — all passing (35/35 total) |

## Test plan

- [x] `tests/test-dns-pinning.sh` — 35/35 pass including 8 new threshold tests
- [x] `bash -n` syntax check on all modified scripts
- [ ] Verify abort message in `launch-agent.sh` dry-run with broken DNS (needs live DNS environment)
- [ ] Verify `KAPSIS_SKIP_DNS_CHECK=true` bypass allows launch despite threshold exceeded

## Config example

```yaml
network:
  dns_pinning:
    enabled: true
    fallback: dynamic
    max_failure_rate: 0.5   # abort if >50% of domains fail
    max_failures: 10        # abort if >10 domains fail (whichever triggers first)
```

Or as env vars:
```bash
KAPSIS_DNS_MAX_FAILURE_RATE=0.5 ./scripts/launch-agent.sh ...
KAPSIS_SKIP_DNS_CHECK=true ./scripts/launch-agent.sh ...  # bypass
```

https://claude.ai/code/session_01K9dHpgwPvxBLFUmyJLiVxo

---
_Generated by [Claude Code](https://claude.ai/code/session_01K9dHpgwPvxBLFUmyJLiVxo)_