### PR TITLE
feat(dns): abort launch when DNS failure rate exceeds threshold (fixes #216)

### DIFF
--- a/configs/network-allowlist.yaml
+++ b/configs/network-allowlist.yaml
@@ -169,6 +169,18 @@ network:
     # Sets chmod 444 after DNS setup (agent runs as non-root, cannot override)
     protect_dns_files: true
 
+    # Abort launch when DNS failure rate exceeds this fraction (0.0-1.0).
+    # Prevents wasted agent runs when the host network/VPN is broken.
+    # Example: 0.5 aborts if more than 50% of domains fail to resolve.
+    # Default: 1.0 (disabled — never abort based on rate alone)
+    # Override at launch time: KAPSIS_SKIP_DNS_CHECK=true
+    max_failure_rate: 0.5
+
+    # Abort launch when more than this many domains fail to resolve (absolute count).
+    # -1 disables this check. Takes effect independently of max_failure_rate.
+    # Default: -1 (disabled)
+    max_failures: -1
+
   # Allowed ports (documented for reference)
   # Note: Port filtering is NOT enforced - only DNS filtering
   # These are the typical ports that allowed services use

--- a/scripts/launch-agent.sh
+++ b/scripts/launch-agent.sh
@@ -893,6 +893,8 @@ parse_config() {
         NETWORK_DNS_PIN_FALLBACK=$(yq eval '.network.dns_pinning.fallback // "dynamic"' "$CONFIG_FILE" 2>/dev/null || echo "dynamic")
         NETWORK_DNS_PIN_TIMEOUT=$(yq eval '.network.dns_pinning.resolve_timeout // "5"' "$CONFIG_FILE" 2>/dev/null || echo "5")
         NETWORK_DNS_PIN_PROTECT=$(yq eval '.network.dns_pinning.protect_dns_files // "true"' "$CONFIG_FILE" 2>/dev/null || echo "true")
+        NETWORK_DNS_PIN_MAX_FAILURE_RATE=$(yq eval '.network.dns_pinning.max_failure_rate // "1.0"' "$CONFIG_FILE" 2>/dev/null || echo "1.0")
+        NETWORK_DNS_PIN_MAX_FAILURES=$(yq eval '.network.dns_pinning.max_failures // "-1"' "$CONFIG_FILE" 2>/dev/null || echo "-1")
 
         # Parse cleanup configuration (Fix #183)
         # Env vars take precedence over YAML via ${VAR:-$(yq ...)} pattern
@@ -2211,7 +2213,7 @@ build_container_command() {
             if [[ "${NETWORK_DNS_PIN_ENABLED:-true}" == "true" ]] && [[ -n "${NETWORK_ALLOWLIST_DOMAINS:-}" ]]; then
                 log_info "DNS pinning: resolving allowlist domains on host..."
                 local resolved_data
-                if resolved_data=$(resolve_allowlist_domains "$NETWORK_ALLOWLIST_DOMAINS" "${NETWORK_DNS_PIN_TIMEOUT:-5}" "${NETWORK_DNS_PIN_FALLBACK:-dynamic}"); then
+                if resolved_data=$(resolve_allowlist_domains "$NETWORK_ALLOWLIST_DOMAINS" "${NETWORK_DNS_PIN_TIMEOUT:-5}" "${NETWORK_DNS_PIN_FALLBACK:-dynamic}" "${NETWORK_DNS_PIN_MAX_FAILURE_RATE:-1.0}" "${NETWORK_DNS_PIN_MAX_FAILURES:--1}"); then
                     if [[ -n "$resolved_data" ]]; then
                         # Create temp file for pinned DNS (cleaned up in _cleanup_with_completion)
                         DNS_PIN_FILE=$(mktemp)

--- a/scripts/lib/config-verifier.sh
+++ b/scripts/lib/config-verifier.sh
@@ -532,6 +532,28 @@ validate_network_config() {
         fi
     fi
 
+    local dns_pin_max_rate
+    dns_pin_max_rate=$(yq -r '.network.dns_pinning.max_failure_rate // "null"' "$config_file" 2>/dev/null)
+    if [[ "$dns_pin_max_rate" != "null" ]]; then
+        # Must be a number in range [0.0, 1.0]
+        if awk -v v="$dns_pin_max_rate" 'BEGIN { exit !(v ~ /^[0-9]*\.?[0-9]+$/ && v+0 >= 0 && v+0 <= 1) }'; then
+            log_pass "Valid dns_pinning.max_failure_rate: $dns_pin_max_rate"
+        else
+            log_error "Invalid dns_pinning.max_failure_rate: $dns_pin_max_rate (must be a number between 0.0 and 1.0)"
+        fi
+    fi
+
+    local dns_pin_max_failures
+    dns_pin_max_failures=$(yq -r '.network.dns_pinning.max_failures // "null"' "$config_file" 2>/dev/null)
+    if [[ "$dns_pin_max_failures" != "null" ]]; then
+        # Must be an integer >= -1 (-1 = disabled)
+        if [[ "$dns_pin_max_failures" =~ ^-?[0-9]+$ ]] && [[ "$dns_pin_max_failures" -ge -1 ]]; then
+            log_pass "Valid dns_pinning.max_failures: $dns_pin_max_failures"
+        else
+            log_error "Invalid dns_pinning.max_failures: $dns_pin_max_failures (must be an integer >= -1)"
+        fi
+    fi
+
     return 0
 }
 
@@ -826,15 +848,23 @@ main() {
                 if [[ "$dirname" == *"/agents"* ]]; then
                     validate_agent_profile "$config_file"
                 else
-                    # Determine by content: launch configs have agent.command
-                    if yq -r '.agent.command // "null"' "$config_file" 2>/dev/null | grep -qv '^null$'; then
-                        validate_launch_config "$config_file"
-                    elif yq -r '.name // "null"' "$config_file" 2>/dev/null | grep -qv '^null$'; then
-                        validate_agent_profile "$config_file"
-                    else
-                        log_warn "Unknown config type, attempting launch config validation"
-                        validate_launch_config "$config_file"
-                    fi
+                    local config_type
+                    config_type=$(detect_config_type "$config_file")
+                    case "$config_type" in
+                        network)
+                            validate_network_config "$config_file"
+                            ;;
+                        launch)
+                            validate_launch_config "$config_file"
+                            ;;
+                        agent)
+                            validate_agent_profile "$config_file"
+                            ;;
+                        *)
+                            log_warn "Unknown config type, attempting launch config validation"
+                            validate_launch_config "$config_file"
+                            ;;
+                    esac
                 fi
                 ;;
             *)

