### PR TITLE
refactor(dns): redesign #216 with distinct return code, list failing domains

### DIFF
--- a/configs/network-allowlist.yaml
+++ b/configs/network-allowlist.yaml
@@ -169,6 +169,17 @@ network:
     # Sets chmod 444 after DNS setup (agent runs as non-root, cannot override)
     protect_dns_files: true
 
+    # Abort container launch when too many domains fail to resolve on the host.
+    # Prevents wasting a long agent run when VPN/DNS is broken at launch time.
+    # Both thresholds are checked independently; either can trigger an abort.
+    # Override at runtime with: KAPSIS_SKIP_DNS_CHECK=true
+    #
+    # Abort if more than N% of domains fail to resolve (fraction 0.0-1.0):
+    # max_failure_rate: 0.5
+    #
+    # Abort if more than N domains fail to resolve (absolute count):
+    # max_failures: 10
+
   # Allowed ports (documented for reference)
   # Note: Port filtering is NOT enforced - only DNS filtering
   # These are the typical ports that allowed services use

--- a/docs/CONFIG-REFERENCE.md
+++ b/docs/CONFIG-REFERENCE.md
@@ -633,6 +633,8 @@ network:
 
     # Abort launch if more than N% of resolvable domains fail to resolve (0.0–1.0).
     # Wildcards are excluded from the denominator (they are never resolvable).
+    # When triggered, the abort message lists up to 10 of the failing domains so
+    # you can immediately see which destinations are unreachable.
     # Default: unset (disabled — preserves existing behaviour)
     # Example: 0.5 aborts if more than 50% of domains fail (e.g. VPN is down)
     # Override at runtime: KAPSIS_SKIP_DNS_CHECK=true

--- a/docs/NETWORK-ISOLATION.md
+++ b/docs/NETWORK-ISOLATION.md
@@ -587,12 +587,19 @@ network:
 
     # Abort if more than N% of domains fail to resolve (0.0–1.0).
     # Useful to catch VPN/DNS outages before wasting compute.
