### PR TITLE
feat(conversations): persist agent JSONL via shared host volume (Issue #265)

### DIFF
--- a/scripts/kapsis-cleanup.sh
+++ b/scripts/kapsis-cleanup.sh
@@ -49,6 +49,7 @@ LOG_DIR="${KAPSIS_LOG_DIR:-$KAPSIS_DIR/logs}"
 SANDBOX_DIR="${KAPSIS_SANDBOX_DIR:-$HOME/.ai-sandboxes}"
 SANITIZED_GIT_DIR="${KAPSIS_SANITIZED_GIT_DIR:-$KAPSIS_DIR/sanitized-git}"
 AUDIT_DIR="${KAPSIS_AUDIT_DIR:-$KAPSIS_DIR/audit}"
+CONVERSATIONS_DIR="${KAPSIS_CONVERSATIONS_BASE_DIR:-$KAPSIS_DIR/conversations}"
 
 # Options
 DRY_RUN=false
@@ -115,6 +116,7 @@ WHAT GETS CLEANED:
     Status files    Completed status files in ~/.kapsis/status/
     Sanitized git   Temporary git dirs in ~/.kapsis/sanitized-git/
     Audit files     Old audit trail files in ~/.kapsis/audit/ (TTL-based or --all)
+    Conversations   Old agent conversation dirs in ~/.kapsis/conversations/ (7-day TTL or --all)
     Containers      Stopped kapsis-* containers (with --containers)
     Volumes         Build cache volumes (with --volumes)
     Images          Kapsis container images (with --images or --all)
@@ -848,6 +850,81 @@ clean_audit() {
     fi
 }
 
+# Clean per-agent conversation directories (Issue #265)
+# Removes directories older than KAPSIS_DEFAULT_CONVERSATIONS_TTL_DAYS (default 7 days).
+# In --all mode removes everything regardless of age.
+clean_conversations() {
+    section "Conversation Directories"
+
+    if [[ ! -d "$CONVERSATIONS_DIR" ]]; then
+        echo "  No conversations directory found"
+        return
+    fi
+
+    # Refuse to traverse a symlinked top-level dir (see clean_worktrees).
+    if [[ -L "$CONVERSATIONS_DIR" ]]; then
+        echo -e "  ${YELLOW}Conversations dir is a symlink; refusing to clean${NC}"
+        return
+    fi
+
+    local count=0
+    local total_size=0
+    local ttl_days="${KAPSIS_DEFAULT_CONVERSATIONS_TTL_DAYS:-7}"
+    local now
+    now=$(date +%s)
+    local ttl_seconds=$((ttl_days * 86400))
+
+    for conv_dir in "$CONVERSATIONS_DIR"/*/; do
+        [[ -d "$conv_dir" ]] || continue
+        # Security: skip symlinks to prevent following attacks (see clean_sandboxes).
+        [[ -L "$conv_dir" ]] && continue
+        local name
+        name=$(basename "$conv_dir")
+
+        # Apply project/agent filter when set
+        if [[ -n "$PROJECT_FILTER" ]] && [[ "$name" != *"${PROJECT_FILTER}"* ]]; then
+            continue
+        fi
+        if [[ -n "$AGENT_FILTER" ]] && [[ "$name" != *"${AGENT_FILTER}"* ]]; then
+            continue
+        fi
+
+        # In --all mode clean everything; otherwise only expire past TTL
+        if [[ "$CLEAN_ALL" != "true" ]]; then
+            local mtime
+            mtime=$(get_file_mtime "$conv_dir" 2>/dev/null) || continue
+            [[ -z "$mtime" ]] && continue
+            local age=$((now - mtime))
+            if [[ "$age" -le "$ttl_seconds" ]]; then
+                continue
+            fi
+        fi
+
+        local size
+        size=$(get_dir_size "$conv_dir")
+        local size_human
+        size_human=$(format_size "$size")
+
+        if [[ "$DRY_RUN" == "true" ]]; then
+            print_item "conversation" "$name" "$size_human"
+        else
+            rm -rf "$conv_dir"
+            print_item "conversation" "$name" "$size_human"
+        fi
+
+        ((total_size += size)) || true
+        ((count++)) || true
+    done
+
+    if (( count == 0 )); then
+        echo "  No expired conversation directories to clean"
+    else
+        echo -e "  ${BOLD}Total: $count conversation directories ($(format_size $total_size))${NC}"
+        ((TOTAL_SIZE_FREED += total_size)) || true
+        ((ITEMS_CLEANED += count)) || true
+    fi
+}
+
 # Clean SSH cache
 clean_ssh_cache() {
     section "SSH Host Key Cache"
@@ -1425,6 +1502,7 @@ main() {
         clean_status
         clean_sanitized_git
         clean_audit
+        clean_conversations
     elif [[ "$CLEAN_WORKTREES" == "true" ]]; then
         # Selective: `--worktrees` alone -- run only clean_worktrees.
         # Skipped when --all (already handled by the default block above).

--- a/scripts/launch-agent.sh
+++ b/scripts/launch-agent.sh
@@ -1268,6 +1268,14 @@ add_common_volume_mounts() {
         VOLUME_MOUNTS+=("-v" "${audit_dir}:${CONTAINER_AUDIT_PATH}")
     fi
 
+    # Conversation JSONL (post-mortem preservation — Issue #265)
+    # Mounted per-agent so conversation history survives container death (OOM,
+    # crash, rm -f). Bind mount outlives the container overlay the same way
+    # /kapsis-status does. TTL-based cleanup in kapsis-cleanup (default 7 days).
+    local conv_dir="${KAPSIS_CONVERSATIONS_DIR:-$HOME/.kapsis/conversations/${AGENT_ID}}"
+    ensure_dir "$conv_dir"
+    VOLUME_MOUNTS+=("-v" "${conv_dir}:${CONTAINER_CONVERSATIONS_PATH}")
+
     # Maven repository (isolated per agent)
     VOLUME_MOUNTS+=("-v" "kapsis-${AGENT_ID}-m2:/home/developer/.m2/repository")
 

--- a/scripts/lib/constants.sh
+++ b/scripts/lib/constants.sh
@@ -349,6 +349,21 @@ readonly KAPSIS_STATUS_VOLUME_SUFFIX="-status"
 readonly KAPSIS_DEFAULT_STATUS_SYNC_INTERVAL=5
 
 #===============================================================================
+# CONVERSATION PERSISTENCE (Issue #265)
+#
+# Agent conversation JSONL is mounted from a per-agent host directory into the
+# container so it survives container death (OOM, crash, rm -f). Same pattern
+# as /kapsis-status — a bind-mount that outlives the container overlay.
+# Per-agent isolation: ~/.kapsis/conversations/<agent-id>/
+#===============================================================================
+
+# Container mount point for Claude Code conversation JSONL files
+readonly CONTAINER_CONVERSATIONS_PATH="/home/developer/.claude/conversations"
+
+# Default TTL (days) for conversation directory cleanup in kapsis-cleanup
+readonly KAPSIS_DEFAULT_CONVERSATIONS_TTL_DAYS=7
+
+#===============================================================================
 # SLEEP PREVENTION (Issue #276)
 #
 # On macOS, preventing the system from sleeping while an agent is running


### PR DESCRIPTION
## Summary

Closes #265

When a Kapsis container is killed (OOM, crash, `podman rm -f`), all conversation JSONL written inside the container overlay is permanently lost — making post-mortem debugging impossible. This PR mounts a host directory into the container so conversation history survives container death.

- **Mount** `~/.kapsis/conversations/<agent-id>/` into each container at `/home/developer/.claude/conversations` — the bind mount outlives the container overlay, exactly like `/kapsis-status` and `/kapsis-audit`
- **Cleanup** — adds `clean_conversations()` to `kapsis-cleanup` with a 7-day TTL (configurable via `KAPSIS_DEFAULT_CONVERSATIONS_TTL_DAYS`); runs automatically in the default cleanup pass alongside `clean_audit`
- **Isolation** — per-agent subdirectory (`<agent-id>/`) prevents one agent from reading another's conversations

## Design decisions

| Question | Decision | Rationale |
|---|---|---|
| Bind mount vs named volume? | Bind mount | Conversations are not crash-critical like status writes; sleep prevention already guards virtio-fs; avoids needing a sync worker |
| Per-agent or shared dir? | Per-agent (`~/.kapsis/conversations/<agent-id>/`) | Mirrors the per-agent build-cache volume pattern; easy to filter in cleanup |
| TTL? | 7 days default | Same as worktree max-age; long enough for post-mortem, short enough to prevent unbounded growth |

## Files changed

- `scripts/lib/constants.sh` — `CONTAINER_CONVERSATIONS_PATH`, `KAPSIS_DEFAULT_CONVERSATIONS_TTL_DAYS`
- `scripts/launch-agent.sh` — bind mount wired into `add_common_volume_mounts()`
- `scripts/kapsis-cleanup.sh` — `CONVERSATIONS_DIR`, `clean_conversations()`, wired into default cleanup pass

## Test plan

- [ ] Launch agent, confirm `~/.kapsis/conversations/<agent-id>/` is created on host and populated during the session
- [ ] Kill container mid-session (`podman rm -f <container>`), confirm JSONL files remain on host
- [ ] `kapsis-cleanup --dry-run` shows conversation directories older than 7 days
- [ ] `kapsis-cleanup --all` removes all conversation directories
- [ ] `bash -n` syntax check passes on all three modified files

https://claude.ai/code/session_01D68NhjR2rWvN4XU3CP7HrT

---
_Generated by [Claude Code](https://claude.ai/code/session_01D68NhjR2rWvN4XU3CP7HrT)_