--- a/scripts/lib/dns-pin.sh
+++ b/scripts/lib/dns-pin.sh
@@ -48,7 +48,7 @@ type log_success &>/dev/null || log_success() { echo "[DNS-PIN] SUCCESS: $*" >&2
 # DOMAIN RESOLUTION
 #===============================================================================
 
-# resolve_allowlist_domains <comma-domains> [timeout] [fallback]
+# resolve_allowlist_domains <comma-domains> [timeout] [fallback] [max_failure_rate] [max_failures]
 #
 # Resolves comma-separated domains to IP addresses on the host.
 # Skips wildcards (emitting security warning) and returns pinned mappings.
@@ -57,16 +57,22 @@ type log_success &>/dev/null || log_success() { echo "[DNS-PIN] SUCCESS: $*" >&2
 #   $1 - Comma-separated list of domains (from KAPSIS_DNS_ALLOWLIST)
 #   $2 - Resolution timeout in seconds (default: 5)
 #   $3 - Fallback behavior: "dynamic" (default) or "abort"
+#   $4 - Max failure rate 0.0–1.0 before aborting launch (default: "1.0" = disabled)
+#   $5 - Max absolute failure count before aborting launch (default: "-1" = disabled)
 #
 # Output:
 #   domain IP1 IP2 ...
 #   (one line per domain with resolved IPs, space-separated)
 #
-# Returns: 0 on success (even partial), 1 on complete failure with abort mode
+# Returns: 0 on success (even partial), 1 on failure (abort mode or threshold exceeded)
+#
+# Set KAPSIS_SKIP_DNS_CHECK=true to bypass threshold checks (useful for --force launches).
 resolve_allowlist_domains() {
     local domain_list="$1"
     local timeout="${2:-5}"
     local fallback="${3:-dynamic}"
+    local max_failure_rate="${4:-1.0}"
+    local max_failures="${5:--1}"
 
     [[ -z "$domain_list" ]] && return 0
 
@@ -74,7 +80,7 @@ resolve_allowlist_domains() {
     local failed_count=0
     local wildcard_count=0
 
-    log_debug "Resolving domains with timeout=${timeout}s, fallback=${fallback}"
+    log_debug "Resolving domains with timeout=${timeout}s, fallback=${fallback}, max_failure_rate=${max_failure_rate}, max_failures=${max_failures}"
 
     # Split by comma and process each domain
     IFS=',' read -ra domains <<< "$domain_list"
@@ -116,12 +122,39 @@ resolve_allowlist_domains() {
         fi
     done
 
+    local total_count=$(( resolved_count + failed_count ))
     log_info "DNS pinning: resolved $resolved_count domains, $failed_count failed, $wildcard_count wildcards skipped"
 
-    # Handle failures based on fallback mode
+    # Gate 1: fallback=abort — any failure is fatal
     if [[ "$failed_count" -gt 0 ]] && [[ "$fallback" == "abort" ]]; then
         log_error "DNS resolution failed with fallback=abort"
         return 1
+    fi
+
+    # Gate 2: threshold check — independent of fallback, bypassable via KAPSIS_SKIP_DNS_CHECK
+    if [[ "${KAPSIS_SKIP_DNS_CHECK:-false}" != "true" ]] && [[ "$failed_count" -gt 0 ]] && [[ "$total_count" -gt 0 ]]; then
+        # Absolute failure count threshold
+        if [[ "$max_failures" -ge 0 ]] && [[ "$failed_count" -gt "$max_failures" ]]; then
+            log_error "DNS failure threshold exceeded: $failed_count failed domains (limit: $max_failures)"
+            log_error "  Resolved $resolved_count/$total_count domains. Check VPN/network and retry."
+            log_error "  Override with: KAPSIS_SKIP_DNS_CHECK=true"
+            return 1
+        fi
+
+        # Failure rate threshold — use awk for float comparison (bash has no float arithmetic)
+        if awk -v rate="$max_failure_rate" 'BEGIN { exit (rate >= 1.0) }'; then
+            local rate_exceeded
+            rate_exceeded=$(awk -v failed="$failed_count" -v total="$total_count" -v limit="$max_failure_rate" \
+                'BEGIN { print (failed / total > limit) ? "yes" : "no" }')
+            if [[ "$rate_exceeded" == "yes" ]]; then
+                local pct
+                pct=$(awk -v f="$failed_count" -v t="$total_count" 'BEGIN { printf "%.0f", f/t*100 }')
+                log_error "DNS failure rate exceeded: $failed_count/$total_count domains failed (${pct}%, limit: $(awk -v r="$max_failure_rate" 'BEGIN { printf "%.0f", r*100 }')%)"
+                log_error "  Check VPN/network and retry."
+                log_error "  Override with: KAPSIS_SKIP_DNS_CHECK=true"
+                return 1
+            fi
+        fi
     fi
 
     return 0

--- a/tests/test-dns-pinning.sh
+++ b/tests/test-dns-pinning.sh
@@ -803,6 +803,247 @@ EOF
 }
 
 #===============================================================================
+# FAILURE THRESHOLD TESTS (Issue #216)
+#===============================================================================
+
+# Simulate resolve_allowlist_domains with a stubbed resolve_domain_ips so we can
+# control which domains "fail" without real network calls.
+
+_stub_resolve_domain_ips() {
+    local domain="$1"
+    # Domains starting with "fail" return empty (resolution failure)
+    if [[ "$domain" == fail* ]]; then
+        return 0  # empty output = failure
+    fi
+    echo "1.2.3.4"
+}
+
+test_threshold_rate_below_limit_succeeds() {
+    log_test "Testing resolve_allowlist_domains succeeds when failure rate is below limit"
+
+    source "$DNS_PIN_LIB"
+    # Override resolve_domain_ips for this test
+    resolve_domain_ips() { _stub_resolve_domain_ips "$1"; }
+
+    # 1 failure out of 4 = 25%, limit is 50% → should succeed
+    local output exit_code
+    output=$(resolve_allowlist_domains "ok1.com,ok2.com,ok3.com,fail1.com" 1 "dynamic" "0.5" "-1" 2>&1)
+    exit_code=$?
+
+    if [[ "$exit_code" -eq 0 ]]; then
+        log_pass "Below-threshold failure rate correctly allows launch"
+    else
+        log_fail "Expected exit 0 for below-threshold failure rate, got: $exit_code"
+        return 1
+    fi
+
+    unset -f resolve_domain_ips
+}
+
+test_threshold_rate_exceeded_aborts() {
+    log_test "Testing resolve_allowlist_domains aborts when failure rate exceeds limit"
+
+    source "$DNS_PIN_LIB"
+    resolve_domain_ips() { _stub_resolve_domain_ips "$1"; }
+
+    # 3 failures out of 4 = 75%, limit is 50% → should fail
+    local output exit_code
+    output=$(resolve_allowlist_domains "ok1.com,fail1.com,fail2.com,fail3.com" 1 "dynamic" "0.5" "-1" 2>&1)
+    exit_code=$?
+
+    if [[ "$exit_code" -ne 0 ]]; then
+        log_pass "Exceeded failure rate correctly aborts launch"
+    else
+        log_fail "Expected non-zero exit for exceeded failure rate, got: $exit_code"
+        unset -f resolve_domain_ips
+        return 1
+    fi
+
+    if echo "$output" | grep -q "failure rate exceeded"; then
+        log_pass "Abort message mentions failure rate"
+    else
+        log_fail "Expected 'failure rate exceeded' in output, got: $output"
+        unset -f resolve_domain_ips
+        return 1
+    fi
+
+    unset -f resolve_domain_ips
+}
+
+test_threshold_max_failures_count_exceeded_aborts() {
+    log_test "Testing resolve_allowlist_domains aborts when absolute failure count exceeds max_failures"
+
+    source "$DNS_PIN_LIB"
+    resolve_domain_ips() { _stub_resolve_domain_ips "$1"; }
+
+    # 2 failures, limit is 1 → should fail
+    local output exit_code
+    output=$(resolve_allowlist_domains "ok1.com,fail1.com,fail2.com" 1 "dynamic" "1.0" "1" 2>&1)
+    exit_code=$?
+
+    if [[ "$exit_code" -ne 0 ]]; then
+        log_pass "Exceeded absolute failure count correctly aborts launch"
+    else
+        log_fail "Expected non-zero exit for exceeded max_failures, got: $exit_code"
+        unset -f resolve_domain_ips
+        return 1
+    fi
+
+    if echo "$output" | grep -q "failure threshold exceeded"; then
+        log_pass "Abort message mentions failure threshold"
+    else
+        log_fail "Expected 'failure threshold exceeded' in output, got: $output"
+        unset -f resolve_domain_ips
+        return 1
+    fi
+
+    unset -f resolve_domain_ips
+}
+
+test_threshold_max_failures_disabled_allows_launch() {
+    log_test "Testing max_failures=-1 disables absolute count check"
+
+    source "$DNS_PIN_LIB"
+    resolve_domain_ips() { _stub_resolve_domain_ips "$1"; }
+
+    # 3 failures, max_failures=-1 (disabled), rate limit=1.0 → should succeed
+    local exit_code
+    resolve_allowlist_domains "ok1.com,fail1.com,fail2.com,fail3.com" 1 "dynamic" "1.0" "-1" >/dev/null 2>&1
+    exit_code=$?
+
+    if [[ "$exit_code" -eq 0 ]]; then
+        log_pass "max_failures=-1 correctly disables absolute count check"
+    else
+        log_fail "Expected exit 0 when max_failures=-1, got: $exit_code"
+        unset -f resolve_domain_ips
+        return 1
+    fi
+
+    unset -f resolve_domain_ips
+}
+
+test_threshold_skip_dns_check_bypass() {
+    log_test "Testing KAPSIS_SKIP_DNS_CHECK=true bypasses threshold abort"
+
+    source "$DNS_PIN_LIB"
+    resolve_domain_ips() { _stub_resolve_domain_ips "$1"; }
+
+    # 3 failures out of 4 = 75%, limit is 50% → would abort, but bypass is set
+    local exit_code
+    KAPSIS_SKIP_DNS_CHECK=true \
+        resolve_allowlist_domains "ok1.com,fail1.com,fail2.com,fail3.com" 1 "dynamic" "0.5" "-1" >/dev/null 2>&1
+    exit_code=$?
+
+    if [[ "$exit_code" -eq 0 ]]; then
+        log_pass "KAPSIS_SKIP_DNS_CHECK=true correctly bypasses threshold"
+    else
+        log_fail "Expected exit 0 with KAPSIS_SKIP_DNS_CHECK=true, got: $exit_code"
+        unset -f resolve_domain_ips
+        return 1
+    fi
+
+    unset -f resolve_domain_ips
+}
+
+test_threshold_rate_at_boundary_succeeds() {
+    log_test "Testing failure rate exactly at limit does not abort (limit is exclusive)"
+
+    source "$DNS_PIN_LIB"
+    resolve_domain_ips() { _stub_resolve_domain_ips "$1"; }
+
+    # 1 failure out of 2 = 50%, limit is 50% → 50% is NOT greater than 50%, should succeed
+    local exit_code
+    resolve_allowlist_domains "ok1.com,fail1.com" 1 "dynamic" "0.5" "-1" >/dev/null 2>&1
+    exit_code=$?
+
+    if [[ "$exit_code" -eq 0 ]]; then
+        log_pass "Failure rate exactly at limit correctly allows launch (boundary is exclusive)"
+    else
+        log_fail "Expected exit 0 at exact boundary, got: $exit_code"
+        unset -f resolve_domain_ips
+        return 1
+    fi
+
+    unset -f resolve_domain_ips
+}
+
+test_config_validation_max_failure_rate_valid() {
+    log_test "Testing config validation accepts valid max_failure_rate values"
+
+    if ! command -v yq &>/dev/null; then
+        log_skip "yq not installed"
+        return 0
+    fi
+
+    local test_config
+    test_config=$(mktemp).yaml
+
+    cat > "$test_config" << 'EOF'
+network:
+  mode: filtered
+  dns_pinning:
+    enabled: true
+    fallback: dynamic
+    max_failure_rate: 0.5
+    max_failures: 10
+EOF
+
+    local output
+    output=$("$CONFIG_VERIFIER" "$test_config" 2>&1) || true
+
+    if echo "$output" | grep -q "\[FAIL\].*max_failure_rate"; then
+        log_fail "Valid max_failure_rate 0.5 should not fail validation"
+        rm -f "$test_config"
+        return 1
+    fi
+    log_pass "Valid max_failure_rate and max_failures accepted"
+
+    rm -f "$test_config"
+}
+
+test_config_validation_max_failure_rate_invalid() {
+    log_test "Testing config validation rejects out-of-range max_failure_rate"
+
+    if ! command -v yq &>/dev/null; then
+        log_skip "yq not installed"
+        return 0
+    fi
+
+    local test_config
+    test_config=$(mktemp).yaml
+
+    cat > "$test_config" << 'EOF'
+network:
+  mode: filtered
+  dns_pinning:
+    enabled: true
+    max_failure_rate: 1.5
+    max_failures: -5
+EOF
+
+    local output
+    output=$("$CONFIG_VERIFIER" "$test_config" 2>&1) || true
+
+    if echo "$output" | grep -q "Invalid dns_pinning.max_failure_rate"; then
+        log_pass "Out-of-range max_failure_rate correctly rejected"
+    else
+        log_fail "Expected validation error for max_failure_rate: 1.5"
+        rm -f "$test_config"
+        return 1
+    fi
+
+    if echo "$output" | grep -q "Invalid dns_pinning.max_failures"; then
+        log_pass "Invalid max_failures (-5) correctly rejected"
+    else
+        log_fail "Expected validation error for max_failures: -5"
+        rm -f "$test_config"
+        return 1
+    fi
+
+    rm -f "$test_config"
+}
+
+#===============================================================================
 # RUN TESTS
 #===============================================================================
 
@@ -835,6 +1076,16 @@ main() {
     run_test test_resolve_returns_valid_ipv4_or_empty
     run_test test_add_host_args_format
     run_test test_pinned_file_parsing_robust
+
+    # Failure threshold tests (Issue #216)
+    run_test test_threshold_rate_below_limit_succeeds
+    run_test test_threshold_rate_exceeded_aborts
+    run_test test_threshold_max_failures_count_exceeded_aborts
+    run_test test_threshold_max_failures_disabled_allows_launch
+    run_test test_threshold_skip_dns_check_bypass
+    run_test test_threshold_rate_at_boundary_succeeds
+    run_test test_config_validation_max_failure_rate_valid
+    run_test test_config_validation_max_failure_rate_invalid
 
     # Container tests
     run_test test_pinned_file_mounted_readonly


### PR DESCRIPTION
## Summary

- Adds `max_failure_rate` and `max_failures` thresholds to DNS pinning — launch aborts with a clear actionable error when host DNS/VPN is too broken to resolve enough domains, preventing wasted agent runs (the issue's motivating example: 50-min Opus task wasted when 33/52 domains failed to resolve)
- Gate is independent of the existing `fallback=abort` mode and bypassable via `KAPSIS_SKIP_DNS_CHECK=true`
- Config verifier now correctly dispatches standalone network configs to `validate_network_config`

## Changed files

| File | Change |
|------|--------|
| `scripts/lib/dns-pin.sh` | `resolve_allowlist_domains` gains `max_failure_rate` and `max_failures` optional params; threshold check with `awk` float comparison; `KAPSIS_SKIP_DNS_CHECK` bypass |
| `scripts/launch-agent.sh` | Parse `network.dns_pinning.max_failure_rate` / `max_failures` from config; pass to resolver |
| `scripts/lib/config-verifier.sh` | Validate new fields; fix standalone routing to call `validate_network_config` for network-type configs |
| `configs/network-allowlist.yaml` | Document new fields; default `max_failure_rate: 0.5`, `max_failures: -1` |
| `tests/test-dns-pinning.sh` | 8 new quick tests: below-threshold, above-threshold, boundary (exclusive), absolute count, disabled checks, and `KAPSIS_SKIP_DNS_CHECK` bypass |

## Test plan

- [x] `KAPSIS_QUICK_TESTS=1 bash tests/test-dns-pinning.sh` — 35/35 pass
- [x] `bash -n` syntax checks on all modified scripts
- [x] Config verifier correctly rejects `max_failure_rate: 1.5` and `max_failures: -5`
- [x] Config verifier correctly accepts `max_failure_rate: 0.5` and `max_failures: 10`

## Design notes (ensemble brainstorm)

**Threshold gate is independent of `fallback` mode.** `fallback=abort` aborts on any failure; the new threshold only aborts when the failure fraction or count crosses a configurable limit. Both gates can be active simultaneously. This means `fallback=dynamic` (the default) now has a safety net without forcing users into all-or-nothing abort behaviour.

**Float comparison via `awk`.** Bash has no float arithmetic; `bc` is not universally available. `awk` is POSIX and present in both macOS and Linux container images.

**Rate boundary is exclusive** (`failed/total > limit`, not `>=`). Exactly 50% failures with a 0.5 limit still allows launch — only strictly above the threshold aborts.

https://claude.ai/code/session_01R4DFBeqkDsp1HWpkQheTto

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4DFBeqkDsp1HWpkQheTto)_