+    # On abort, the error lists up to 10 of the failing domains so you
+    # can immediately see which destinations are unreachable.
     # Default: unset. Override: KAPSIS_SKIP_DNS_CHECK=true
     # max_failure_rate: 0.5
 
     # Abort if more than N domains fail to resolve (absolute count).
     # max_failures: 10
 ```
+
+The check is implemented inside `resolve_allowlist_domains` and signalled via
+return code: `0` for success (even partial), `1` for `fallback: abort` failures,
+and `2` for threshold breaches. `launch-agent.sh` distinguishes these to log
+the appropriate guidance and honor `KAPSIS_SKIP_DNS_CHECK`.
 
 ### Defense-in-Depth Layers
 

--- a/scripts/launch-agent.sh
+++ b/scripts/launch-agent.sh
@@ -2212,53 +2212,16 @@ build_container_command() {
             # This prevents DNS manipulation attacks inside the container
             if [[ "${NETWORK_DNS_PIN_ENABLED:-true}" == "true" ]] && [[ -n "${NETWORK_ALLOWLIST_DOMAINS:-}" ]]; then
                 log_info "DNS pinning: resolving allowlist domains on host..."
-                local resolved_data
-                if resolved_data=$(resolve_allowlist_domains "$NETWORK_ALLOWLIST_DOMAINS" "${NETWORK_DNS_PIN_TIMEOUT:-5}" "${NETWORK_DNS_PIN_FALLBACK:-dynamic}"); then
-                    # Extract the stats sentinel emitted by resolve_allowlist_domains.
-                    # The sentinel is embedded in stdout so it survives the subshell boundary
-                    # (env exports from command substitution subshells are discarded by bash).
-                    local _dns_stats_line
-                    _dns_stats_line=$(echo "${resolved_data}" | grep '^__KAPSIS_DNS_STATS__' || true)
-                    # Strip the sentinel before writing to the pinned DNS file
-                    resolved_data=$(echo "${resolved_data}" | grep -v '^__KAPSIS_DNS_STATS__' || true)
+                local resolved_data dns_pin_rc
+                dns_pin_rc=0
+                resolved_data=$(resolve_allowlist_domains \
+                    "$NETWORK_ALLOWLIST_DOMAINS" \
+                    "${NETWORK_DNS_PIN_TIMEOUT:-5}" \
+                    "${NETWORK_DNS_PIN_FALLBACK:-dynamic}" \
+                    "${NETWORK_DNS_PIN_MAX_FAILURE_RATE:-}" \
+                    "${NETWORK_DNS_PIN_MAX_FAILURES:-}") || dns_pin_rc=$?
 
-                    # Check DNS failure rate threshold (Issue #216)
-                    # Aborts if too many domains failed to resolve — indicating broken DNS/VPN
-                    if [[ -z "${KAPSIS_SKIP_DNS_CHECK:-}" ]] && [[ -n "${_dns_stats_line}" ]]; then
-                        local _dns_failed _dns_total
-                        _dns_failed=$(echo "${_dns_stats_line}" | grep -o 'failed=[0-9]*' | cut -d= -f2 || true)
-                        _dns_total=$(echo "${_dns_stats_line}" | grep -o 'total=[0-9]*' | cut -d= -f2 || true)
-                        _dns_failed="${_dns_failed:-0}"
-                        _dns_total="${_dns_total:-0}"
-
-                        local _dns_abort=0
-
-                        # Absolute failure count threshold
-                        if [[ -n "${NETWORK_DNS_PIN_MAX_FAILURES:-}" ]] && [[ "$_dns_failed" -gt "${NETWORK_DNS_PIN_MAX_FAILURES}" ]]; then
-                            log_error "DNS pre-flight failed: $_dns_failed domain(s) failed to resolve (threshold: ${NETWORK_DNS_PIN_MAX_FAILURES})"
-                            _dns_abort=1
-                        fi
-
-                        # Failure rate threshold (0.0–1.0)
-                        if [[ -n "${NETWORK_DNS_PIN_MAX_FAILURE_RATE:-}" ]] && [[ "$_dns_total" -gt 0 ]]; then
-                            local _rate_exceeded
-                            _rate_exceeded=$(awk -v failed="$_dns_failed" -v total="$_dns_total" \
-                                -v threshold="${NETWORK_DNS_PIN_MAX_FAILURE_RATE}" \
-                                'BEGIN { rate = failed / total; print (rate > threshold) ? "1" : "0" }' || true)
-                            if [[ "$_rate_exceeded" == "1" ]]; then
-                                log_error "DNS pre-flight failed: $_dns_failed/$_dns_total domain(s) failed to resolve (rate exceeds ${NETWORK_DNS_PIN_MAX_FAILURE_RATE})"
-                                _dns_abort=1
-                            fi
-                        fi
-
-                        if [[ "$_dns_abort" -eq 1 ]]; then
-                            log_error "Check your VPN / network connectivity and retry, or set KAPSIS_SKIP_DNS_CHECK=true to bypass."
-                            exit 1
-                        fi
-                    elif [[ -n "${KAPSIS_SKIP_DNS_CHECK:-}" ]]; then
-                        log_warn "SECURITY: DNS failure threshold check bypassed via KAPSIS_SKIP_DNS_CHECK"
-                    fi
-
+                if [[ "$dns_pin_rc" -eq 0 ]]; then
                     if [[ -n "$resolved_data" ]]; then
                         # Create temp file for pinned DNS (cleaned up in _cleanup_with_completion)
                         DNS_PIN_FILE=$(mktemp)
@@ -2281,7 +2244,17 @@ build_container_command() {
                             CONTAINER_CMD+=("-e" "KAPSIS_DNS_PIN_ENABLED=true")
                         fi
                     fi
+                elif [[ "$dns_pin_rc" -eq 2 ]]; then
+                    # Threshold exceeded (max_failure_rate or max_failures)
+                    if [[ "${KAPSIS_SKIP_DNS_CHECK:-false}" == "true" ]]; then
+                        log_warn "DNS failure threshold exceeded but KAPSIS_SKIP_DNS_CHECK=true — proceeding with degraded security"
+                    else
+                        log_error "Aborting container launch due to high DNS resolution failure rate."
+                        log_error "Set KAPSIS_SKIP_DNS_CHECK=true to bypass this check."
+                        exit 1
+                    fi
                 else
+                    # rc=1: fallback=abort or other partial failure
                     if [[ "${NETWORK_DNS_PIN_FALLBACK:-dynamic}" == "abort" ]]; then
                         log_error "DNS pinning failed with fallback=abort - aborting container launch"
                         exit 1

--- a/scripts/lib/config-verifier.sh
+++ b/scripts/lib/config-verifier.sh
@@ -532,6 +532,26 @@ validate_network_config() {
         fi
     fi
 
+    local dns_pin_max_rate
+    dns_pin_max_rate=$(yq -r '.network.dns_pinning.max_failure_rate // "null"' "$config_file" 2>/dev/null)
+    if [[ "$dns_pin_max_rate" != "null" ]]; then
+        if awk -v v="$dns_pin_max_rate" 'BEGIN { exit (v ~ /^[0-9]*\.?[0-9]+$/ && v+0 >= 0 && v+0 <= 1) ? 0 : 1 }' 2>/dev/null; then
+            log_pass "Valid dns_pinning.max_failure_rate: $dns_pin_max_rate"
+        else
+            log_error "Invalid dns_pinning.max_failure_rate: $dns_pin_max_rate (must be a number between 0.0 and 1.0)"
+        fi
+    fi
+
+    local dns_pin_max_failures
+    dns_pin_max_failures=$(yq -r '.network.dns_pinning.max_failures // "null"' "$config_file" 2>/dev/null)
+    if [[ "$dns_pin_max_failures" != "null" ]]; then
+        if [[ "$dns_pin_max_failures" =~ ^[0-9]+$ ]] && [[ "$dns_pin_max_failures" -gt 0 ]]; then
+            log_pass "Valid dns_pinning.max_failures: $dns_pin_max_failures"
+        else
+            log_error "Invalid dns_pinning.max_failures: $dns_pin_max_failures (must be a positive integer)"
+        fi
+    fi
+
     return 0
 }
 

--- a/scripts/lib/config-verifier.sh
+++ b/scripts/lib/config-verifier.sh
@@ -545,10 +545,12 @@ validate_network_config() {
     local dns_pin_max_failures
     dns_pin_max_failures=$(yq -r '.network.dns_pinning.max_failures // "null"' "$config_file" 2>/dev/null)
     if [[ "$dns_pin_max_failures" != "null" ]]; then
-        if [[ "$dns_pin_max_failures" =~ ^[0-9]+$ ]] && [[ "$dns_pin_max_failures" -gt 0 ]]; then
+        # Accept 0 as a legal "any failure aborts" zero-tolerance setting (symmetric
+        # with max_failure_rate=0.0 which is also accepted).
+        if [[ "$dns_pin_max_failures" =~ ^[0-9]+$ ]]; then
             log_pass "Valid dns_pinning.max_failures: $dns_pin_max_failures"
         else
-            log_error "Invalid dns_pinning.max_failures: $dns_pin_max_failures (must be a positive integer)"
+            log_error "Invalid dns_pinning.max_failures: $dns_pin_max_failures (must be a non-negative integer)"
         fi
     fi
 

--- a/scripts/lib/dns-pin.sh
+++ b/scripts/lib/dns-pin.sh
@@ -56,10 +56,13 @@ _log_failed_domains() {
     [[ "$total" -eq 0 ]] && return 0
     local shown=$(( total < _DNS_FAILED_DOMAIN_PREVIEW ? total : _DNS_FAILED_DOMAIN_PREVIEW ))
     log_error "Failing domains (showing $shown of $total):"
-    local i=0
+    local i=0 d_safe
     for d in "$@"; do
         (( i < shown )) || break
-        log_error "  - $d"
+        # Strip control chars (incl. ANSI escapes / newlines) — domains come from
+        # user-controlled YAML allowlist, must not corrupt logs or terminal.
+        d_safe=$(printf '%s' "$d" | tr -d '[:cntrl:]')
+        log_error "  - $d_safe"
         i=$((i + 1))
     done
     if (( total > shown )); then
@@ -89,12 +92,32 @@ _log_failed_domains() {
 #   0 - success (even partial)
 #   1 - any failure with fallback=abort
 #   2 - DNS failure threshold exceeded (max_failure_rate or max_failures)
+#
+# Precedence: rc=2 short-circuits before rc=1, so a threshold breach wins over
+# fallback=abort. This is intentional — the threshold is the user's explicit
+# pre-flight policy and produces the most actionable error (lists failing domains).
 resolve_allowlist_domains() {
     local domain_list="$1"
     local timeout="${2:-5}"
     local fallback="${3:-dynamic}"
     local max_failure_rate="${4:-${KAPSIS_DNS_MAX_FAILURE_RATE:-}}"
     local max_failures="${5:-${KAPSIS_DNS_MAX_FAILURES:-}}"
+
+    # Validate threshold inputs — reject non-numeric values early so arithmetic
+    # below can't false-abort on whitespace or unbound-variable on letters.
+    # max_failure_rate: float in [0.0, 1.0]; max_failures: non-negative integer.
+    if [[ -n "$max_failure_rate" ]]; then
+        if ! [[ "$max_failure_rate" =~ ^(0(\.[0-9]+)?|1(\.0+)?)$ ]]; then
+            log_error "Invalid max_failure_rate: '$max_failure_rate' (expected float 0.0–1.0); ignoring"
+            max_failure_rate=""
+        fi
+    fi
+    if [[ -n "$max_failures" ]]; then
+        if ! [[ "$max_failures" =~ ^[0-9]+$ ]]; then
+            log_error "Invalid max_failures: '$max_failures' (expected non-negative integer); ignoring"
+            max_failures=""
+        fi
+    fi
 
     [[ -z "$domain_list" ]] && return 0
 

--- a/scripts/lib/dns-pin.sh
+++ b/scripts/lib/dns-pin.sh
@@ -48,6 +48,25 @@ type log_success &>/dev/null || log_success() { echo "[DNS-PIN] SUCCESS: $*" >&2
 # DOMAIN RESOLUTION
 #===============================================================================
 
+# Print the failing-domain list during a threshold abort. Caps the output at
+# _DNS_FAILED_DOMAIN_PREVIEW lines so a 500-domain allowlist doesn't flood the log.
+_DNS_FAILED_DOMAIN_PREVIEW=10
+_log_failed_domains() {
+    local total=$#
+    [[ "$total" -eq 0 ]] && return 0
+    local shown=$(( total < _DNS_FAILED_DOMAIN_PREVIEW ? total : _DNS_FAILED_DOMAIN_PREVIEW ))
+    log_error "Failing domains (showing $shown of $total):"
+    local i=0
+    for d in "$@"; do
+        (( i < shown )) || break
+        log_error "  - $d"
+        i=$((i + 1))
+    done
+    if (( total > shown )); then
+        log_error "  ... and $(( total - shown )) more (set KAPSIS_DEBUG=1 for the full list above)"
+    fi
+}
+
 # resolve_allowlist_domains <comma-domains> [timeout] [fallback] [max_failure_rate] [max_failures]
 #
 # Resolves comma-separated domains to IP addresses on the host.
@@ -82,6 +101,7 @@ resolve_allowlist_domains() {
     local resolved_count=0
     local failed_count=0
     local wildcard_count=0
+    local -a failed_domains=()
 
     log_debug "Resolving domains with timeout=${timeout}s, fallback=${fallback}"
 
@@ -122,6 +142,7 @@ resolve_allowlist_domains() {
         else
             log_warn "Failed to resolve domain: $domain"
             failed_count=$((failed_count + 1))
+            failed_domains+=("$domain")
         fi
     done
 
@@ -134,6 +155,7 @@ resolve_allowlist_domains() {
         # Absolute failure count threshold
         if [[ -n "$max_failures" ]] && (( failed_count > max_failures )); then
             log_error "DNS resolution failure threshold exceeded: $failed_count/$total_count domains failed (max allowed: $max_failures)"
+            _log_failed_domains "${failed_domains[@]}"
             log_error "Check VPN/network connectivity and retry."
             log_error "Override: set KAPSIS_SKIP_DNS_CHECK=true to bypass this check"
             return 2
@@ -147,6 +169,7 @@ resolve_allowlist_domains() {
                 pct=$(awk -v f="$failed_count" -v t="$total_count" 'BEGIN { printf "%.0f", (f/t)*100 }')
                 max_pct=$(awk -v m="$max_failure_rate" 'BEGIN { printf "%.0f", m*100 }')
                 log_error "DNS resolution failure rate ${pct}% exceeds threshold ${max_pct}%: $failed_count/$total_count domains failed"
+                _log_failed_domains "${failed_domains[@]}"
                 log_error "Check VPN/network connectivity and retry."
                 log_error "Override: set KAPSIS_SKIP_DNS_CHECK=true to bypass this check"
                 return 2

--- a/scripts/lib/dns-pin.sh
+++ b/scripts/lib/dns-pin.sh
@@ -48,7 +48,7 @@ type log_success &>/dev/null || log_success() { echo "[DNS-PIN] SUCCESS: $*" >&2
 # DOMAIN RESOLUTION
 #===============================================================================
 
-# resolve_allowlist_domains <comma-domains> [timeout] [fallback]
+# resolve_allowlist_domains <comma-domains> [timeout] [fallback] [max_failure_rate] [max_failures]
 #
 # Resolves comma-separated domains to IP addresses on the host.
 # Skips wildcards (emitting security warning) and returns pinned mappings.
@@ -57,16 +57,25 @@ type log_success &>/dev/null || log_success() { echo "[DNS-PIN] SUCCESS: $*" >&2
 #   $1 - Comma-separated list of domains (from KAPSIS_DNS_ALLOWLIST)
 #   $2 - Resolution timeout in seconds (default: 5)
 #   $3 - Fallback behavior: "dynamic" (default) or "abort"
+#   $4 - Max failure rate as fraction 0.0-1.0, e.g. "0.5" (50%); empty = no check
+#        Falls back to KAPSIS_DNS_MAX_FAILURE_RATE env var if arg is empty.
+#   $5 - Max absolute failure count, e.g. "10"; empty = no check
+#        Falls back to KAPSIS_DNS_MAX_FAILURES env var if arg is empty.
 #
 # Output:
 #   domain IP1 IP2 ...
 #   (one line per domain with resolved IPs, space-separated)
 #
-# Returns: 0 on success (even partial), 1 on complete failure with abort mode
+# Returns:
+#   0 - success (even partial)
+#   1 - any failure with fallback=abort
+#   2 - DNS failure threshold exceeded (max_failure_rate or max_failures)
 resolve_allowlist_domains() {
     local domain_list="$1"
     local timeout="${2:-5}"
     local fallback="${3:-dynamic}"
+    local max_failure_rate="${4:-${KAPSIS_DNS_MAX_FAILURE_RATE:-}}"
+    local max_failures="${5:-${KAPSIS_DNS_MAX_FAILURES:-}}"
 
     [[ -z "$domain_list" ]] && return 0
 
@@ -119,10 +128,31 @@ resolve_allowlist_domains() {
     local total_count=$((resolved_count + failed_count))
     log_info "DNS pinning: resolved $resolved_count domains, $failed_count failed, $wildcard_count wildcards skipped"
 
-    # Emit a sentinel line on stdout so the caller can parse stats even when this
-    # function runs inside a command substitution subshell (where env exports are lost).
-    # The caller strips this line before writing the pinned DNS file.
-    echo "__KAPSIS_DNS_STATS__ resolved=${resolved_count} failed=${failed_count} total=${total_count}"
+    # Threshold-based abort check — returns 2 so callers can distinguish from fallback=abort (1).
+    # Both max_failure_rate and max_failures are checked independently; either can trigger.
+    if [[ "$failed_count" -gt 0 ]] && [[ -n "$max_failure_rate" || -n "$max_failures" ]]; then
+        # Absolute failure count threshold
+        if [[ -n "$max_failures" ]] && (( failed_count > max_failures )); then
+            log_error "DNS resolution failure threshold exceeded: $failed_count/$total_count domains failed (max allowed: $max_failures)"
+            log_error "Check VPN/network connectivity and retry."
+            log_error "Override: set KAPSIS_SKIP_DNS_CHECK=true to bypass this check"
+            return 2
+        fi
+
+        # Failure rate threshold (float comparison via awk; awk exits 0 when threshold exceeded)
+        if [[ -n "$max_failure_rate" ]] && (( total_count > 0 )); then
+            if awk -v f="$failed_count" -v t="$total_count" -v m="$max_failure_rate" \
+                   'BEGIN { exit (f/t > m) ? 0 : 1 }'; then
+                local pct max_pct
+                pct=$(awk -v f="$failed_count" -v t="$total_count" 'BEGIN { printf "%.0f", (f/t)*100 }')
+                max_pct=$(awk -v m="$max_failure_rate" 'BEGIN { printf "%.0f", m*100 }')
+                log_error "DNS resolution failure rate ${pct}% exceeds threshold ${max_pct}%: $failed_count/$total_count domains failed"
+                log_error "Check VPN/network connectivity and retry."
+                log_error "Override: set KAPSIS_SKIP_DNS_CHECK=true to bypass this check"
+                return 2
+            fi
+        fi
+    fi
 
     # Handle failures based on fallback mode
     if [[ "$failed_count" -gt 0 ]] && [[ "$fallback" == "abort" ]]; then

--- a/scripts/lib/dns-pin.sh
+++ b/scripts/lib/dns-pin.sh
@@ -50,7 +50,9 @@ type log_success &>/dev/null || log_success() { echo "[DNS-PIN] SUCCESS: $*" >&2
 
 # Print the failing-domain list during a threshold abort. Caps the output at
 # _DNS_FAILED_DOMAIN_PREVIEW lines so a 500-domain allowlist doesn't flood the log.
-_DNS_FAILED_DOMAIN_PREVIEW=10
+# Override with KAPSIS_DNS_FAILED_PREVIEW (e.g. =200 for full list, =0 to silence).
+: "${_DNS_FAILED_DOMAIN_PREVIEW:=${KAPSIS_DNS_FAILED_PREVIEW:-10}}"
+readonly _DNS_FAILED_DOMAIN_PREVIEW
 _log_failed_domains() {
     local total=$#
     [[ "$total" -eq 0 ]] && return 0
@@ -66,7 +68,7 @@ _log_failed_domains() {
         i=$((i + 1))
     done
     if (( total > shown )); then
-        log_error "  ... and $(( total - shown )) more (set KAPSIS_DEBUG=1 for the full list above)"
+        log_error "  ... and $(( total - shown )) more (see WARN entries above for the full list, or KAPSIS_DNS_FAILED_PREVIEW=N to widen)"
     fi
 }
 

--- a/tests/test-dns-pinning.sh
+++ b/tests/test-dns-pinning.sh
@@ -627,6 +627,206 @@ EOF
 }
 
 #===============================================================================
+# THRESHOLD TESTS (Issue #216 — abort launch when DNS failure rate too high)
+#===============================================================================
+
+test_threshold_max_failures_triggers_exit2() {
+    log_test "Testing resolve_allowlist_domains returns 2 when max_failures exceeded"
+
+    source "$DNS_PIN_LIB"
+
+    # Use all-invalid domains so every one fails, max_failures=1
+    local rc=0
+    resolve_allowlist_domains \
+        "this-will-not-resolve-xyz123.invalid,also-not-real-abc987.invalid" \
+        2 "dynamic" "" "1" >/dev/null 2>&1 || rc=$?
+
+    if [[ "$rc" -eq 2 ]]; then
+        log_pass "Exit code 2 returned when failures exceed max_failures"
+    elif [[ "$rc" -eq 0 ]]; then
+        log_skip "All domains resolved unexpectedly (DNS returns 0.0.0.0 for all?) — skipping"
+    else
+        log_fail "Expected exit code 2, got: $rc"
+        return 1
+    fi
+}
+
+test_threshold_max_failure_rate_triggers_exit2() {
+    log_test "Testing resolve_allowlist_domains returns 2 when max_failure_rate exceeded"
+
+    source "$DNS_PIN_LIB"
+
+    # 2 invalid domains out of 2 = 100% failure rate; threshold 0.4 (40%) should trigger
+    local rc=0
+    resolve_allowlist_domains \
+        "this-will-not-resolve-xyz123.invalid,also-not-real-abc987.invalid" \
+        2 "dynamic" "0.4" "" >/dev/null 2>&1 || rc=$?
+
+    if [[ "$rc" -eq 2 ]]; then
+        log_pass "Exit code 2 returned when failure rate exceeds max_failure_rate"
+    elif [[ "$rc" -eq 0 ]]; then
+        log_skip "All domains resolved unexpectedly (DNS returns 0.0.0.0 for all?) — skipping"
+    else
+        log_fail "Expected exit code 2, got: $rc"
+        return 1
+    fi
+}
+
+test_threshold_under_limit_returns_0() {
+    log_test "Testing resolve_allowlist_domains returns 0 when failures stay under threshold"
+
+    source "$DNS_PIN_LIB"
+
+    # max_failures=100 — even if some domains fail, 2 failures won't exceed 100
+    local rc=0
+    resolve_allowlist_domains \
+        "this-will-not-resolve-xyz123.invalid,also-not-real-abc987.invalid" \
+        2 "dynamic" "" "100" >/dev/null 2>&1 || rc=$?
+
+    if [[ "$rc" -eq 0 ]]; then
+        log_pass "Exit code 0 returned when failures are under max_failures threshold"
+    elif [[ "$rc" -eq 2 ]]; then
+        log_fail "Threshold triggered unexpectedly — more than 100 failures?"
+        return 1
+    else
+        log_fail "Unexpected exit code: $rc"
+        return 1
+    fi
+}
+
+test_threshold_env_var_max_failures() {
+    log_test "Testing KAPSIS_DNS_MAX_FAILURES env var is respected"
+
+    source "$DNS_PIN_LIB"
+
+    export KAPSIS_DNS_MAX_FAILURES=1
+    local rc=0
+    # Pass no positional threshold args — function should pick up the env var
+    resolve_allowlist_domains \
+        "this-will-not-resolve-xyz123.invalid,also-not-real-abc987.invalid" \
+        2 "dynamic" >/dev/null 2>&1 || rc=$?
+    unset KAPSIS_DNS_MAX_FAILURES
+
+    if [[ "$rc" -eq 2 ]]; then
+        log_pass "KAPSIS_DNS_MAX_FAILURES env var triggers exit code 2"
+    elif [[ "$rc" -eq 0 ]]; then
+        log_skip "All domains resolved unexpectedly — skipping"
+    else
+        log_fail "Expected exit code 2, got: $rc"
+        return 1
+    fi
+}
+
+test_threshold_env_var_max_failure_rate() {
+    log_test "Testing KAPSIS_DNS_MAX_FAILURE_RATE env var is respected"
+
+    source "$DNS_PIN_LIB"
+
+    export KAPSIS_DNS_MAX_FAILURE_RATE=0.1
+    local rc=0
+    resolve_allowlist_domains \
+        "this-will-not-resolve-xyz123.invalid,also-not-real-abc987.invalid" \
+        2 "dynamic" >/dev/null 2>&1 || rc=$?
+    unset KAPSIS_DNS_MAX_FAILURE_RATE
+
+    if [[ "$rc" -eq 2 ]]; then
+        log_pass "KAPSIS_DNS_MAX_FAILURE_RATE env var triggers exit code 2"
+    elif [[ "$rc" -eq 0 ]]; then
+        log_skip "All domains resolved unexpectedly — skipping"
+    else
+        log_fail "Expected exit code 2, got: $rc"
+        return 1
+    fi
+}
+
+test_threshold_no_limit_set_returns_0() {
+    log_test "Testing resolve_allowlist_domains returns 0 with no threshold configured"
+
+    source "$DNS_PIN_LIB"
+
+    # No threshold args and no env vars — failures are silently tolerated (existing behavior)
+    unset KAPSIS_DNS_MAX_FAILURES KAPSIS_DNS_MAX_FAILURE_RATE
+    local rc=0
+    resolve_allowlist_domains \
+        "this-will-not-resolve-xyz123.invalid" \
+        2 "dynamic" "" "" >/dev/null 2>&1 || rc=$?
+
+    if [[ "$rc" -eq 0 ]]; then
+        log_pass "No threshold — failures tolerated, exit code 0"
+    elif [[ "$rc" -eq 2 ]]; then
+        log_fail "Threshold triggered when none was configured"
+        return 1
+    else
+        log_fail "Unexpected exit code: $rc"
+        return 1
+    fi
+}
+
+test_config_validation_max_failure_rate_valid() {
+    log_test "Testing config validation accepts valid max_failure_rate values"
+
+    if ! command -v yq &>/dev/null; then
+        log_skip "yq not installed"
+        return 0
+    fi
+
+    local test_config
+    test_config=$(mktemp).yaml
+    cat > "$test_config" << 'EOF'
+network:
+  mode: filtered
+  dns_pinning:
+    enabled: true
+    max_failure_rate: 0.5
+    max_failures: 10
+EOF
+
+    local output
+    output=$("$CONFIG_VERIFIER" "$test_config" 2>&1) || true
+
+    if echo "$output" | grep -q "Invalid dns_pinning.max_failure_rate\|Invalid dns_pinning.max_failures"; then
+        log_fail "Valid values rejected by config verifier: $output"
+        rm -f "$test_config"
+        return 1
+    else
+        log_pass "Valid max_failure_rate and max_failures accepted"
+    fi
+
+    rm -f "$test_config"
+}
+
+test_config_validation_max_failure_rate_invalid() {
+    log_test "Testing config validation rejects invalid max_failure_rate values"
+
+    if ! command -v yq &>/dev/null; then
+        log_skip "yq not installed"
+        return 0
+    fi
+
+    local test_config
+    test_config=$(mktemp).yaml
+    cat > "$test_config" << 'EOF'
+network:
+  mode: filtered
+  dns_pinning:
+    enabled: true
+    max_failure_rate: 1.5
+    max_failures: -1
+EOF
+
+    local output
+    output=$("$CONFIG_VERIFIER" "$test_config" 2>&1) || true
+
+    if echo "$output" | grep -q "Invalid dns_pinning.max_failure_rate"; then
+        log_pass "Invalid max_failure_rate (>1.0) correctly rejected"
+    else
+        log_warn "Expected validation error for max_failure_rate=1.5"
+    fi
+
+    rm -f "$test_config"
+}
+
+#===============================================================================
 # CONTAINER TESTS (require Podman)
 #===============================================================================
 
@@ -998,6 +1198,16 @@ main() {
     run_test test_resolve_returns_valid_ipv4_or_empty
     run_test test_add_host_args_format
     run_test test_pinned_file_parsing_robust
+
+    # Threshold tests (Issue #216)
+    run_test test_threshold_max_failures_triggers_exit2
+    run_test test_threshold_max_failure_rate_triggers_exit2
+    run_test test_threshold_under_limit_returns_0
+    run_test test_threshold_env_var_max_failures
+    run_test test_threshold_env_var_max_failure_rate
+    run_test test_threshold_no_limit_set_returns_0
+    run_test test_config_validation_max_failure_rate_valid
+    run_test test_config_validation_max_failure_rate_invalid
 
     # Container tests
     run_test test_pinned_file_mounted_readonly

--- a/tests/test-dns-pinning.sh
+++ b/tests/test-dns-pinning.sh
@@ -628,138 +628,215 @@ EOF
 
 #===============================================================================
 # THRESHOLD TESTS (Issue #216 — abort launch when DNS failure rate too high)
+#
+# These tests stub resolve_domain_ips so the threshold logic runs against
+# fixed, deterministic outcomes — no real DNS, no log_skip on flaky networks.
+# Domains prefixed "fail-" return empty (failure); all others return 1.2.3.4.
 #===============================================================================
+
+_stub_resolve_domain_ips() {
+    local domain="$1"
+    if [[ "$domain" == fail-* ]]; then
+        echo ""  # empty = resolution failure
+    else
+        echo "1.2.3.4"
+    fi
+}
 
 test_threshold_max_failures_triggers_exit2() {
     log_test "Testing resolve_allowlist_domains returns 2 when max_failures exceeded"
 
     source "$DNS_PIN_LIB"
+    resolve_domain_ips() { _stub_resolve_domain_ips "$1"; }
 
-    # Use all-invalid domains so every one fails, max_failures=1
+    # 2 failures, max_failures=1
     local rc=0
-    resolve_allowlist_domains \
-        "this-will-not-resolve-xyz123.invalid,also-not-real-abc987.invalid" \
-        2 "dynamic" "" "1" >/dev/null 2>&1 || rc=$?
+    resolve_allowlist_domains "fail-a.test,fail-b.test" 1 "dynamic" "" "1" >/dev/null 2>&1 || rc=$?
 
     if [[ "$rc" -eq 2 ]]; then
         log_pass "Exit code 2 returned when failures exceed max_failures"
-    elif [[ "$rc" -eq 0 ]]; then
-        log_skip "All domains resolved unexpectedly (DNS returns 0.0.0.0 for all?) — skipping"
     else
         log_fail "Expected exit code 2, got: $rc"
+        unset -f resolve_domain_ips
         return 1
     fi
+    unset -f resolve_domain_ips
 }
 
 test_threshold_max_failure_rate_triggers_exit2() {
     log_test "Testing resolve_allowlist_domains returns 2 when max_failure_rate exceeded"
 
     source "$DNS_PIN_LIB"
+    resolve_domain_ips() { _stub_resolve_domain_ips "$1"; }
 
-    # 2 invalid domains out of 2 = 100% failure rate; threshold 0.4 (40%) should trigger
+    # 2/2 = 100% > 0.4
     local rc=0
-    resolve_allowlist_domains \
-        "this-will-not-resolve-xyz123.invalid,also-not-real-abc987.invalid" \
-        2 "dynamic" "0.4" "" >/dev/null 2>&1 || rc=$?
+    resolve_allowlist_domains "fail-a.test,fail-b.test" 1 "dynamic" "0.4" "" >/dev/null 2>&1 || rc=$?
 
     if [[ "$rc" -eq 2 ]]; then
         log_pass "Exit code 2 returned when failure rate exceeds max_failure_rate"
-    elif [[ "$rc" -eq 0 ]]; then
-        log_skip "All domains resolved unexpectedly (DNS returns 0.0.0.0 for all?) — skipping"
     else
         log_fail "Expected exit code 2, got: $rc"
+        unset -f resolve_domain_ips
         return 1
     fi
+    unset -f resolve_domain_ips
 }
 
 test_threshold_under_limit_returns_0() {
     log_test "Testing resolve_allowlist_domains returns 0 when failures stay under threshold"
 
     source "$DNS_PIN_LIB"
+    resolve_domain_ips() { _stub_resolve_domain_ips "$1"; }
 
-    # max_failures=100 — even if some domains fail, 2 failures won't exceed 100
+    # 2 failures, max_failures=100 (well under)
     local rc=0
-    resolve_allowlist_domains \
-        "this-will-not-resolve-xyz123.invalid,also-not-real-abc987.invalid" \
-        2 "dynamic" "" "100" >/dev/null 2>&1 || rc=$?
+    resolve_allowlist_domains "fail-a.test,fail-b.test" 1 "dynamic" "" "100" >/dev/null 2>&1 || rc=$?
 
     if [[ "$rc" -eq 0 ]]; then
-        log_pass "Exit code 0 returned when failures are under max_failures threshold"
-    elif [[ "$rc" -eq 2 ]]; then
-        log_fail "Threshold triggered unexpectedly — more than 100 failures?"
-        return 1
+        log_pass "Exit code 0 when failures are under max_failures threshold"
     else
-        log_fail "Unexpected exit code: $rc"
+        log_fail "Expected exit code 0, got: $rc"
+        unset -f resolve_domain_ips
         return 1
     fi
+    unset -f resolve_domain_ips
 }
 
 test_threshold_env_var_max_failures() {
     log_test "Testing KAPSIS_DNS_MAX_FAILURES env var is respected"
 
     source "$DNS_PIN_LIB"
+    resolve_domain_ips() { _stub_resolve_domain_ips "$1"; }
 
     export KAPSIS_DNS_MAX_FAILURES=1
     local rc=0
-    # Pass no positional threshold args — function should pick up the env var
-    resolve_allowlist_domains \
-        "this-will-not-resolve-xyz123.invalid,also-not-real-abc987.invalid" \
-        2 "dynamic" >/dev/null 2>&1 || rc=$?
+    resolve_allowlist_domains "fail-a.test,fail-b.test" 1 "dynamic" >/dev/null 2>&1 || rc=$?
     unset KAPSIS_DNS_MAX_FAILURES
 
     if [[ "$rc" -eq 2 ]]; then
         log_pass "KAPSIS_DNS_MAX_FAILURES env var triggers exit code 2"
-    elif [[ "$rc" -eq 0 ]]; then
-        log_skip "All domains resolved unexpectedly — skipping"
     else
         log_fail "Expected exit code 2, got: $rc"
+        unset -f resolve_domain_ips
         return 1
     fi
+    unset -f resolve_domain_ips
 }
 
 test_threshold_env_var_max_failure_rate() {
     log_test "Testing KAPSIS_DNS_MAX_FAILURE_RATE env var is respected"
 
     source "$DNS_PIN_LIB"
+    resolve_domain_ips() { _stub_resolve_domain_ips "$1"; }
 
     export KAPSIS_DNS_MAX_FAILURE_RATE=0.1
     local rc=0
-    resolve_allowlist_domains \
-        "this-will-not-resolve-xyz123.invalid,also-not-real-abc987.invalid" \
-        2 "dynamic" >/dev/null 2>&1 || rc=$?
+    resolve_allowlist_domains "fail-a.test,fail-b.test" 1 "dynamic" >/dev/null 2>&1 || rc=$?
     unset KAPSIS_DNS_MAX_FAILURE_RATE
 
     if [[ "$rc" -eq 2 ]]; then
         log_pass "KAPSIS_DNS_MAX_FAILURE_RATE env var triggers exit code 2"
-    elif [[ "$rc" -eq 0 ]]; then
-        log_skip "All domains resolved unexpectedly — skipping"
     else
         log_fail "Expected exit code 2, got: $rc"
+        unset -f resolve_domain_ips
         return 1
     fi
+    unset -f resolve_domain_ips
 }
 
 test_threshold_no_limit_set_returns_0() {
     log_test "Testing resolve_allowlist_domains returns 0 with no threshold configured"
 
     source "$DNS_PIN_LIB"
+    resolve_domain_ips() { _stub_resolve_domain_ips "$1"; }
 
-    # No threshold args and no env vars — failures are silently tolerated (existing behavior)
     unset KAPSIS_DNS_MAX_FAILURES KAPSIS_DNS_MAX_FAILURE_RATE
     local rc=0
-    resolve_allowlist_domains \
-        "this-will-not-resolve-xyz123.invalid" \
-        2 "dynamic" "" "" >/dev/null 2>&1 || rc=$?
+    resolve_allowlist_domains "fail-a.test" 1 "dynamic" "" "" >/dev/null 2>&1 || rc=$?
 
     if [[ "$rc" -eq 0 ]]; then
         log_pass "No threshold — failures tolerated, exit code 0"
-    elif [[ "$rc" -eq 2 ]]; then
-        log_fail "Threshold triggered when none was configured"
-        return 1
     else
-        log_fail "Unexpected exit code: $rc"
+        log_fail "Expected exit code 0, got: $rc"
+        unset -f resolve_domain_ips
         return 1
     fi
+    unset -f resolve_domain_ips
+}
+
+test_threshold_zero_concrete_domains() {
+    log_test "Testing zero-concrete-domains (all wildcards) does not trigger rate threshold"
+
+    source "$DNS_PIN_LIB"
+    resolve_domain_ips() { _stub_resolve_domain_ips "$1"; }
+
+    # All wildcards — no resolved, no failed, no divide-by-zero, no abort.
+    local rc=0
+    resolve_allowlist_domains "*.github.com,*.npmjs.org" 1 "dynamic" "0.0" "0" >/dev/null 2>&1 || rc=$?
+
+    if [[ "$rc" -eq 0 ]]; then
+        log_pass "All-wildcard list with strict thresholds does not abort"
+    else
+        log_fail "Expected exit code 0 for all-wildcard list, got: $rc"
+        unset -f resolve_domain_ips
+        return 1
+    fi
+    unset -f resolve_domain_ips
+}
+
+test_threshold_lists_failing_domains() {
+    log_test "Testing abort message includes the failing domains"
+
+    source "$DNS_PIN_LIB"
+    resolve_domain_ips() { _stub_resolve_domain_ips "$1"; }
+
+    local output rc=0
+    output=$(resolve_allowlist_domains \
+        "ok.test,fail-alpha.test,fail-beta.test" \
+        1 "dynamic" "" "1" 2>&1) || rc=$?
+
+    if [[ "$rc" -ne 2 ]]; then
+        log_fail "Expected exit 2, got: $rc"
+        unset -f resolve_domain_ips
+        return 1
+    fi
+
+    if echo "$output" | grep -q "fail-alpha.test" && echo "$output" | grep -q "fail-beta.test"; then
+        log_pass "Both failing domains listed in abort output"
+    else
+        log_fail "Failing domains not listed in output. Got: $output"
+        unset -f resolve_domain_ips
+        return 1
+    fi
+    unset -f resolve_domain_ips
+}
+
+test_threshold_failing_domain_preview_caps_at_10() {
+    log_test "Testing failing-domain preview caps at 10 with 'N more' summary"
+
+    source "$DNS_PIN_LIB"
+    resolve_domain_ips() { _stub_resolve_domain_ips "$1"; }
+
+    # 12 failures — preview should show 10 with "and 2 more"
+    local domain_list="fail-1.test,fail-2.test,fail-3.test,fail-4.test,fail-5.test,fail-6.test,fail-7.test,fail-8.test,fail-9.test,fail-10.test,fail-11.test,fail-12.test"
+    local output rc=0
+    output=$(resolve_allowlist_domains "$domain_list" 1 "dynamic" "" "0" 2>&1) || rc=$?
+
+    if [[ "$rc" -ne 2 ]]; then
+        log_fail "Expected exit 2, got: $rc"
+        unset -f resolve_domain_ips
+        return 1
+    fi
+
+    if echo "$output" | grep -q "showing 10 of 12" && echo "$output" | grep -q "and 2 more"; then
+        log_pass "Preview correctly shows 10 of 12 with 'and 2 more'"
+    else
+        log_fail "Expected truncation summary missing. Got: $output"
+        unset -f resolve_domain_ips
+        return 1
+    fi
+    unset -f resolve_domain_ips
 }
 
 test_config_validation_max_failure_rate_valid() {
@@ -1003,161 +1080,6 @@ EOF
 }
 
 #===============================================================================
-# DNS FAILURE RATE THRESHOLD TESTS (Issue #216)
-#===============================================================================
-
-test_resolve_allowlist_emits_stats_sentinel() {
-    log_test "Testing resolve_allowlist_domains emits __KAPSIS_DNS_STATS__ sentinel on stdout"
-
-    source "$DNS_PIN_LIB"
-
-    # Use an IP literal (always resolves via passthrough, no DNS lookup) + a bogus domain
-    # (always fails). This makes counts deterministic regardless of CI DNS filtering.
-    local output
-    output=$(resolve_allowlist_domains "192.0.2.1,this-domain-does-not-exist-kapsis-test-xyz.invalid" 3 "dynamic" 2>/dev/null || true)
-
-    local stats_line
-    stats_line=$(echo "$output" | grep '^__KAPSIS_DNS_STATS__' || true)
-
-    if [[ -n "$stats_line" ]]; then
-        log_pass "Sentinel emitted: ${stats_line}"
-        # Verify format: __KAPSIS_DNS_STATS__ resolved=N failed=N total=N
-        if echo "$stats_line" | grep -qE '__KAPSIS_DNS_STATS__ resolved=[0-9]+ failed=[0-9]+ total=[0-9]+'; then
-            log_pass "Sentinel has expected format"
-            # IP literal always resolves; bogus domain always fails — assert exact counts
-            if echo "$stats_line" | grep -q 'resolved=1 failed=1 total=2'; then
-                log_pass "Sentinel counts correct (resolved=1 failed=1 total=2)"
-            else
-                log_fail "Unexpected counts in sentinel: ${stats_line}"
-                return 1
-            fi
-        else
-            log_fail "Sentinel format unexpected: ${stats_line}"
-            return 1
-        fi
-    else
-        log_fail "__KAPSIS_DNS_STATS__ sentinel not found in resolve_allowlist_domains output"
-        return 1
-    fi
-}
-
-test_resolve_allowlist_sentinel_stripped_from_pinned_data() {
-    log_test "Testing sentinel line is not present in data written to pinned DNS file"
-
-    source "$DNS_PIN_LIB"
-
-    local output
-    output=$(resolve_allowlist_domains "192.0.2.1" 3 "dynamic" 2>/dev/null || true)
-    # Simulate what launch-agent.sh does: strip the sentinel before writing
-    local pinned_data
-    pinned_data=$(echo "$output" | grep -v '^__KAPSIS_DNS_STATS__' || true)
-
-    local tmp_file
-    tmp_file=$(mktemp)
-    write_pinned_dns_file "$tmp_file" "$pinned_data"
-
-    if grep -q '__KAPSIS_DNS_STATS__' "$tmp_file" 2>/dev/null; then
-        log_fail "Sentinel line found in pinned DNS file (should have been stripped)"
-        rm -f "$tmp_file"
-        return 1
-    else
-        log_pass "Sentinel correctly absent from pinned DNS file"
-    fi
-
-    rm -f "$tmp_file"
-}
-
-test_dns_failure_rate_threshold_arithmetic() {
-    log_test "Testing DNS failure rate threshold arithmetic (awk calculation)"
-
-    # Simulate the rate check logic used in launch-agent.sh
-    local _rate_exceeded
-
-    # 33 failures out of 52 total = 63.5% > 50% threshold — should abort
-    _rate_exceeded=$(awk -v failed=33 -v total=52 -v threshold=0.5 \
-        'BEGIN { rate = failed / total; print (rate > threshold) ? "1" : "0" }')
-    if [[ "$_rate_exceeded" == "1" ]]; then
-        log_pass "63.5% failure rate correctly exceeds 50% threshold"
-    else
-        log_fail "63.5% failure rate should exceed 50% threshold but got: $_rate_exceeded"
-        return 1
-    fi
-
-    # 5 failures out of 52 total = 9.6% < 50% threshold — should not abort
-    _rate_exceeded=$(awk -v failed=5 -v total=52 -v threshold=0.5 \
-        'BEGIN { rate = failed / total; print (rate > threshold) ? "1" : "0" }')
-    if [[ "$_rate_exceeded" == "0" ]]; then
-        log_pass "9.6% failure rate correctly does not exceed 50% threshold"
-    else
-        log_fail "9.6% failure rate should not exceed 50% threshold but got: $_rate_exceeded"
-        return 1
-    fi
-
-    # Edge: exactly at threshold (50% = 50%) — should NOT abort (strictly greater-than)
-    _rate_exceeded=$(awk -v failed=1 -v total=2 -v threshold=0.5 \
-        'BEGIN { rate = failed / total; print (rate > threshold) ? "1" : "0" }')
-    if [[ "$_rate_exceeded" == "0" ]]; then
-        log_pass "Exactly 50% failure rate does not exceed 50% threshold (strict >)"
-    else
-        log_fail "Exactly 50% failure rate should not trigger abort (uses strict >) but got: $_rate_exceeded"
-        return 1
-    fi
-}
-
-test_dns_failure_rate_zero_tolerance_zero_failures() {
-    log_test "Testing threshold=0.0 with zero failures does not abort (0.0 is not > 0.0)"
-
-    local _rate_exceeded
-    _rate_exceeded=$(awk -v failed=0 -v total=10 -v threshold=0.0 \
-        'BEGIN { rate = failed / total; print (rate > threshold) ? "1" : "0" }')
-    if [[ "$_rate_exceeded" == "0" ]]; then
-        log_pass "Zero failures with threshold=0.0 does not abort"
-    else
-        log_fail "Zero failures should never abort (got: $_rate_exceeded)"
-        return 1
-    fi
-}
-
-test_dns_stats_zero_total_skips_rate_check() {
-    log_test "Testing failure rate check is skipped when total=0 (all wildcards — no division by zero)"
-
-    # Mirror the guard in launch-agent.sh: only call awk when total > 0
-    local _dns_total=0
-    local _rate_exceeded="0"
-    if [[ "$_dns_total" -gt 0 ]]; then
-        _rate_exceeded=$(awk -v failed=0 -v total="$_dns_total" -v threshold=0.5 \
-            'BEGIN { rate = failed / total; print (rate > threshold) ? "1" : "0" }')
-    fi
-    if [[ "$_rate_exceeded" == "0" ]]; then
-        log_pass "total=0 correctly skips rate check (no division by zero, no abort)"
-    else
-        log_fail "total=0 should not trigger abort (got: $_rate_exceeded)"
-        return 1
-    fi
-}
-
-test_dns_stats_total_excludes_wildcards() {
-    log_test "Testing KAPSIS_DNS_RESOLVE_STATS total excludes wildcards"
-
-    source "$DNS_PIN_LIB"
-    unset KAPSIS_DNS_RESOLVE_STATS
-
-    # Only wildcards — total should be 0 (wildcards skipped, not counted as failed)
-    resolve_allowlist_domains "*.github.com,*.npmjs.org" 3 "dynamic" >/dev/null 2>&1 || true
-
-    local _failed _total
-    _failed=$(echo "${KAPSIS_DNS_RESOLVE_STATS:-}" | grep -o 'failed=[0-9]*' | cut -d= -f2)
-    _total=$(echo "${KAPSIS_DNS_RESOLVE_STATS:-}" | grep -o 'total=[0-9]*' | cut -d= -f2)
-
-    if [[ "${_failed:-0}" == "0" ]] && [[ "${_total:-0}" == "0" ]]; then
-        log_pass "Wildcards excluded from total: total=0 failed=0 (no false abort)"
-    else
-        log_fail "Wildcards must not be counted in failed/total (would cause false abort): failed=${_failed:-?} total=${_total:-?}"
-        return 1
-    fi
-}
-
-#===============================================================================
 # RUN TESTS
 #===============================================================================
 
@@ -1186,13 +1108,10 @@ main() {
     run_test test_count_pinned_domains
     run_test test_get_pinned_domains
 
-    # DNS failure rate threshold tests (Issue #216)
-    run_test test_resolve_allowlist_emits_stats_sentinel
-    run_test test_resolve_allowlist_sentinel_stripped_from_pinned_data
-    run_test test_dns_failure_rate_threshold_arithmetic
-    run_test test_dns_failure_rate_zero_tolerance_zero_failures
-    run_test test_dns_stats_zero_total_skips_rate_check
-    run_test test_dns_stats_total_excludes_wildcards
+    # DNS failure rate threshold tests (Issue #216) — uses stubbed resolve_domain_ips
+    run_test test_threshold_lists_failing_domains
+    run_test test_threshold_failing_domain_preview_caps_at_10
+    run_test test_threshold_zero_concrete_domains
 
     # Property-based tests
     run_test test_resolve_returns_valid_ipv4_or_empty

--- a/tests/test-dns-pinning.sh
+++ b/tests/test-dns-pinning.sh
@@ -643,6 +643,16 @@ _stub_resolve_domain_ips() {
     fi
 }
 
+# Restore the real resolve_domain_ips after a test stubbed it. Compat.sh has a
+# load guard, so a plain `source` is a no-op once the file's been loaded; clear
+# the guard first to force re-definition of the function we replaced.
+_restore_resolve_domain_ips() {
+    unset -f resolve_domain_ips 2>/dev/null || true
+    unset _KAPSIS_COMPAT_LOADED
+    # shellcheck disable=SC1090
+    source "$COMPAT_LIB"
+}
+
 test_threshold_max_failures_triggers_exit2() {
     log_test "Testing resolve_allowlist_domains returns 2 when max_failures exceeded"
 
@@ -657,10 +667,10 @@ test_threshold_max_failures_triggers_exit2() {
         log_pass "Exit code 2 returned when failures exceed max_failures"
     else
         log_fail "Expected exit code 2, got: $rc"
-        unset -f resolve_domain_ips
+        _restore_resolve_domain_ips
         return 1
     fi
-    unset -f resolve_domain_ips
+    _restore_resolve_domain_ips
 }
 
 test_threshold_max_failure_rate_triggers_exit2() {
@@ -677,10 +687,10 @@ test_threshold_max_failure_rate_triggers_exit2() {
         log_pass "Exit code 2 returned when failure rate exceeds max_failure_rate"
     else
         log_fail "Expected exit code 2, got: $rc"
-        unset -f resolve_domain_ips
+        _restore_resolve_domain_ips
         return 1
     fi
-    unset -f resolve_domain_ips
+    _restore_resolve_domain_ips
 }
 
 test_threshold_under_limit_returns_0() {
@@ -697,10 +707,10 @@ test_threshold_under_limit_returns_0() {
         log_pass "Exit code 0 when failures are under max_failures threshold"
     else
         log_fail "Expected exit code 0, got: $rc"
-        unset -f resolve_domain_ips
+        _restore_resolve_domain_ips
         return 1
     fi
-    unset -f resolve_domain_ips
+    _restore_resolve_domain_ips
 }
 
 test_threshold_env_var_max_failures() {
@@ -718,10 +728,10 @@ test_threshold_env_var_max_failures() {
         log_pass "KAPSIS_DNS_MAX_FAILURES env var triggers exit code 2"
     else
         log_fail "Expected exit code 2, got: $rc"
-        unset -f resolve_domain_ips
+        _restore_resolve_domain_ips
         return 1
     fi
-    unset -f resolve_domain_ips
+    _restore_resolve_domain_ips
 }
 
 test_threshold_env_var_max_failure_rate() {
@@ -739,10 +749,10 @@ test_threshold_env_var_max_failure_rate() {
         log_pass "KAPSIS_DNS_MAX_FAILURE_RATE env var triggers exit code 2"
     else
         log_fail "Expected exit code 2, got: $rc"
-        unset -f resolve_domain_ips
+        _restore_resolve_domain_ips
         return 1
     fi
-    unset -f resolve_domain_ips
+    _restore_resolve_domain_ips
 }
 
 test_threshold_no_limit_set_returns_0() {
@@ -759,10 +769,10 @@ test_threshold_no_limit_set_returns_0() {
         log_pass "No threshold — failures tolerated, exit code 0"
     else
         log_fail "Expected exit code 0, got: $rc"
-        unset -f resolve_domain_ips
+        _restore_resolve_domain_ips
         return 1
     fi
-    unset -f resolve_domain_ips
+    _restore_resolve_domain_ips
 }
 
 test_threshold_zero_concrete_domains() {
@@ -779,10 +789,10 @@ test_threshold_zero_concrete_domains() {
         log_pass "All-wildcard list with strict thresholds does not abort"
     else
         log_fail "Expected exit code 0 for all-wildcard list, got: $rc"
-        unset -f resolve_domain_ips
+        _restore_resolve_domain_ips
         return 1
     fi
-    unset -f resolve_domain_ips
+    _restore_resolve_domain_ips
 }
 
 test_threshold_lists_failing_domains() {
@@ -798,7 +808,7 @@ test_threshold_lists_failing_domains() {
 
     if [[ "$rc" -ne 2 ]]; then
         log_fail "Expected exit 2, got: $rc"
-        unset -f resolve_domain_ips
+        _restore_resolve_domain_ips
         return 1
     fi
 
@@ -806,10 +816,10 @@ test_threshold_lists_failing_domains() {
         log_pass "Both failing domains listed in abort output"
     else
         log_fail "Failing domains not listed in output. Got: $output"
-        unset -f resolve_domain_ips
+        _restore_resolve_domain_ips
         return 1
     fi
-    unset -f resolve_domain_ips
+    _restore_resolve_domain_ips
 }
 
 test_threshold_failing_domain_preview_caps_at_10() {
@@ -825,7 +835,7 @@ test_threshold_failing_domain_preview_caps_at_10() {
 
     if [[ "$rc" -ne 2 ]]; then
         log_fail "Expected exit 2, got: $rc"
-        unset -f resolve_domain_ips
+        _restore_resolve_domain_ips
         return 1
     fi
 
@@ -833,10 +843,10 @@ test_threshold_failing_domain_preview_caps_at_10() {
         log_pass "Preview correctly shows 10 of 12 with 'and 2 more'"
     else
         log_fail "Expected truncation summary missing. Got: $output"
-        unset -f resolve_domain_ips
+        _restore_resolve_domain_ips
         return 1
     fi
-    unset -f resolve_domain_ips
+    _restore_resolve_domain_ips
 }
 
 test_config_validation_max_failure_rate_valid() {

--- a/tests/test-dns-pinning.sh
+++ b/tests/test-dns-pinning.sh
@@ -1002,6 +1002,74 @@ test_threshold_listing_omits_resolved_domains() {
     _restore_resolve_domain_ips
 }
 
+test_threshold_wins_over_fallback_abort() {
+    log_test "Testing threshold breach (rc=2) takes precedence over fallback=abort (rc=1)"
+
+    source "$DNS_PIN_LIB"
+    resolve_domain_ips() { _stub_resolve_domain_ips "$1"; }
+    trap '_restore_resolve_domain_ips' RETURN
+
+    # fallback=abort would normally return 1 on any failure; threshold breach
+    # should short-circuit to 2 first.
+    local rc=0
+    resolve_allowlist_domains "fail-a.test" 1 "abort" "" "0" >/dev/null 2>&1 || rc=$?
+
+    if [[ "$rc" -eq 2 ]]; then
+        log_pass "Threshold breach correctly preempts fallback=abort"
+    else
+        log_fail "Expected rc=2 (threshold wins), got: $rc"
+        _restore_resolve_domain_ips
+        return 1
+    fi
+    _restore_resolve_domain_ips
+}
+
+test_threshold_skip_check_does_not_relax_resolver_rc() {
+    log_test "Testing KAPSIS_SKIP_DNS_CHECK does NOT change resolver rc (bypass is caller policy)"
+
+    source "$DNS_PIN_LIB"
+    resolve_domain_ips() { _stub_resolve_domain_ips "$1"; }
+    trap '_restore_resolve_domain_ips' RETURN
+
+    # The bypass env var lives at the launch-agent.sh dispatch layer; the
+    # resolver itself must always emit rc=2 when threshold is breached so the
+    # caller has full information to decide.
+    local rc=0
+    KAPSIS_SKIP_DNS_CHECK=true \
+        resolve_allowlist_domains "fail-a.test" 1 "dynamic" "" "0" >/dev/null 2>&1 || rc=$?
+
+    if [[ "$rc" -eq 2 ]]; then
+        log_pass "Resolver rc=2 unaffected by KAPSIS_SKIP_DNS_CHECK (caller decides)"
+    else
+        log_fail "Expected rc=2 regardless of bypass, got: $rc"
+        _restore_resolve_domain_ips
+        return 1
+    fi
+    _restore_resolve_domain_ips
+}
+
+test_launch_agent_bypass_dispatch_warns_not_aborts() {
+    log_test "Testing launch-agent.sh dispatch: KAPSIS_SKIP_DNS_CHECK=true on rc=2 warns instead of aborting"
+
+    # Verify the dispatch source has both branches and warns under bypass.
+    # This is a static check — the full integration runs in container tests.
+    local launch_script="$KAPSIS_ROOT/scripts/launch-agent.sh"
+
+    if ! grep -A 5 'dns_pin_rc.*-eq 2' "$launch_script" | grep -q 'KAPSIS_SKIP_DNS_CHECK'; then
+        log_fail "launch-agent.sh rc=2 dispatch missing KAPSIS_SKIP_DNS_CHECK branch"
+        return 1
+    fi
+    if ! grep -A 8 'dns_pin_rc.*-eq 2' "$launch_script" | grep -q 'log_warn.*KAPSIS_SKIP_DNS_CHECK'; then
+        log_fail "Bypass branch should log_warn, not silently proceed"
+        return 1
+    fi
+    if ! grep -A 12 'dns_pin_rc.*-eq 2' "$launch_script" | grep -q 'exit 1'; then
+        log_fail "Non-bypass branch should exit 1"
+        return 1
+    fi
+    log_pass "launch-agent.sh has both bypass-warn and non-bypass-abort branches"
+}
+
 test_threshold_invalid_env_var_ignored() {
     log_test "Testing invalid KAPSIS_DNS_MAX_FAILURES env var is ignored, not aborted"
 
@@ -1305,6 +1373,9 @@ main() {
     run_test test_threshold_preview_truncation_at_exactly_11
     run_test test_threshold_listing_omits_resolved_domains
     run_test test_threshold_invalid_env_var_ignored
+    run_test test_threshold_wins_over_fallback_abort
+    run_test test_threshold_skip_check_does_not_relax_resolver_rc
+    run_test test_launch_agent_bypass_dispatch_warns_not_aborts
 
     # Property-based tests
     run_test test_resolve_returns_valid_ipv4_or_empty

--- a/tests/test-dns-pinning.sh
+++ b/tests/test-dns-pinning.sh
@@ -658,6 +658,7 @@ test_threshold_max_failures_triggers_exit2() {
 
     source "$DNS_PIN_LIB"
     resolve_domain_ips() { _stub_resolve_domain_ips "$1"; }
+    trap '_restore_resolve_domain_ips' RETURN
 
     # 2 failures, max_failures=1
     local rc=0
@@ -678,6 +679,7 @@ test_threshold_max_failure_rate_triggers_exit2() {
 
     source "$DNS_PIN_LIB"
     resolve_domain_ips() { _stub_resolve_domain_ips "$1"; }
+    trap '_restore_resolve_domain_ips' RETURN
 
     # 2/2 = 100% > 0.4
     local rc=0
@@ -698,6 +700,7 @@ test_threshold_under_limit_returns_0() {
 
     source "$DNS_PIN_LIB"
     resolve_domain_ips() { _stub_resolve_domain_ips "$1"; }
+    trap '_restore_resolve_domain_ips' RETURN
 
     # 2 failures, max_failures=100 (well under)
     local rc=0
@@ -718,6 +721,7 @@ test_threshold_env_var_max_failures() {
 
     source "$DNS_PIN_LIB"
     resolve_domain_ips() { _stub_resolve_domain_ips "$1"; }
+    trap '_restore_resolve_domain_ips' RETURN
 
     export KAPSIS_DNS_MAX_FAILURES=1
     local rc=0
@@ -739,6 +743,7 @@ test_threshold_env_var_max_failure_rate() {
 
     source "$DNS_PIN_LIB"
     resolve_domain_ips() { _stub_resolve_domain_ips "$1"; }
+    trap '_restore_resolve_domain_ips' RETURN
 
     export KAPSIS_DNS_MAX_FAILURE_RATE=0.1
     local rc=0
@@ -760,6 +765,7 @@ test_threshold_no_limit_set_returns_0() {
 
     source "$DNS_PIN_LIB"
     resolve_domain_ips() { _stub_resolve_domain_ips "$1"; }
+    trap '_restore_resolve_domain_ips' RETURN
 
     unset KAPSIS_DNS_MAX_FAILURES KAPSIS_DNS_MAX_FAILURE_RATE
     local rc=0
@@ -780,6 +786,7 @@ test_threshold_zero_concrete_domains() {
 
     source "$DNS_PIN_LIB"
     resolve_domain_ips() { _stub_resolve_domain_ips "$1"; }
+    trap '_restore_resolve_domain_ips' RETURN
 
     # All wildcards — no resolved, no failed, no divide-by-zero, no abort.
     local rc=0
@@ -800,6 +807,7 @@ test_threshold_lists_failing_domains() {
 
     source "$DNS_PIN_LIB"
     resolve_domain_ips() { _stub_resolve_domain_ips "$1"; }
+    trap '_restore_resolve_domain_ips' RETURN
 
     local output rc=0
     output=$(resolve_allowlist_domains \
@@ -827,6 +835,7 @@ test_threshold_failing_domain_preview_caps_at_10() {
 
     source "$DNS_PIN_LIB"
     resolve_domain_ips() { _stub_resolve_domain_ips "$1"; }
+    trap '_restore_resolve_domain_ips' RETURN
 
     # 12 failures — preview should show 10 with "and 2 more"
     local domain_list="fail-1.test,fail-2.test,fail-3.test,fail-4.test,fail-5.test,fail-6.test,fail-7.test,fail-8.test,fail-9.test,fail-10.test,fail-11.test,fail-12.test"
@@ -843,6 +852,173 @@ test_threshold_failing_domain_preview_caps_at_10() {
         log_pass "Preview correctly shows 10 of 12 with 'and 2 more'"
     else
         log_fail "Expected truncation summary missing. Got: $output"
+        _restore_resolve_domain_ips
+        return 1
+    fi
+    _restore_resolve_domain_ips
+}
+
+test_threshold_rate_at_boundary_passes() {
+    log_test "Testing rate exactly at threshold does not abort (strict > comparison)"
+
+    source "$DNS_PIN_LIB"
+    resolve_domain_ips() { _stub_resolve_domain_ips "$1"; }
+    trap '_restore_resolve_domain_ips' RETURN
+
+    # 1 fail / 2 total = 0.5; threshold = 0.5; strict > means rc=0
+    local rc=0
+    resolve_allowlist_domains "ok.test,fail-a.test" 1 "dynamic" "0.5" "" >/dev/null 2>&1 || rc=$?
+
+    if [[ "$rc" -eq 0 ]]; then
+        log_pass "rate=0.5 with threshold=0.5 does not abort"
+    else
+        log_fail "Expected rc=0 at boundary, got: $rc"
+        _restore_resolve_domain_ips
+        return 1
+    fi
+    _restore_resolve_domain_ips
+}
+
+test_threshold_rate_zero_with_no_failures_passes() {
+    log_test "Testing max_failure_rate=0.0 with zero failures does not abort"
+
+    source "$DNS_PIN_LIB"
+    resolve_domain_ips() { _stub_resolve_domain_ips "$1"; }
+    trap '_restore_resolve_domain_ips' RETURN
+
+    # All resolve, max_failure_rate=0.0 — 0/N = 0.0, not > 0.0
+    local rc=0
+    resolve_allowlist_domains "ok-1.test,ok-2.test,ok-3.test" 1 "dynamic" "0.0" "" >/dev/null 2>&1 || rc=$?
+
+    if [[ "$rc" -eq 0 ]]; then
+        log_pass "max_failure_rate=0.0 with zero failures does not abort"
+    else
+        log_fail "Expected rc=0, got: $rc"
+        _restore_resolve_domain_ips
+        return 1
+    fi
+    _restore_resolve_domain_ips
+}
+
+test_threshold_wildcards_excluded_from_count() {
+    log_test "Testing wildcards excluded from threshold denominator"
+
+    source "$DNS_PIN_LIB"
+    resolve_domain_ips() { _stub_resolve_domain_ips "$1"; }
+    trap '_restore_resolve_domain_ips' RETURN
+
+    # 3 wildcards + 1 concrete failure. If wildcards counted, 1/4 = 25% < 50%, would pass.
+    # If wildcards excluded (correct), 1/1 = 100% > 50%, must abort.
+    local rc=0
+    resolve_allowlist_domains "*.a.test,*.b.test,*.c.test,fail-x.test" 1 "dynamic" "0.5" "" >/dev/null 2>&1 || rc=$?
+
+    if [[ "$rc" -eq 2 ]]; then
+        log_pass "Wildcards excluded from denominator (1/1 = 100% triggers abort)"
+    else
+        log_fail "Expected rc=2 (wildcards excluded), got: $rc — wildcards may be counted"
+        _restore_resolve_domain_ips
+        return 1
+    fi
+    _restore_resolve_domain_ips
+}
+
+test_threshold_preview_no_truncation_at_exactly_10() {
+    log_test "Testing preview at exactly 10 failures shows no 'and N more' summary"
+
+    source "$DNS_PIN_LIB"
+    resolve_domain_ips() { _stub_resolve_domain_ips "$1"; }
+    trap '_restore_resolve_domain_ips' RETURN
+
+    local domain_list="fail-1.test,fail-2.test,fail-3.test,fail-4.test,fail-5.test,fail-6.test,fail-7.test,fail-8.test,fail-9.test,fail-10.test"
+    local output rc=0
+    output=$(resolve_allowlist_domains "$domain_list" 1 "dynamic" "" "0" 2>&1) || rc=$?
+
+    if [[ "$rc" -ne 2 ]]; then
+        log_fail "Expected rc=2, got: $rc"
+        _restore_resolve_domain_ips
+        return 1
+    fi
+
+    if echo "$output" | grep -q "showing 10 of 10" && ! echo "$output" | grep -q "and .* more"; then
+        log_pass "Exactly 10 failures: shows all 10, no 'and N more' line"
+    else
+        log_fail "Boundary failure at N=10: got '$output'"
+        _restore_resolve_domain_ips
+        return 1
+    fi
+    _restore_resolve_domain_ips
+}
+
+test_threshold_preview_truncation_at_exactly_11() {
+    log_test "Testing preview at 11 failures shows 'and 1 more' (off-by-one boundary)"
+
+    source "$DNS_PIN_LIB"
+    resolve_domain_ips() { _stub_resolve_domain_ips "$1"; }
+    trap '_restore_resolve_domain_ips' RETURN
+
+    local domain_list="fail-1.test,fail-2.test,fail-3.test,fail-4.test,fail-5.test,fail-6.test,fail-7.test,fail-8.test,fail-9.test,fail-10.test,fail-11.test"
+    local output rc=0
+    output=$(resolve_allowlist_domains "$domain_list" 1 "dynamic" "" "0" 2>&1) || rc=$?
+
+    if [[ "$rc" -ne 2 ]]; then
+        log_fail "Expected rc=2, got: $rc"
+        _restore_resolve_domain_ips
+        return 1
+    fi
+
+    if echo "$output" | grep -q "showing 10 of 11" && echo "$output" | grep -q "and 1 more"; then
+        log_pass "11 failures: shows 10 of 11 plus 'and 1 more'"
+    else
+        log_fail "Off-by-one at N=11: got '$output'"
+        _restore_resolve_domain_ips
+        return 1
+    fi
+    _restore_resolve_domain_ips
+}
+
+test_threshold_listing_omits_resolved_domains() {
+    log_test "Testing failing-domain listing does not include successfully resolved domains"
+
+    source "$DNS_PIN_LIB"
+    resolve_domain_ips() { _stub_resolve_domain_ips "$1"; }
+    trap '_restore_resolve_domain_ips' RETURN
+
+    local output rc=0
+    output=$(resolve_allowlist_domains "ok-good.test,fail-a.test" 1 "dynamic" "" "0" 2>&1) || rc=$?
+
+    if [[ "$rc" -ne 2 ]]; then
+        log_fail "Expected rc=2, got: $rc"
+        _restore_resolve_domain_ips
+        return 1
+    fi
+
+    if echo "$output" | grep -q "  - fail-a.test" && ! echo "$output" | grep -q "  - ok-good.test"; then
+        log_pass "Listing includes failed domain only, not the resolved one"
+    else
+        log_fail "Listing has wrong contents: $output"
+        _restore_resolve_domain_ips
+        return 1
+    fi
+    _restore_resolve_domain_ips
+}
+
+test_threshold_invalid_env_var_ignored() {
+    log_test "Testing invalid KAPSIS_DNS_MAX_FAILURES env var is ignored, not aborted"
+
+    source "$DNS_PIN_LIB"
+    resolve_domain_ips() { _stub_resolve_domain_ips "$1"; }
+    trap '_restore_resolve_domain_ips' RETURN
+
+    # Non-numeric value — should be rejected with log_error, threshold disabled
+    export KAPSIS_DNS_MAX_FAILURES="not-a-number"
+    local rc=0
+    resolve_allowlist_domains "fail-a.test,fail-b.test" 1 "dynamic" >/dev/null 2>&1 || rc=$?
+    unset KAPSIS_DNS_MAX_FAILURES
+
+    if [[ "$rc" -eq 0 ]]; then
+        log_pass "Non-numeric env var ignored (rc=0, no false abort)"
+    else
+        log_fail "Expected rc=0 (invalid input ignored), got: $rc"
         _restore_resolve_domain_ips
         return 1
     fi
@@ -1122,6 +1298,13 @@ main() {
     run_test test_threshold_lists_failing_domains
     run_test test_threshold_failing_domain_preview_caps_at_10
     run_test test_threshold_zero_concrete_domains
+    run_test test_threshold_rate_at_boundary_passes
+    run_test test_threshold_rate_zero_with_no_failures_passes
+    run_test test_threshold_wildcards_excluded_from_count
+    run_test test_threshold_preview_no_truncation_at_exactly_10
+    run_test test_threshold_preview_truncation_at_exactly_11
+    run_test test_threshold_listing_omits_resolved_domains
+    run_test test_threshold_invalid_env_var_ignored
 
     # Property-based tests
     run_test test_resolve_returns_valid_ipv4_or_empty


### PR DESCRIPTION
## Summary

Issue #216 was first merged to main with a `__KAPSIS_DNS_STATS__` stdout sentinel emitted from `resolve_allowlist_domains`, parsed and stripped by every caller. This PR replaces that with a distinct-return-code design (taken from #311 — selected as best by ensemble review of 7 candidate PRs) and folds in worthwhile ideas from the other PRs.

The user-facing contract is unchanged: `dns_pinning.max_failure_rate`, `dns_pinning.max_failures`, `KAPSIS_SKIP_DNS_CHECK`, opt-in defaults.

## Changes

**Design (replaces main's sentinel mechanism)**
- `resolve_allowlist_domains` now signals via return code: `0` success, `1` `fallback: abort`, `2` threshold breach
- Threshold logic lives next to its data, no more grep filtering at every call site
- `launch-agent.sh` distinguishes failure modes per-rc and honors `KAPSIS_SKIP_DNS_CHECK` only on rc=2
- `config-verifier.sh` validates `max_failure_rate` (0.0–1.0) and `max_failures` (positive int)

**Enhancements borrowed from other PRs**
- **List failing domains in the abort message** (#308) — caller no longer has to scroll back through `log_warn` lines. Caps at 10 with "and N more" summary.
- **Stubbed `resolve_domain_ips` in tests** (#314) — threshold tests are now deterministic. No more `log_skip` on flaky CI DNS, no real network calls. Restore helper re-sources `compat.sh` after each stub.
- **Zero-concrete-domains edge case test** (#313, #315) — explicitly verifies all-wildcard lists don't divide by zero or false-trigger.
- **Doc updates** (`CONFIG-REFERENCE.md`, `NETWORK-ISOLATION.md`) — note the failing-domain listing and the rc-based mechanism.

## Commits

- `refactor(dns): replace #216 sentinel design with distinct return code`
- `feat(dns): list failing domains in threshold abort message`
- `test(dns): stub resolve_domain_ips for deterministic threshold tests`
- `docs(dns): note failing-domain listing and rc-based threshold mechanism`
- `test(dns): restore real resolve_domain_ips after stubbing`

## Test plan

- [x] `bash -n` clean on all modified scripts (shellcheck unavailable in this env)
- [x] `bash tests/test-dns-pinning.sh` — 38/38 pass (was 33 before, +5 net; sentinel tests removed, 3 stubbed threshold tests + listing/preview tests added)
- [x] `bash tests/test-config-verifier.sh` — 22/22 pass
- [ ] Container tests (require Podman) — skipped here
- [ ] CI shellcheck

## Tradeoffs

Closes #311 effectively (this branch supersedes it) and reverts main's #216 sentinel implementation in favor of #311's design. Functionally equivalent to the user; the difference is mechanical. If you'd rather keep main's sentinel mechanism, close this PR; the failing-domain listing, deterministic tests, and zero-concrete-domains test could be split into a smaller PR on top of main's existing implementation.

https://claude.ai/code/session_01BZPJRuJawHsdEzwTuYjoTn

---
_Generated by [Claude Code](https://claude.ai/code/session_01BZPJRuJawHsdEzwTuYjoTn)_