### PR TITLE
fix(launch-agent): guard critical unguarded function calls (closes #261)

### DIFF
--- a/scripts/launch-agent.sh
+++ b/scripts/launch-agent.sh
@@ -2069,7 +2069,8 @@ handle_existing_worktree() {
     # Handle --force-clean: remove existing worktree
     if [[ "$FORCE_CLEAN" == "true" ]]; then
         log_warn "Force-clean requested: removing existing worktree..."
-        cleanup_worktree "$PROJECT_PATH" "$existing_agent_id"
+        cleanup_worktree "$PROJECT_PATH" "$existing_agent_id" \
+            || log_warn "Worktree cleanup failed for agent '$existing_agent_id' — manual removal may be needed: git worktree remove $existing_worktree"
         log_info "Existing worktree removed. Continuing with fresh start."
         return 0
     fi
@@ -2112,7 +2113,8 @@ handle_existing_worktree() {
                 ;;
             s)
                 log_warn "Starting fresh: removing existing worktree..."
-                cleanup_worktree "$PROJECT_PATH" "$existing_agent_id"
+                cleanup_worktree "$PROJECT_PATH" "$existing_agent_id" \
+                    || log_warn "Worktree cleanup failed for agent '$existing_agent_id' — manual removal may be needed: git worktree remove $existing_worktree"
                 log_info "Existing worktree removed. Continuing with fresh start."
                 return 0
                 ;;
@@ -2497,7 +2499,11 @@ main() {
 
     log_timer_start "config"
     resolve_config
-    validate_config_security "$CONFIG_FILE"
+    if ! validate_config_security "$CONFIG_FILE"; then
+        status_complete 1 "Config security validation failed"
+        _STATUS_COMPLETE_SHOWN=true
+        exit 1
+    fi
     parse_config
     validate_agent_command "$AGENT_COMMAND"
     log_timer_end "config"
@@ -2513,7 +2519,11 @@ main() {
 
     # Handle existing worktree for branch (Fix #1: resume/force-clean)
     if [[ -n "$BRANCH" ]] && [[ "$SANDBOX_MODE" != "overlay" ]] && [[ "$DRY_RUN" != "true" ]]; then
-        handle_existing_worktree
+        if ! handle_existing_worktree; then
+            status_complete 1 "Failed to resolve existing worktree for branch '${BRANCH}'"
+            _STATUS_COMPLETE_SHOWN=true
+            exit 1
+        fi
     fi
 
     # Run pre-flight validation for worktree mode (skip in dry-run)
@@ -2532,7 +2542,11 @@ main() {
     # Setup sandbox (worktree/overlay) — only for backends that support it
     if backend_supports "worktree" || backend_supports "overlay"; then
         log_timer_start "sandbox_setup"
-        setup_sandbox
+        if ! setup_sandbox; then
+            status_complete 1 "Sandbox setup failed (mode: ${SANDBOX_MODE:-unknown})"
+            _STATUS_COMPLETE_SHOWN=true
+            exit 1
+        fi
         log_timer_end "sandbox_setup"
     else
         log_info "Backend '$BACKEND' handles sandbox setup in-cluster"
@@ -2545,11 +2559,27 @@ main() {
     # Podman-specific: generate volume mounts, env vars, secrets env-file
     # K8s backend generates its own CR with this info
     if [[ "$BACKEND" == "podman" ]]; then
-        generate_volume_mounts
-        generate_env_vars
-        write_secrets_env_file
+        if ! generate_volume_mounts; then
+            status_complete 1 "Failed to generate container volume mounts"
+            _STATUS_COMPLETE_SHOWN=true
+            exit 1
+        fi
+        if ! generate_env_vars; then
+            status_complete 1 "Failed to generate container environment variables"
+            _STATUS_COMPLETE_SHOWN=true
+            exit 1
+        fi
+        if ! write_secrets_env_file; then
+            status_complete 1 "Failed to write secrets env-file"
+            _STATUS_COMPLETE_SHOWN=true
+            exit 1
+        fi
     fi
-    backend_build_spec
+    if ! backend_build_spec; then
+        status_complete 1 "Failed to build container spec for backend '${BACKEND}'"
+        _STATUS_COMPLETE_SHOWN=true
+        exit 1
+    fi
     status_phase "preparing" 20 "Container configured"
 
     echo ""
@@ -2672,7 +2702,8 @@ main() {
         # status.json mount_failure entries).
         _VFKIT_FIRED_SENTINEL="${TMPDIR:-/tmp}/kapsis-${AGENT_ID}.vfkit-fired"
         rm -f "$_VFKIT_FIRED_SENTINEL" 2>/dev/null || true
-        start_vfkit_watchdog "$AGENT_ID" "" "" "$_VFKIT_FIRED_SENTINEL"
+        start_vfkit_watchdog "$AGENT_ID" "" "" "$_VFKIT_FIRED_SENTINEL" \
+            || log_warn "vfkit watchdog failed to start — mount failure detection disabled for this session"
     fi
 
     # Display progress header (shows sandbox ready status with timer)
@@ -2867,7 +2898,8 @@ main() {
     # Auto-cleanup agent volumes after session end (Fix #191)
     if [[ "$BACKEND" == "podman" ]] && [[ "$KEEP_VOLUMES" != "true" ]]; then
         log_debug "Auto-cleaning volumes for agent $AGENT_ID (use --keep-volumes to preserve)..."
-        cleanup_agent_volumes "$AGENT_ID"
+        cleanup_agent_volumes "$AGENT_ID" \
+            || log_warn "Volume cleanup failed for agent $AGENT_ID — volumes may accumulate (use 'kapsis-cleanup' to reclaim)"
     fi
 
     log_timer_end "total"
@@ -3023,7 +3055,11 @@ post_container_worktree() {
 
     # Re-point sanitized git objects symlink BEFORE any git operations (#219)
     # Must happen first so git status and sync_index_from_container work correctly
-    repoint_sanitized_git_objects "$SANITIZED_GIT_PATH" "$OBJECTS_PATH"
+    if ! repoint_sanitized_git_objects "$SANITIZED_GIT_PATH" "$OBJECTS_PATH"; then
+        log_error "Failed to repoint sanitized git objects symlink — post-container git operations may fail"
+        _pcg_rc=1
+        return 1
+    fi
 
     # Show changes summary
     cd "$WORKTREE_PATH"
@@ -3123,7 +3159,8 @@ post_container_worktree() {
     else
         log_info "Auto-cleaning worktree (use --keep-worktree or KAPSIS_KEEP_WORKTREE=true to preserve)..."
         local delete_branch="${KAPSIS_CLEANUP_BRANCH_ENABLED:-${KAPSIS_DEFAULT_CLEANUP_BRANCH_ENABLED:-false}}"
-        cleanup_worktree "$PROJECT_PATH" "$AGENT_ID" "$delete_branch"
+        cleanup_worktree "$PROJECT_PATH" "$AGENT_ID" "$delete_branch" \
+            || log_warn "Worktree cleanup failed for agent '$AGENT_ID' — manual removal may be needed: git worktree remove ${WORKTREE_PATH:-<worktree>}"
         prune_worktrees "$PROJECT_PATH"
     fi
 

--- a/scripts/launch-agent.sh
+++ b/scripts/launch-agent.sh
@@ -2070,7 +2070,7 @@ handle_existing_worktree() {
     if [[ "$FORCE_CLEAN" == "true" ]]; then
         log_warn "Force-clean requested: removing existing worktree..."
         cleanup_worktree "$PROJECT_PATH" "$existing_agent_id" \
-            || log_warn "Worktree cleanup failed for agent '$existing_agent_id' — manual removal may be needed: git worktree remove $existing_worktree"
+            || log_warn "Worktree cleanup failed for agent '$existing_agent_id' — manual removal may be needed: git worktree remove '$existing_worktree'"
         log_info "Existing worktree removed. Continuing with fresh start."
         return 0
     fi
@@ -2114,7 +2114,7 @@ handle_existing_worktree() {
             s)
                 log_warn "Starting fresh: removing existing worktree..."
                 cleanup_worktree "$PROJECT_PATH" "$existing_agent_id" \
-                    || log_warn "Worktree cleanup failed for agent '$existing_agent_id' — manual removal may be needed: git worktree remove $existing_worktree"
+                    || log_warn "Worktree cleanup failed for agent '$existing_agent_id' — manual removal may be needed: git worktree remove '$existing_worktree'"
                 log_info "Existing worktree removed. Continuing with fresh start."
                 return 0
                 ;;
@@ -2472,6 +2472,11 @@ main() {
 
     log_timer_start "config"
     resolve_config
+    # Guards below use `if ! func` rather than bare calls. Several of these functions
+    # currently reach failure via internal `exit 1` (not `return 1`), so the guard
+    # catches only residual command-substitution / printf failures on those paths.
+    # The pattern is intentionally forward-compatible: if inner exits are ever converted
+    # to returns, the guards will absorb them without further changes here.
     if ! validate_config_security "$CONFIG_FILE"; then
         status_complete 1 "Config security validation failed"
         _STATUS_COMPLETE_SHOWN=true
@@ -3064,6 +3069,9 @@ post_container_worktree() {
     # Must happen first so git status and sync_index_from_container work correctly
     if ! repoint_sanitized_git_objects "$SANITIZED_GIT_PATH" "$OBJECTS_PATH"; then
         log_error "Failed to repoint sanitized git objects symlink — post-container git operations may fail"
+        # Mark commit as failed so the post-container chain routes to exit 6 (commit_failure)
+        # and preserves the worktree for manual recovery, rather than misreporting push_failure.
+        status_set_commit_info "failed"
         _pcg_rc=1
         return 1
     fi
@@ -3167,7 +3175,7 @@ post_container_worktree() {
         log_info "Auto-cleaning worktree (use --keep-worktree or KAPSIS_KEEP_WORKTREE=true to preserve)..."
         local delete_branch="${KAPSIS_CLEANUP_BRANCH_ENABLED:-${KAPSIS_DEFAULT_CLEANUP_BRANCH_ENABLED:-false}}"
         cleanup_worktree "$PROJECT_PATH" "$AGENT_ID" "$delete_branch" \
-            || log_warn "Worktree cleanup failed for agent '$AGENT_ID' — manual removal may be needed: git worktree remove ${WORKTREE_PATH:-<worktree>}"
+            || log_warn "Worktree cleanup failed for agent '$AGENT_ID' — manual removal may be needed: git worktree remove '${WORKTREE_PATH:-<worktree>}'"
         prune_worktrees "$PROJECT_PATH"
     fi
 


### PR DESCRIPTION
## Summary

Closes #261.

`launch-agent.sh` runs under `set -euo pipefail` and is 3,195 lines. Bare function calls without `||` guards are silent-failure landmines — issue #256 (commit failure causing 3× repeated 1h43m of wasted agent work) was a direct consequence of exactly this pattern.

An ensemble of three parallel agents audited the script and identified 13 critical unguarded call sites. This PR applies guards to all of them using the three patterns already established in the codebase.

## Changes

**Fail-fast (`if ! func; then status_complete 1 ...; exit 1; fi`)** — failures here leave the agent in an unrecoverable state:

| Call | Why it must fail-fast |
|------|-----------------------|
| `validate_config_security` | Proceeding with an untrusted config is a security bypass |
| `handle_existing_worktree` | Two concurrent worktrees for the same branch causes data loss |
| `setup_sandbox` | `WORKTREE_PATH` is set inside this function; failure leaves it unbound, crashing every downstream call under `set -u` |
| `generate_volume_mounts` | Container launched without mounts runs against the wrong filesystem |
| `generate_env_vars` | Agent runs blind without its environment |
| `write_secrets_env_file` | Agent runs without credentials |
| `backend_build_spec` | Malformed spec produces opaque container engine errors |

**Warn-and-continue (`\|\| log_warn ...`)** — failures are recoverable; crashing here would hide the primary agent result:

| Call | Why it continues |
|------|-----------------|
| `start_vfkit_watchdog` | Defense-in-depth sentinel only; container still runs correctly |
| `cleanup_agent_volumes` | Post-exit maintenance; don't replace a clean exit code with a cleanup failure |
| `cleanup_worktree` (3 sites) | Stale worktree ≠ current-session data corruption; recovery hint included in warning |

**Propagate via `_pcg_rc`** — failure in a sub-function that must abort via the existing error chain:

| Call | Why rc propagation |
|------|--------------------|
| `repoint_sanitized_git_objects` | Must succeed before any `git status`/`sync_index_from_container`; uses `_pcg_rc` so the main exit-code chain (exit 6 / commit_failure) triggers correctly |

## Test plan

- [ ] Launch agent with a deliberately broken config path → should see `status_complete 1 "Config security validation failed"` instead of opaque crash
- [ ] Quick tests pass: `./tests/run-all-tests.sh --quick`
- [ ] `bash -n scripts/launch-agent.sh` passes (syntax clean — verified locally)
- [ ] No new shellcheck warnings on the modified lines

https://claude.ai/code/session_01XTUuspFLHFdAobTHcPVYK6

---
_Generated by [Claude Code](https://claude.ai/code/session_01XTUuspFLHFdAobTHcPVYK6)_