### PR TITLE
feat(dns): abort launch when DNS failure threshold exceeded (Issue #216)

### DIFF
--- a/configs/network-allowlist.yaml
+++ b/configs/network-allowlist.yaml
@@ -169,6 +169,22 @@ network:
     # Sets chmod 444 after DNS setup (agent runs as non-root, cannot override)
     protect_dns_files: true
 
+    # Abort launch when DNS failure rate exceeds a threshold (Issue #216).
+    # Prevents wasting agent runtime when host DNS/VPN is broken.
+    # Both thresholds are DISABLED by default (opt-in). Either one firing triggers abort.
+    # Override at runtime with: KAPSIS_DNS_THRESHOLD_SKIP=true
+    #
+    # max_failure_rate: abort if fraction of concrete domains failing exceeds this.
+    #   Wildcards are excluded from the denominator.
+    #   Tune conservatively — many build profiles only use a subset of the allowlist.
+    #   Example: 0.8 aborts if >80% of resolvable domains fail.
+    #   max_failure_rate: 0.8
+    #
+    # max_failures: abort if the absolute count of failed domains exceeds this.
+    #   Useful for small allowlists where a rate threshold is less meaningful.
+    #   Example: 10 aborts if more than 10 domains fail to resolve.
+    #   max_failures: 10
+
   # Allowed ports (documented for reference)
   # Note: Port filtering is NOT enforced - only DNS filtering
   # These are the typical ports that allowed services use

--- a/scripts/launch-agent.sh
+++ b/scripts/launch-agent.sh
@@ -893,6 +893,9 @@ parse_config() {
         NETWORK_DNS_PIN_FALLBACK=$(yq eval '.network.dns_pinning.fallback // "dynamic"' "$CONFIG_FILE" 2>/dev/null || echo "dynamic")
         NETWORK_DNS_PIN_TIMEOUT=$(yq eval '.network.dns_pinning.resolve_timeout // "5"' "$CONFIG_FILE" 2>/dev/null || echo "5")
         NETWORK_DNS_PIN_PROTECT=$(yq eval '.network.dns_pinning.protect_dns_files // "true"' "$CONFIG_FILE" 2>/dev/null || echo "true")
+        # Failure threshold — disabled by default (empty = opt-in only)
+        NETWORK_DNS_PIN_MAX_FAILURE_RATE=$(yq eval '.network.dns_pinning.max_failure_rate // ""' "$CONFIG_FILE" 2>/dev/null || echo "")
+        NETWORK_DNS_PIN_MAX_FAILURES=$(yq eval '.network.dns_pinning.max_failures // ""' "$CONFIG_FILE" 2>/dev/null || echo "")
 
         # Parse cleanup configuration (Fix #183)
         # Env vars take precedence over YAML via ${VAR:-$(yq ...)} pattern
@@ -2210,8 +2213,33 @@ build_container_command() {
             # This prevents DNS manipulation attacks inside the container
             if [[ "${NETWORK_DNS_PIN_ENABLED:-true}" == "true" ]] && [[ -n "${NETWORK_ALLOWLIST_DOMAINS:-}" ]]; then
                 log_info "DNS pinning: resolving allowlist domains on host..."
+                # Redirect stdout to a temp file so resolve_allowlist_domains() runs in
+                # the current shell (not a subshell), allowing _DNS_RESOLVED_COUNT /
+                # _DNS_FAILED_COUNT globals to survive for the threshold check below.
+                local _dns_resolve_tmp
+                _dns_resolve_tmp=$(mktemp)
+                local _dns_pin_rc=0
+                resolve_allowlist_domains "$NETWORK_ALLOWLIST_DOMAINS" "${NETWORK_DNS_PIN_TIMEOUT:-5}" "${NETWORK_DNS_PIN_FALLBACK:-dynamic}" \
+                    > "$_dns_resolve_tmp" || _dns_pin_rc=$?
+
                 local resolved_data
-                if resolved_data=$(resolve_allowlist_domains "$NETWORK_ALLOWLIST_DOMAINS" "${NETWORK_DNS_PIN_TIMEOUT:-5}" "${NETWORK_DNS_PIN_FALLBACK:-dynamic}"); then
+                resolved_data=$(cat "$_dns_resolve_tmp")
+                rm -f "$_dns_resolve_tmp"
+
+                if [[ "$_dns_pin_rc" -eq 0 ]]; then
+                    # Check failure threshold (Issue #216) — skip if KAPSIS_DNS_THRESHOLD_SKIP is set
+                    if [[ "${KAPSIS_DNS_THRESHOLD_SKIP:-false}" != "true" ]]; then
+                        if ! check_dns_failure_threshold \
+                                "${NETWORK_DNS_PIN_MAX_FAILURE_RATE:-}" \
+                                "${NETWORK_DNS_PIN_MAX_FAILURES:-}"; then
+                            log_error "DNS failure threshold exceeded — set KAPSIS_DNS_THRESHOLD_SKIP=true to override"
+                            log_error "Check VPN/network connectivity and retry, or lower max_failure_rate/max_failures in config"
+                            exit 1
+                        fi
+                    else
+                        log_warn "DNS failure threshold check skipped (KAPSIS_DNS_THRESHOLD_SKIP=true)"
+                    fi
+
                     if [[ -n "$resolved_data" ]]; then
                         # Create temp file for pinned DNS (cleaned up in _cleanup_with_completion)
                         DNS_PIN_FILE=$(mktemp)

--- a/scripts/lib/config-verifier.sh
+++ b/scripts/lib/config-verifier.sh
@@ -532,6 +532,32 @@ validate_network_config() {
         fi
     fi
 
+    local dns_pin_max_rate
+    dns_pin_max_rate=$(yq -r '.network.dns_pinning.max_failure_rate // "null"' "$config_file" 2>/dev/null)
+    if [[ "$dns_pin_max_rate" != "null" ]]; then
+        if echo "$dns_pin_max_rate" | grep -qE '^(0(\.[0-9]+)?|1(\.0+)?)$'; then
+            local rate_ok
+            rate_ok=$(awk -v r="$dns_pin_max_rate" 'BEGIN { print (r >= 0 && r <= 1) ? "ok" : "bad" }')
+            if [[ "$rate_ok" == "ok" ]]; then
+                log_pass "Valid dns_pinning.max_failure_rate: $dns_pin_max_rate"
+            else
+                log_error "Invalid dns_pinning.max_failure_rate: $dns_pin_max_rate (must be 0.0-1.0)"
+            fi
+        else
+            log_error "Invalid dns_pinning.max_failure_rate: $dns_pin_max_rate (must be a float 0.0-1.0)"
+        fi
+    fi
+
+    local dns_pin_max_failures
+    dns_pin_max_failures=$(yq -r '.network.dns_pinning.max_failures // "null"' "$config_file" 2>/dev/null)
+    if [[ "$dns_pin_max_failures" != "null" ]]; then
+        if [[ "$dns_pin_max_failures" =~ ^[0-9]+$ ]] && [[ "$dns_pin_max_failures" -ge 0 ]]; then
+            log_pass "Valid dns_pinning.max_failures: $dns_pin_max_failures"
+        else
+            log_error "Invalid dns_pinning.max_failures: $dns_pin_max_failures (must be a non-negative integer)"
+        fi
+    fi
+
     return 0
 }
 

--- a/scripts/lib/dns-pin.sh
+++ b/scripts/lib/dns-pin.sh
@@ -48,10 +48,19 @@ type log_success &>/dev/null || log_success() { echo "[DNS-PIN] SUCCESS: $*" >&2
 # DOMAIN RESOLUTION
 #===============================================================================
 
+# Global counters set by resolve_allowlist_domains() after each call.
+# Callers can read these immediately after the function returns.
+_DNS_RESOLVED_COUNT=0
+_DNS_FAILED_COUNT=0
+_DNS_WILDCARD_COUNT=0
+
 # resolve_allowlist_domains <comma-domains> [timeout] [fallback]
 #
 # Resolves comma-separated domains to IP addresses on the host.
 # Skips wildcards (emitting security warning) and returns pinned mappings.
+#
+# After returning, the global vars _DNS_RESOLVED_COUNT, _DNS_FAILED_COUNT,
+# and _DNS_WILDCARD_COUNT hold the final counts for the caller to inspect.
 #
 # Arguments:
 #   $1 - Comma-separated list of domains (from KAPSIS_DNS_ALLOWLIST)
@@ -118,12 +127,83 @@ resolve_allowlist_domains() {
 
     log_info "DNS pinning: resolved $resolved_count domains, $failed_count failed, $wildcard_count wildcards skipped"
 
+    # Expose counts to the caller via globals (subshell-safe via process substitution
+    # callers should NOT use $() to call this function if they need the globals).
+    _DNS_RESOLVED_COUNT=$resolved_count
+    _DNS_FAILED_COUNT=$failed_count
+    _DNS_WILDCARD_COUNT=$wildcard_count
+
     # Handle failures based on fallback mode
     if [[ "$failed_count" -gt 0 ]] && [[ "$fallback" == "abort" ]]; then
         log_error "DNS resolution failed with fallback=abort"
         return 1
     fi
 
+    return 0
+}
+
+#===============================================================================
+# FAILURE THRESHOLD CHECK
+#===============================================================================
+
+# check_dns_failure_threshold [max_failure_rate] [max_failures]
+#
+# Evaluates the DNS resolution result (from _DNS_RESOLVED_COUNT / _DNS_FAILED_COUNT
+# set by resolve_allowlist_domains) against configurable thresholds.
+#
+# Wildcards are excluded from the denominator — they are never resolved.
+# Denominator is (resolved + failed), i.e., pingable concrete domains only.
+#
+# Either threshold triggers abort (OR semantics). Both are optional; pass ""
+# to disable a threshold.
+#
+# Arguments:
+#   $1 - max_failure_rate: float 0.0-1.0 (abort if rate > this). "" = disabled.
+#   $2 - max_failures: int >= 0 (abort if count > this). "" = disabled.
+#
+# Returns:
+#   0 - thresholds not exceeded (or both disabled, or no pingable domains)
+#   1 - threshold exceeded; caller should abort
+check_dns_failure_threshold() {
+    local max_failure_rate="${1:-}"
+    local max_failures="${2:-}"
+
+    # Both disabled — nothing to check
+    if [[ -z "$max_failure_rate" && -z "$max_failures" ]]; then
+        return 0
+    fi
+
+    local resolved="${_DNS_RESOLVED_COUNT:-0}"
+    local failed="${_DNS_FAILED_COUNT:-0}"
+    local total=$(( resolved + failed ))
+
+    # No concrete (pingable) domains — nothing meaningful to measure
+    if [[ "$total" -eq 0 ]]; then
+        log_debug "DNS threshold: no concrete domains to evaluate (all wildcards or empty)"
+        return 0
+    fi
+
+    # Check absolute count threshold
+    if [[ -n "$max_failures" ]] && [[ "$failed" -gt "$max_failures" ]]; then
+        log_error "DNS threshold exceeded: $failed failed domains > max_failures=$max_failures (resolved $resolved/$total)"
+        return 1
+    fi
+
+    # Check rate threshold using awk for float arithmetic
+    if [[ -n "$max_failure_rate" ]]; then
+        local rate_exceeded
+        rate_exceeded=$(awk -v failed="$failed" -v total="$total" -v limit="$max_failure_rate" \
+            'BEGIN { rate = failed / total; print (rate >= limit) ? "1" : "0" }')
+        if [[ "$rate_exceeded" == "1" ]]; then
+            local pct
+            pct=$(awk -v failed="$failed" -v total="$total" \
+                'BEGIN { printf "%.0f", (failed / total) * 100 }')
+            log_error "DNS threshold exceeded: ${pct}% of domains failed (${failed}/${total}) > max_failure_rate=${max_failure_rate}"
+            return 1
+        fi
+    fi
+
+    log_debug "DNS threshold check passed: ${failed}/${total} failed"
     return 0
 }
 

--- a/tests/test-dns-pinning.sh
+++ b/tests/test-dns-pinning.sh
@@ -627,6 +627,227 @@ EOF
 }
 
 #===============================================================================
+# FAILURE THRESHOLD TESTS (Issue #216, no container required)
+#===============================================================================
+
+# Helper: stub resolve_domain_ips to return fixed results based on domain name.
+# Domains starting with "fail-" return empty; all others return a fake IP.
+_stub_resolve_domain_ips() {
+    local domain="$1"
+    if [[ "$domain" == fail-* ]]; then
+        echo ""
+    else
+        echo "1.2.3.4"
+    fi
+}
+
+test_threshold_disabled_by_default() {
+    log_test "Testing check_dns_failure_threshold with both thresholds disabled returns 0"
+
+    source "$DNS_PIN_LIB"
+
+    _DNS_RESOLVED_COUNT=2
+    _DNS_FAILED_COUNT=33
+
+    assert_command_succeeds "check_dns_failure_threshold '' ''" \
+        "Disabled thresholds should never abort"
+}
+
+test_threshold_max_failures_below_limit() {
+    log_test "Testing max_failures: failures below limit returns 0"
+
+    source "$DNS_PIN_LIB"
+
+    _DNS_RESOLVED_COUNT=19
+    _DNS_FAILED_COUNT=5
+
+    assert_command_succeeds "check_dns_failure_threshold '' '10'" \
+        "5 failures < max_failures=10 should pass"
+}
+
+test_threshold_max_failures_exceeded() {
+    log_test "Testing max_failures: failures exceed limit returns 1"
+
+    source "$DNS_PIN_LIB"
+
+    _DNS_RESOLVED_COUNT=19
+    _DNS_FAILED_COUNT=33
+
+    assert_command_fails "check_dns_failure_threshold '' '10'" \
+        "33 failures > max_failures=10 should abort"
+}
+
+test_threshold_max_failure_rate_below_limit() {
+    log_test "Testing max_failure_rate: rate below limit returns 0"
+
+    source "$DNS_PIN_LIB"
+
+    _DNS_RESOLVED_COUNT=19
+    _DNS_FAILED_COUNT=3
+
+    # 3/22 ≈ 13.6% < 80%
+    assert_command_succeeds "check_dns_failure_threshold '0.8' ''" \
+        "13.6% failure rate < 0.8 should pass"
+}
+
+test_threshold_max_failure_rate_exceeded() {
+    log_test "Testing max_failure_rate: rate exceeds limit returns 1"
+
+    source "$DNS_PIN_LIB"
+
+    _DNS_RESOLVED_COUNT=19
+    _DNS_FAILED_COUNT=33
+
+    # 33/52 ≈ 63.5% > 50%
+    assert_command_fails "check_dns_failure_threshold '0.5' ''" \
+        "63.5% failure rate > 0.5 should abort"
+}
+
+test_threshold_or_semantics_rate_triggers() {
+    log_test "Testing OR semantics: rate threshold triggers even when count is under limit"
+
+    source "$DNS_PIN_LIB"
+
+    _DNS_RESOLVED_COUNT=1
+    _DNS_FAILED_COUNT=9
+
+    # 9/10 = 90% > 0.5; but 9 < max_failures=20 — rate alone should trigger
+    assert_command_fails "check_dns_failure_threshold '0.5' '20'" \
+        "Rate threshold should trigger abort regardless of count threshold"
+}
+
+test_threshold_or_semantics_count_triggers() {
+    log_test "Testing OR semantics: count threshold triggers even when rate is under limit"
+
+    source "$DNS_PIN_LIB"
+
+    _DNS_RESOLVED_COUNT=90
+    _DNS_FAILED_COUNT=11
+
+    # 11/101 ≈ 10.9% < 80%; but 11 > max_failures=10 — count alone should trigger
+    assert_command_fails "check_dns_failure_threshold '0.8' '10'" \
+        "Count threshold should trigger abort regardless of rate threshold"
+}
+
+test_threshold_zero_concrete_domains() {
+    log_test "Testing threshold with zero concrete domains (all wildcards) returns 0"
+
+    source "$DNS_PIN_LIB"
+
+    _DNS_RESOLVED_COUNT=0
+    _DNS_FAILED_COUNT=0
+
+    # 0 concrete domains — divide-by-zero guard, should never abort
+    assert_command_succeeds "check_dns_failure_threshold '0.5' '0'" \
+        "Zero concrete domains should never trigger threshold abort"
+}
+
+test_threshold_all_fail_rate_1() {
+    log_test "Testing max_failure_rate=1.0 only aborts when 100% fail"
+
+    source "$DNS_PIN_LIB"
+
+    # 50% failure — should NOT abort at rate=1.0
+    _DNS_RESOLVED_COUNT=5
+    _DNS_FAILED_COUNT=5
+    assert_command_succeeds "check_dns_failure_threshold '1.0' ''" \
+        "50% failure < max_failure_rate=1.0 should pass"
+
+    # 100% failure — should abort
+    _DNS_RESOLVED_COUNT=0
+    _DNS_FAILED_COUNT=5
+    assert_command_fails "check_dns_failure_threshold '1.0' ''" \
+        "100% failure rate should abort at max_failure_rate=1.0"
+}
+
+test_threshold_globals_set_by_resolve() {
+    log_test "Testing _DNS_RESOLVED/FAILED_COUNT globals set by resolve_allowlist_domains"
+
+    # Stub resolve_domain_ips so test is network-independent
+    source "$DNS_PIN_LIB"
+    resolve_domain_ips() { _stub_resolve_domain_ips "$1"; }
+
+    _DNS_RESOLVED_COUNT=0
+    _DNS_FAILED_COUNT=0
+
+    # 2 resolvable + 2 failing + 1 wildcard
+    local tmp
+    tmp=$(mktemp)
+    resolve_allowlist_domains "github.com,gitlab.com,fail-one.invalid,fail-two.invalid,*.wildcard.com" 1 "dynamic" \
+        > "$tmp"
+    rm -f "$tmp"
+
+    if [[ "$_DNS_RESOLVED_COUNT" -eq 2 && "$_DNS_FAILED_COUNT" -eq 2 && "$_DNS_WILDCARD_COUNT" -eq 1 ]]; then
+        log_pass "Globals: resolved=$_DNS_RESOLVED_COUNT failed=$_DNS_FAILED_COUNT wildcards=$_DNS_WILDCARD_COUNT"
+    else
+        log_fail "Expected resolved=2 failed=2 wildcards=1, got resolved=$_DNS_RESOLVED_COUNT failed=$_DNS_FAILED_COUNT wildcards=$_DNS_WILDCARD_COUNT"
+        return 1
+    fi
+}
+
+test_config_validation_max_failure_rate_valid() {
+    log_test "Testing config validation accepts valid max_failure_rate"
+
+    if ! command -v yq &>/dev/null; then
+        log_skip "yq not installed"
+        return 0
+    fi
+
+    local test_config
+    test_config=$(mktemp).yaml
+    cat > "$test_config" << 'EOF'
+network:
+  mode: filtered
+  dns_pinning:
+    enabled: true
+    max_failure_rate: 0.8
+    max_failures: 10
+EOF
+
+    local output
+    output=$("$CONFIG_VERIFIER" "$test_config" 2>&1) || true
+
+    if echo "$output" | grep -q "\[FAIL\].*max_failure_rate\|\[FAIL\].*max_failures"; then
+        log_fail "Valid max_failure_rate/max_failures rejected by verifier"
+        rm -f "$test_config"
+        return 1
+    fi
+    log_pass "Valid max_failure_rate and max_failures accepted"
+    rm -f "$test_config"
+}
+
+test_config_validation_max_failure_rate_invalid() {
+    log_test "Testing config validation rejects invalid max_failure_rate"
+
+    if ! command -v yq &>/dev/null; then
+        log_skip "yq not installed"
+        return 0
+    fi
+
+    local test_config
+    test_config=$(mktemp).yaml
+    cat > "$test_config" << 'EOF'
+network:
+  mode: filtered
+  dns_pinning:
+    enabled: true
+    max_failure_rate: 1.5
+    max_failures: -3
+EOF
+
+    local output
+    output=$("$CONFIG_VERIFIER" "$test_config" 2>&1) || true
+
+    if echo "$output" | grep -q "\[FAIL\].*max_failure_rate"; then
+        log_pass "Invalid max_failure_rate (1.5) correctly rejected"
+    else
+        log_warn "Expected validation error for max_failure_rate=1.5"
+    fi
+
+    rm -f "$test_config"
+}
+
+#===============================================================================
 # CONTAINER TESTS (require Podman)
 #===============================================================================
 
@@ -835,6 +1056,20 @@ main() {
     run_test test_resolve_returns_valid_ipv4_or_empty
     run_test test_add_host_args_format
     run_test test_pinned_file_parsing_robust
+
+    # Failure threshold tests (Issue #216)
+    run_test test_threshold_disabled_by_default
+    run_test test_threshold_max_failures_below_limit
+    run_test test_threshold_max_failures_exceeded
+    run_test test_threshold_max_failure_rate_below_limit
+    run_test test_threshold_max_failure_rate_exceeded
+    run_test test_threshold_or_semantics_rate_triggers
+    run_test test_threshold_or_semantics_count_triggers
+    run_test test_threshold_zero_concrete_domains
+    run_test test_threshold_all_fail_rate_1
+    run_test test_threshold_globals_set_by_resolve
+    run_test test_config_validation_max_failure_rate_valid
+    run_test test_config_validation_max_failure_rate_invalid
 
     # Container tests
     run_test test_pinned_file_mounted_readonly


### PR DESCRIPTION
## Summary

Fixes #216. Adds configurable DNS failure rate and count thresholds that abort container launch when too many allowlist domains fail to resolve — preventing wasted 50-minute agent runs when the host DNS/VPN is broken.

### Problem

When host DNS is flaky (VPN reconnecting, corporate DNS down), Kapsis resolved what it could and launched the container anyway with degraded DNS. The agent then spent tens of minutes before hitting network errors.

Example from the issue: 33/52 domains failed (63%) — container launched, agent reported "cannot reach internal infrastructure."

### Design decisions (from ensemble brainstorm)

- **Both thresholds disabled by default** (opt-in) — avoids false positives in environments where only a subset of the allowlist is reachable (e.g., Java-only agents that can't reach PyPI/npm domains)
- **OR semantics** — either `max_failure_rate` OR `max_failures` firing alone is sufficient to abort
- **Wildcards excluded from denominator** — they are never resolved; denominator = `resolved + failed` (concrete domains only)
- **`KAPSIS_DNS_THRESHOLD_SKIP=true`** — narrow override that skips only the abort decision while still running resolution and pinning; more targeted than a broad DNS-disable flag
- **`>=` semantics** for rate — `max_failure_rate: 1.0` aborts on 100% failure; `max_failure_rate: 0.5` aborts at or above 50%

### Changes

| File | Change |
|------|--------|
| `scripts/lib/dns-pin.sh` | Expose `_DNS_RESOLVED_COUNT` / `_DNS_FAILED_COUNT` / `_DNS_WILDCARD_COUNT` globals after each call; new `check_dns_failure_threshold()` function |
| `scripts/launch-agent.sh` | Parse `max_failure_rate` / `max_failures` config; redirect resolution output to temp file (so globals survive outside subshell); call threshold check before container launch |
| `scripts/lib/config-verifier.sh` | Validate both new fields (float 0.0–1.0, non-negative int) |
| `configs/network-allowlist.yaml` | Document new options (commented-out examples) |
| `tests/test-dns-pinning.sh` | 12 new unit tests covering happy path, OR semantics, edge cases (empty list, all-wildcards, boundary at 1.0) |

### Config example

```yaml
network:
  dns_pinning:
    # Abort if ≥80% of resolvable domains fail (tune conservatively per environment)
    max_failure_rate: 0.8
    # OR abort if more than 10 absolute domains fail
    max_failures: 10
```

### Runtime override

```bash
KAPSIS_DNS_THRESHOLD_SKIP=true ./scripts/launch-agent.sh ...
```

## Test plan

- [x] All 12 new threshold unit tests pass (`KAPSIS_QUICK_TESTS=1 bash tests/test-dns-pinning.sh`)
- [x] All pre-existing DNS pinning tests still pass
- [x] ShellCheck clean at `warning` severity on all modified files
- [ ] Integration test with a real network where some domains are unreachable

https://claude.ai/code/session_012SGrV19SuFFKiLWXAdyp13

---
_Generated by [Claude Code](https://claude.ai/code/session_012SGrV19SuFFKiLWXAdyp13)_