### PR TITLE
feat(plugins): inject Claude Code plugin hooks into settings.local.json

### DIFF
--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -1,0 +1,120 @@
+# Claude Code plugin support
+
+Kapsis bypasses Claude Code's native plugin loader so the container can run in `--print`/headless mode safely. As a side effect, plugin hooks (and their LSP servers, skills, etc.) are never wired up automatically. This page describes the opt-in mechanism Kapsis provides to bring **plugin hooks** back into the container.
+
+## What gets loaded
+
+For each user-installed Claude Code plugin that passes both filters below, Kapsis merges that plugin's `hooks/hooks.json` into `~/.claude/settings.local.json` **inside the container**, with `${CLAUDE_PLUGIN_ROOT}` substituted to the plugin's container-side installPath. This places plugin hooks next to Kapsis's own status/gist hooks in the same merged hook chain.
+
+The two filters:
+
+1. **Host-enabled.** The plugin id must be `true` in the host's `~/.claude/settings.json::enabledPlugins`. If you've disabled a plugin on the host, it stays off in the container — there is no override.
+2. **Whitelist (optional).** If `agent.plugin_whitelist` is set in the kapsis YAML config and non-empty, the plugin id must be in it. If unset or `[]`, this check is a no-op (allow all host-enabled plugins).
+
+Both filters must pass.
+
+## Configuration
+
+```yaml
+agent:
+  type: claude-cli
+
+  # Master switch — default true for claude/claude-cli/claude-code agents,
+  # false for everything else.
+  install_plugins: true
+
+  # OPTIONAL whitelist. Plugin ids match the keys in
+  # ~/.claude/plugins/installed_plugins.json::plugins, which use the
+  # `<plugin>@<marketplace>` form.
+  #
+  # Unset or [] = allow all host-enabled plugins (the default).
+  plugin_whitelist:
+    - "deeperdive-java-linter@deeperdive"
+    - "deeperdive-java-code-quality@deeperdive"
+```
+
+YAML keys are plumbed to in-container env vars by `launch-agent.sh`:
+
+| YAML key | Env var | Default |
+|---|---|---|
+| `agent.install_plugins` | `KAPSIS_INSTALL_PLUGINS` (`true`/`false`) | `true` for claude-cli, `false` otherwise |
+| `agent.plugin_whitelist` | `KAPSIS_PLUGIN_WHITELIST` (JSON-encoded array) | `[]` (allow all) |
+
+### Why a whitelist?
+
+The host typically has many plugins installed. Loading all of them into every agent container silently widens the trust boundary — any hook on `PostToolUse` runs on every tool call the agent makes. The whitelist lets operators (especially for unattended bots) restrict the in-container plugin surface to a vetted set, regardless of what's installed on the host.
+
+For interactive `kapsis ...` runs from a developer's own machine, leaving the whitelist unset (allow all host-enabled plugins) is usually the right default.
+
+### Runtime override
+
+`KAPSIS_PLUGIN_WHITELIST` can also be passed via the kapsis CLI's `--env` / through the launching shell — useful for one-off experiments without editing YAML. Same JSON-array format.
+
+## `${CLAUDE_PLUGIN_ROOT}` substitution
+
+Plugin hook commands typically look like:
+
+```json
+{
+  "type": "command",
+  "command": "${CLAUDE_PLUGIN_ROOT}/scripts/ensure-lsp.sh",
+  "timeout": 60
+}
+```
+
+Claude Code's own plugin loader would expand `${CLAUDE_PLUGIN_ROOT}` per-hook at execution time. Since Kapsis bypasses that loader, **`inject-plugin-hooks.sh` substitutes the placeholder at merge time** with the plugin's already-rewritten installPath (see `rewrite-plugin-paths.sh`). What lands in `settings.local.json` is a fully concrete command string — no env var dependency, no late binding.
+
+Only the literal token `${CLAUDE_PLUGIN_ROOT}` is substituted. Other `${...}` references in commands (e.g. `$HOME`) are left alone for the shell to expand at hook execution.
+
+## Order of operations
+
+Inside the container, the boot sequence is:
+
+1. `rewrite-plugin-paths.sh` — rewrite host paths in `installed_plugins.json` → container paths.
+2. `inject-status-hooks.sh::inject_claude_hooks` — write Kapsis status/gist/stop hooks into `~/.claude/settings.local.json`.
+3. `inject-plugin-hooks.sh::inject_plugin_hooks` — append filtered plugin hooks into the same file.
+
+Kapsis hooks therefore precede plugin hooks within each event's array. This matters for `PostToolUse`: `kapsis-status-hook.sh` reads `/workspace/.kapsis/gist.txt` to populate the status JSON, and `kapsis-gist-hook.sh` writes that file. Plugin hooks that mutate gist.txt would race the status hook otherwise.
+
+## Idempotency
+
+`inject-plugin-hooks.sh` dedupes by command string. Running the injection twice on the same `settings.local.json` produces byte-identical output. This makes it safe to call from `setup_status_tracking` on every container start, even when re-entering a recovered worktree.
+
+## Failure modes
+
+- **Plugin's `hooks/hooks.json` missing** — silently skipped, debug-logged.
+- **`hooks.json` malformed or missing top-level `hooks` object** — logged at WARN, other plugins still processed.
+- **Whitelist entry references an uninstalled plugin** — silently skipped (no error).
+- **`jq` not installed in image** — logged at WARN, injection aborts gracefully (the agent still runs, just without plugin hooks).
+- **`KAPSIS_PLUGIN_WHITELIST` is not a valid JSON array** — logged at WARN, treated as empty (= allow all host-enabled).
+
+## What is NOT injected
+
+Only **hooks** are merged. The following plugin surfaces are NOT brought in by this mechanism:
+
+- Plugin **skills** (`<installPath>/skills/`) — accessed via `/<plugin>:<skill>` slash commands, normally registered by Claude Code's plugin loader at session start. Not exposed yet.
+- Plugin **slash commands** (`<installPath>/commands/`) — same loader path.
+- Plugin **agents** (`<installPath>/agents/`).
+- Plugin **MCP servers** declared in `.claude-plugin/plugin.json`. Kapsis already accepts `--mcp-config` separately; merging plugin MCPs is a future concern.
+
+If a plugin's hook references its own skills/commands by relative path, that part works because the hook's command is now anchored to the plugin's concrete installPath inside the container.
+
+## Worked example: just `deeperdive-java-linter` in the bot
+
+```yaml
+# slack-bot-agent.yaml — keep the in-container plugin surface minimal
+agent:
+  type: claude-cli
+  install_plugins: true
+  plugin_whitelist:
+    - "deeperdive-java-linter@deeperdive"
+```
+
+After container start, `~/.claude/settings.local.json::hooks.PostToolUse` will contain (in order):
+
+1. Kapsis gist hook (matcher `*`) — if `inject_gist: true`
+2. Kapsis status hook (matcher `*`)
+3. `deeperdive-java-linter`'s `Edit|Write` matcher with `python3 /home/developer/.claude/plugins/cache/deeperdive/deeperdive-java-linter/1.1.9/hooks/java_linter_reminder.py`
+4. `deeperdive-java-linter`'s `Bash` matcher with `bash <installPath>/scripts/verify-after-merge.sh`
+
+Other host-enabled plugins (e.g. `frontend-design`, `frida`, `ghidra`) won't appear because they're not in the whitelist.

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -1,6 +1,6 @@
 # Claude Code plugin support
 
-Kapsis bypasses Claude Code's native plugin loader so the container can run in `--print`/headless mode safely. As a side effect, plugin hooks (and their LSP servers, skills, etc.) are never wired up automatically. This page describes the opt-in mechanism Kapsis provides to bring **plugin hooks** back into the container.
+Claude Code's `--print` / headless mode does load plugins from settings as interactive mode would. The reason Kapsis needs its own plugin-hook injection step is that the container starts from a CoW-filtered subset of `~/.claude/` and runs without the interactive trust dialog plugins rely on at first install, so the loader sees an environment in which the host's plugin hooks are not auto-registered into the active hook chain. This page describes the opt-in mechanism Kapsis provides to bring **plugin hooks** back into the container.
 
 ## What gets loaded
 
@@ -64,7 +64,9 @@ Plugin hook commands typically look like:
 
 Claude Code's own plugin loader would expand `${CLAUDE_PLUGIN_ROOT}` per-hook at execution time. Since Kapsis bypasses that loader, **`inject-plugin-hooks.sh` substitutes the placeholder at merge time** with the plugin's already-rewritten installPath (see `rewrite-plugin-paths.sh`). What lands in `settings.local.json` is a fully concrete command string — no env var dependency, no late binding.
 
-Only the literal token `${CLAUDE_PLUGIN_ROOT}` is substituted. Other `${...}` references in commands (e.g. `$HOME`) are left alone for the shell to expand at hook execution.
+**Only `${CLAUDE_PLUGIN_ROOT}` is substituted by Kapsis.** Other `${...}` references (e.g. `${HOME}`, `${CLAUDE_PROJECT_DIR}`, `$PATH`) are left intact for the shell to expand at hook execution time. If you author a plugin that needs an env var beyond `${CLAUDE_PLUGIN_ROOT}`, ensure it's exported into the agent's environment via the Kapsis YAML config or the user's `~/.claude/settings.json` `env` block — the substitution layer here only handles the one canonical plugin-root token.
+
+Multiple `${CLAUDE_PLUGIN_ROOT}` occurrences in a single command are all replaced (verified by `test_multiple_plugin_root_occurrences`).
 
 ## Order of operations
 
@@ -86,7 +88,23 @@ Kapsis hooks therefore precede plugin hooks within each event's array. This matt
 - **`hooks.json` malformed or missing top-level `hooks` object** — logged at WARN, other plugins still processed.
 - **Whitelist entry references an uninstalled plugin** — silently skipped (no error).
 - **`jq` not installed in image** — logged at WARN, injection aborts gracefully (the agent still runs, just without plugin hooks).
-- **`KAPSIS_PLUGIN_WHITELIST` is not a valid JSON array** — logged at WARN, treated as empty (= allow all host-enabled).
+- **`KAPSIS_PLUGIN_WHITELIST` is not a valid JSON array of strings** — **fails closed**. No plugin hooks are injected. The bad value is NOT logged (avoids leaking misconfigured secrets); only its length appears in the WARN. This is a deliberate departure from "fail open" — a corrupted whitelist is treated as "operator intent unknown, refuse everything" rather than "operator wanted no filter, allow all."
+- **`installed_plugins.json` / `settings.json` / `settings.local.json` is a symlink** — refused. Symlinks could redirect writes or fool the merge into reading attacker-chosen content.
+- **A plugin's `installPath` resolves outside `$HOME/.claude/plugins/`** — refused (logged at WARN, naming the plugin). Resolution uses `realpath -m` so `..` traversal can't bypass the prefix check. This closes the gap where the plugin id passes the whitelist but the bytes loaded come from an attacker-controlled location.
+
+## Security model
+
+The whitelist gates plugin **ids**. The containment check above gates plugin **bytes**. Both apply:
+
+| Threat | Defense |
+|---|---|
+| Operator forgot to lock down plugin set in unattended container | `plugin_whitelist` YAML knob |
+| Compromised agent rewrites `installed_plugins.json` to use a whitelisted id with attacker-chosen `installPath` | `installPath` prefix-check under `$HOME/.claude/plugins/` after `realpath -m` |
+| Compromised agent symlinks `settings.local.json` to overwrite a host file | Symlink check before merge |
+| Whitelist value corrupted in transit or by partial config write | Fail-closed (no plugins injected) |
+| Plugin id substring collision (e.g., `"a@b"` matching whitelist `["alpha@beta"]`) | Exact-match via `any(. == .key)` (not jq's `inside()`, which does substring matching on strings) |
+
+These layers together mean: a plugin id reaching the merge step has been (a) explicitly enabled by the operator on the host, AND (b) explicitly listed in the bot's whitelist (when set), AND (c) backed by files inside the trusted plugin cache.
 
 ## What is NOT injected
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1177,6 +1177,19 @@ gemini-cli|Gemini CLI"
         # Agent supports hooks - install them
         display_name="${hook_entry#*|}"
         install_agent_hooks "$agent_type" "$display_name"
+
+        # Plugin hook injection (Claude Code only, opt-in via KAPSIS_INSTALL_PLUGINS).
+        # Must run AFTER install_agent_hooks so Kapsis's status/gist hooks sit
+        # BEFORE plugin hooks in PostToolUse — the kapsis-status-hook reads
+        # /workspace/.kapsis/gist.txt to populate the status JSON, so plugin
+        # hooks that mutate gist.txt should run after status hook has read it.
+        case "$agent_type" in
+            claude|claude-cli|claude-code)
+                if [[ "${KAPSIS_INSTALL_PLUGINS:-false}" == "true" ]]; then
+                    install_plugin_hooks
+                fi
+                ;;
+        esac
     elif [[ " $python_agents " == *" $agent_type "* ]]; then
         # Python agent - status.py library available
         log_info "Python agent - status.py library available for direct integration"
@@ -1227,6 +1240,30 @@ install_agent_hooks() {
 # Note: Agent-specific wrapper functions (setup_claude_hooks, etc.) have been
 # removed in favor of the data-driven lookup in setup_status_tracking().
 # Add new agents by updating the hook_agents variable there.
+
+# Plugin hook installation (Claude Code only). Merges user-installed Claude
+# Code plugin hooks into the same ~/.claude/settings.local.json that
+# install_agent_hooks just wrote — so Kapsis (status/gist) hooks AND plugin
+# hooks (e.g. deeperdive-java-linter) both fire on agent tool calls.
+#
+# This is necessary because Kapsis bypasses Claude Code's native plugin loader.
+install_plugin_hooks() {
+    local inject_script="$KAPSIS_HOME/lib/inject-plugin-hooks.sh"
+
+    if [[ ! -f "$inject_script" ]]; then
+        log_debug "Plugin hook injection script not found — skipping"
+        return 0
+    fi
+
+    log_info "Installing Claude Code plugin hooks..."
+    # shellcheck source=lib/inject-plugin-hooks.sh
+    if source "$inject_script" && inject_plugin_hooks; then
+        return 0
+    else
+        log_warn "Plugin hook injection failed (non-fatal — agent will run without plugin hooks)"
+        return 1
+    fi
+}
 
 # Start background progress monitor for agents without hook support
 start_progress_monitor() {

--- a/scripts/launch-agent.sh
+++ b/scripts/launch-agent.sh
@@ -766,6 +766,22 @@ parse_config() {
         # LLM gist upgrade layer (default: false — adds per-tool Haiku API call)
         GIST_LLM=$(yq -r '.agent.gist_llm // "false"' "$CONFIG_FILE")
         GIST_LLM_INTERVAL=$(yq -r '.agent.gist_llm_interval // "60"' "$CONFIG_FILE")
+        # Plugin hook injection (default: true for claude-cli, false otherwise).
+        # Kapsis bypasses Claude Code's native plugin loader; this flag tells the
+        # in-container inject-plugin-hooks.sh to merge plugin hooks into
+        # ~/.claude/settings.local.json so they actually fire.
+        case "$AGENT_CONFIG_TYPE" in
+            claude|claude-cli|claude-code)
+                INSTALL_PLUGINS=$(yq -r '.agent.install_plugins // "true"' "$CONFIG_FILE")
+                ;;
+            *)
+                INSTALL_PLUGINS=$(yq -r '.agent.install_plugins // "false"' "$CONFIG_FILE")
+                ;;
+        esac
+        # Optional whitelist: JSON-encoded array of plugin ids (e.g.
+        # ["foo@m","bar@m"]). Empty/unset = allow all host-enabled plugins.
+        # yq emits JSON for sequences via `-o=json` + `-I=0` (compact form).
+        PLUGIN_WHITELIST_JSON=$(yq -o=json -I=0 '.agent.plugin_whitelist // []' "$CONFIG_FILE" 2>/dev/null || echo '[]')
         RESOURCE_MEMORY=$(yq -r '.resources.memory // "8g"' "$CONFIG_FILE")
         RESOURCE_CPUS=$(yq -r '.resources.cpus // "4"' "$CONFIG_FILE")
         SANDBOX_UPPER_BASE=$(yq -r '.sandbox.upper_dir_base // "~/.ai-sandboxes"' "$CONFIG_FILE")
@@ -1785,6 +1801,8 @@ generate_env_vars() {
     ENV_VARS+=("-e" "KAPSIS_INJECT_GIST=${INJECT_GIST:-false}")
     ENV_VARS+=("-e" "KAPSIS_GIST_LLM=${GIST_LLM:-false}")
     ENV_VARS+=("-e" "KAPSIS_GIST_LLM_INTERVAL=${GIST_LLM_INTERVAL:-60}")
+    ENV_VARS+=("-e" "KAPSIS_INSTALL_PLUGINS=${INSTALL_PLUGINS:-false}")
+    ENV_VARS+=("-e" "KAPSIS_PLUGIN_WHITELIST=${PLUGIN_WHITELIST_JSON:-[]}")
 
     # Audit environment variables
     if [[ "${KAPSIS_AUDIT_ENABLED:-${KAPSIS_DEFAULT_AUDIT_ENABLED}}" == "true" ]]; then

--- a/scripts/lib/inject-plugin-hooks.sh
+++ b/scripts/lib/inject-plugin-hooks.sh
@@ -62,18 +62,35 @@ fi
 # concrete installPath. Used inline via jq's --arg, not as a shell function.
 
 # Parse the whitelist env var into a normalized JSON array string.
-# Empty/unset/invalid input is normalized to "[]" (= no filter, allow all).
+# Empty/unset input  → "[]" (= no filter, allow all host-enabled).
+# Corrupted input    → exits with code 2 (fail-closed: refuse to inject anything
+# rather than silently widening the trust boundary). The bad value is NOT
+# logged to avoid leaking misconfigured secrets through audit logs.
 _parse_whitelist() {
     local raw="${KAPSIS_PLUGIN_WHITELIST:-}"
     if [[ -z "$raw" ]]; then
         printf '[]'
         return 0
     fi
-    if printf '%s' "$raw" | jq -e 'type == "array"' &>/dev/null; then
+    if printf '%s' "$raw" | jq -e 'type == "array" and all(.[]?; type == "string")' &>/dev/null; then
         printf '%s' "$raw"
     else
-        log_warn "KAPSIS_PLUGIN_WHITELIST is not a JSON array (got: ${raw:0:60}...) — treating as empty (allow all host-enabled)"
-        printf '[]'
+        log_warn "KAPSIS_PLUGIN_WHITELIST is set but not a JSON array of strings (length=${#raw}) — refusing to inject plugin hooks (fail-closed)"
+        return 2
+    fi
+}
+
+# Resolve the plugins cache prefix that installPaths must live under, with
+# symlinks fully resolved. Used to gate untrusted installPath strings from
+# installed_plugins.json — defense against an agent rewriting that registry to
+# point a whitelisted plugin id at attacker-controlled bytes.
+_plugins_cache_prefix() {
+    local prefix="${HOME}/.claude/plugins"
+    # realpath -m: don't require the path to exist; just normalize it.
+    if command -v realpath &>/dev/null; then
+        realpath -m "$prefix" 2>/dev/null || printf '%s' "$prefix"
+    else
+        printf '%s' "$prefix"
     fi
 }
 
@@ -103,6 +120,18 @@ inject_plugin_hooks() {
         return 0
     fi
 
+    # Symlink defense: settings_local + the read-only inputs must be regular
+    # files. A symlinked settings_local could redirect our writes outside the
+    # agent's $HOME, and a symlinked installed_plugins.json could feed us
+    # attacker-chosen content from an unexpected location.
+    local f
+    for f in "$settings_local" "$plugins_file" "$user_settings"; do
+        if [[ -L "$f" ]]; then
+            log_warn "Refusing to inject plugin hooks: $f is a symlink"
+            return 1
+        fi
+    done
+
     # settings.local.json should already exist (inject-status-hooks.sh ran first),
     # but be defensive — create empty if missing.
     mkdir -p "$settings_dir"
@@ -111,11 +140,14 @@ inject_plugin_hooks() {
         log_debug "Created empty settings.local.json (inject-status-hooks.sh should have run first)"
     fi
 
-    # Normalize whitelist
+    # Normalize whitelist. _parse_whitelist exits 2 on corrupted input — propagate
+    # so the caller surfaces it rather than silently allowing all plugins.
     local whitelist_json
-    whitelist_json=$(_parse_whitelist)
-    local whitelist_count
-    whitelist_count=$(printf '%s' "$whitelist_json" | jq 'length')
+    if ! whitelist_json=$(_parse_whitelist); then
+        return 1
+    fi
+    local whitelist_empty=true
+    [[ "$whitelist_json" != "[]" ]] && whitelist_empty=false
 
     # Read host enabledPlugins (default empty object if file missing or key absent)
     local enabled_plugins_json='{}'
@@ -123,10 +155,20 @@ inject_plugin_hooks() {
         enabled_plugins_json=$(jq -c '.enabledPlugins // {}' "$user_settings" 2>/dev/null || echo '{}')
     fi
 
-    # Build candidate list: plugins that pass BOTH filters.
+    # Trusted prefix every installPath must live under (defense vs. attacker
+    # rewriting installed_plugins.json to point a whitelisted id at /tmp/evil).
+    local plugins_prefix
+    plugins_prefix=$(_plugins_cache_prefix)
+
+    # Build candidate list: plugins that pass ALL filters.
     # Returns: [{"id": "plugin@m", "installPath": "/path"}, ...]
     # Filter 1: host enabledPlugins[id] == true
-    # Filter 2: whitelist is empty OR id is in whitelist (single-element subset test)
+    # Filter 2: whitelist is empty OR id matches a whitelist entry EXACTLY
+    #          (uses any(. == .key) — NOT `inside()`, which would do substring
+    #          matching on strings and let "a@b" pass a whitelist of
+    #          ["alpha@beta"]).
+    # Schema defense: .value must be a non-empty array with a non-null
+    # installPath (matches installed_plugins.json v2 shape).
     local candidates_json
     if ! candidates_json=$(jq -c \
         --argjson whitelist "$whitelist_json" \
@@ -136,10 +178,12 @@ inject_plugin_hooks() {
         | to_entries
         | map(select(
             ($enabled[.key] == true)
-            and (($whitelist | length) == 0 or ([.key] | inside($whitelist)))
+            and (($whitelist | length) == 0
+                 or (.key as $k | $whitelist | any(. == $k)))
             and ((.value | type) == "array")
             and ((.value | length) > 0)
-            and (.value[0].installPath != null)
+            and ((.value[0].installPath // null) != null)
+            and ((.value[0].installPath | type) == "string")
         ))
         | map({id: .key, installPath: .value[0].installPath})
         ' "$plugins_file" 2>/dev/null); then
@@ -147,11 +191,10 @@ inject_plugin_hooks() {
         return 1
     fi
 
-    local candidate_count
-    candidate_count=$(printf '%s' "$candidates_json" | jq 'length')
-
-    # Audit: log plugins host-enabled but rejected by whitelist
-    if (( whitelist_count > 0 )); then
+    # Audit: enumerate host-enabled plugins that were filtered out by the
+    # whitelist, so operators can spot "I installed plugin X on the host but
+    # it's not appearing in the bot" without having to diff configs.
+    if ! $whitelist_empty; then
         local rejected_ids
         rejected_ids=$(jq -r \
             --argjson whitelist "$whitelist_json" \
@@ -159,7 +202,8 @@ inject_plugin_hooks() {
             '
             (.plugins // {})
             | to_entries
-            | map(select(($enabled[.key] == true) and ([.key] | inside($whitelist) | not)))
+            | map(select(($enabled[.key] == true)
+                         and ((.key as $k | $whitelist | any(. == $k)) | not)))
             | map(.key)
             | join(", ")
             ' "$plugins_file" 2>/dev/null || echo '')
@@ -168,18 +212,42 @@ inject_plugin_hooks() {
         fi
     fi
 
+    local candidate_count
+    candidate_count=$(printf '%s' "$candidates_json" | jq 'length')
+
     if (( candidate_count == 0 )); then
         log_info "No plugin hooks to inject (host-enabled & whitelisted: 0)"
         return 0
     fi
 
-    # Iterate candidates and merge each one's hooks/hooks.json
+    # Single jq call to unpack {id, installPath} pairs — avoids 2*N forks when
+    # iterating large whitelists.
     local merged_count=0
-    local i
-    for (( i = 0; i < candidate_count; i++ )); do
-        local plugin_id install_path hooks_file
-        plugin_id=$(printf '%s' "$candidates_json" | jq -r ".[$i].id")
-        install_path=$(printf '%s' "$candidates_json" | jq -r ".[$i].installPath")
+    local plugin_id install_path hooks_file
+    while IFS=$'\t' read -r plugin_id install_path; do
+        [[ -z "$plugin_id" ]] && continue
+
+        # installPath containment check (defense vs. installed_plugins.json
+        # tampering). The plugin id has passed the whitelist already; the
+        # bytes the hooks will load from MUST live under the trusted cache
+        # prefix. realpath -m normalizes ".." and symlinks before the prefix
+        # comparison so we can't be tricked by a path like
+        # /home/dev/.claude/plugins/../../../tmp/evil.
+        local resolved_path
+        if command -v realpath &>/dev/null; then
+            resolved_path=$(realpath -m "$install_path" 2>/dev/null || printf '%s' "$install_path")
+        else
+            resolved_path="$install_path"
+        fi
+        case "$resolved_path" in
+            "$plugins_prefix"/*)
+                ;;
+            *)
+                log_warn "Plugin ${plugin_id}: installPath outside ${plugins_prefix} (${resolved_path}) — refusing"
+                continue
+                ;;
+        esac
+
         hooks_file="${install_path}/hooks/hooks.json"
 
         if [[ ! -f "$hooks_file" ]]; then
@@ -187,7 +255,7 @@ inject_plugin_hooks() {
             continue
         fi
 
-        # Validate plugin hooks.json before merging
+        # Validate plugin hooks.json shape before merging
         if ! jq -e '.hooks | type == "object"' "$hooks_file" &>/dev/null; then
             log_warn "Plugin ${plugin_id}: hooks.json is missing top-level 'hooks' object — skipping"
             continue
@@ -195,11 +263,18 @@ inject_plugin_hooks() {
 
         # Merge with command-level dedup. For each event/group/hook:
         # - Substitute ${CLAUDE_PLUGIN_ROOT} -> install_path in command strings.
+        #   (Only this token is substituted; other ${...} refs like $HOME are
+        #   left intact for the shell to expand at hook execution time.)
         # - For each individual hook command, if it already exists anywhere
-        #   under that event in settings.local.json, drop it.
+        #   under that event in settings.local.json OR earlier in this same
+        #   merge pass, drop it. This catches both cross-plugin and
+        #   intra-plugin (same command in two of a plugin's own groups)
+        #   duplicates in a single run.
         # - If the substituted plugin_group still has at least one hook left,
         #   append the group (preserving its matcher) to settings.local.json.
-        local tmp_file
+        # Emits {settings: <merged>, plugin_hook_count: N} so the caller gets
+        # both values without a follow-up jq fork.
+        local tmp_file plugin_hook_count
         tmp_file=$(mktemp)
         if jq \
             --slurpfile plugin_data "$hooks_file" \
@@ -213,34 +288,45 @@ inject_plugin_hooks() {
                 );
 
             ($plugin_data[0].hooks // {}) as $plugin_hooks
+            | ([$plugin_hooks | to_entries[] | .value[] | .hooks | length] | add // 0) as $plugin_hook_count
             | .hooks //= {}
             | reduce ($plugin_hooks | keys[]) as $event (.;
                 .hooks[$event] //= []
+                # Snapshot every command already registered under this event
+                # at the START of processing the event, then track ADDITIONAL
+                # commands appended during this pass inside the reduce so two
+                # groups of the same plugin sharing a command also dedupe.
                 | ([.hooks[$event][]? | .hooks[]? | .command] | unique) as $existing_cmds
                 | reduce ($plugin_hooks[$event][] | subst_root($plugin_root)) as $plugin_group (.;
-                    ($plugin_group
+                    ([.hooks[$event][]? | .hooks[]? | .command] | unique) as $current_cmds
+                    | ($plugin_group
                         | .hooks //= []
-                        | .hooks |= map(select((.command // "") as $c | $existing_cmds | index($c) | not))
-                    ) as $filtered
+                        | .hooks |= map(select((.command // "") as $c
+                            | ($existing_cmds | index($c) | not)
+                            and ($current_cmds | index($c) | not)))
+                      ) as $filtered
                     | if ($filtered.hooks | length) > 0
                       then .hooks[$event] += [$filtered]
                       else .
                       end
                 )
             )
+            | {settings: ., plugin_hook_count: $plugin_hook_count}
             ' \
             "$settings_local" > "$tmp_file" 2>/dev/null; then
-            mv "$tmp_file" "$settings_local"
+            # Split combined result into settings (atomic mv) + count (log)
+            plugin_hook_count=$(jq -r '.plugin_hook_count' "$tmp_file")
+            jq -c '.settings' "$tmp_file" > "${tmp_file}.settings" \
+                && mv "${tmp_file}.settings" "$settings_local"
+            rm -f "$tmp_file"
             chmod 600 "$settings_local"
-            local hook_count
-            hook_count=$(jq '[.hooks | to_entries[] | .value[] | .hooks | length] | add // 0' "$hooks_file")
-            log_info "Loaded plugin ${plugin_id} (hooks=${hook_count}, root=${install_path})"
+            log_info "Loaded plugin ${plugin_id} (plugin_hooks=${plugin_hook_count}, root=${install_path})"
             merged_count=$((merged_count + 1))
         else
             rm -f "$tmp_file"
             log_warn "Plugin ${plugin_id}: jq merge failed — skipping (other plugins still processed)"
         fi
-    done
+    done < <(printf '%s' "$candidates_json" | jq -r '.[] | "\(.id)\t\(.installPath)"')
 
     log_success "Plugin hook injection complete (merged ${merged_count}/${candidate_count})"
     return 0

--- a/scripts/lib/inject-plugin-hooks.sh
+++ b/scripts/lib/inject-plugin-hooks.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+#===============================================================================
+# inject-plugin-hooks.sh - Inject Claude Code plugin hooks into agent settings
+#
+# Kapsis bypasses Claude Code's native plugin loader (which only runs in
+# interactive mode). To make plugins like deeperdive-java-linter actually fire
+# inside a Kapsis container, this script enumerates host-enabled plugins and
+# merges their hooks/hooks.json into ~/.claude/settings.local.json — alongside
+# Kapsis's own status/gist hooks injected by inject-status-hooks.sh.
+#
+# Filters (both must pass):
+#   1. Host-enabled: plugin id present with value `true` in
+#      ~/.claude/settings.json::enabledPlugins.
+#   2. Whitelist (optional): if KAPSIS_PLUGIN_WHITELIST is a non-empty JSON
+#      array, the plugin id must be in it. If unset or empty, allow all
+#      host-enabled plugins (default).
+#
+# ${CLAUDE_PLUGIN_ROOT} placeholder in each plugin's command strings is
+# substituted with the plugin's rewritten installPath at merge time, since
+# Kapsis is bypassing the loader that would otherwise set that env var
+# per-hook at execution time.
+#
+# Usage:
+#   Called from entrypoint.sh::setup_status_tracking AFTER inject-status-hooks.sh
+#   so Kapsis hooks (gist → status) sit before plugin hooks in PostToolUse.
+#
+# Requires (must run AFTER):
+#   - rewrite-plugin-paths.sh (installed_plugins.json paths must be container-correct)
+#   - inject-status-hooks.sh   (settings.local.json must already exist with Kapsis hooks)
+#
+# Environment:
+#   KAPSIS_INSTALL_PLUGINS   - "true" to activate (gate; falsy = no-op)
+#   KAPSIS_PLUGIN_WHITELIST  - JSON array of plugin ids (e.g. ["foo@m","bar@m"]);
+#                              empty/unset = allow all host-enabled plugins
+#   KAPSIS_HOME              - Kapsis installation directory (default /opt/kapsis)
+#   HOME                     - Container user home (settings live under $HOME/.claude)
+#===============================================================================
+
+set -euo pipefail
+
+# Source guard
+[[ -n "${_KAPSIS_INJECT_PLUGIN_HOOKS_LOADED:-}" ]] && return 0
+_KAPSIS_INJECT_PLUGIN_HOOKS_LOADED=1
+
+# Source logging if available
+if [[ -f "${KAPSIS_LIB:-/opt/kapsis/lib}/logging.sh" ]]; then
+    # shellcheck source=logging.sh
+    source "${KAPSIS_LIB:-/opt/kapsis/lib}/logging.sh"
+else
+    log_info() { echo "[INFO] $*"; }
+    log_warn() { echo "[WARN] $*" >&2; }
+    log_error() { echo "[ERROR] $*" >&2; }
+    log_debug() { :; }
+    log_success() { echo "[OK] $*"; }
+fi
+
+#===============================================================================
+# Plugin Hook Injection
+#===============================================================================
+
+# Substitute ${CLAUDE_PLUGIN_ROOT} in plugin hook commands with the plugin's
+# concrete installPath. Used inline via jq's --arg, not as a shell function.
+
+# Parse the whitelist env var into a normalized JSON array string.
+# Empty/unset/invalid input is normalized to "[]" (= no filter, allow all).
+_parse_whitelist() {
+    local raw="${KAPSIS_PLUGIN_WHITELIST:-}"
+    if [[ -z "$raw" ]]; then
+        printf '[]'
+        return 0
+    fi
+    if printf '%s' "$raw" | jq -e 'type == "array"' &>/dev/null; then
+        printf '%s' "$raw"
+    else
+        log_warn "KAPSIS_PLUGIN_WHITELIST is not a JSON array (got: ${raw:0:60}...) — treating as empty (allow all host-enabled)"
+        printf '[]'
+    fi
+}
+
+# Inject hooks from all host-enabled (and whitelisted) plugins into
+# ~/.claude/settings.local.json.
+inject_plugin_hooks() {
+    # Gate: opt-in
+    if [[ "${KAPSIS_INSTALL_PLUGINS:-false}" != "true" ]]; then
+        log_debug "Plugin hook injection disabled (set agent.install_plugins: true to enable)"
+        return 0
+    fi
+
+    local settings_dir="${HOME}/.claude"
+    local settings_local="${settings_dir}/settings.local.json"
+    local plugins_file="${settings_dir}/plugins/installed_plugins.json"
+    local user_settings="${settings_dir}/settings.json"
+
+    # jq is mandatory
+    if ! command -v jq &>/dev/null; then
+        log_warn "jq not found - cannot inject plugin hooks"
+        return 1
+    fi
+
+    # Nothing to do if no plugin registry
+    if [[ ! -f "$plugins_file" ]]; then
+        log_debug "No installed_plugins.json — no plugins to inject"
+        return 0
+    fi
+
+    # settings.local.json should already exist (inject-status-hooks.sh ran first),
+    # but be defensive — create empty if missing.
+    mkdir -p "$settings_dir"
+    if [[ ! -f "$settings_local" ]]; then
+        echo '{}' > "$settings_local"
+        log_debug "Created empty settings.local.json (inject-status-hooks.sh should have run first)"
+    fi
+
+    # Normalize whitelist
+    local whitelist_json
+    whitelist_json=$(_parse_whitelist)
+    local whitelist_count
+    whitelist_count=$(printf '%s' "$whitelist_json" | jq 'length')
+
+    # Read host enabledPlugins (default empty object if file missing or key absent)
+    local enabled_plugins_json='{}'
+    if [[ -f "$user_settings" ]]; then
+        enabled_plugins_json=$(jq -c '.enabledPlugins // {}' "$user_settings" 2>/dev/null || echo '{}')
+    fi
+
+    # Build candidate list: plugins that pass BOTH filters.
+    # Returns: [{"id": "plugin@m", "installPath": "/path"}, ...]
+    # Filter 1: host enabledPlugins[id] == true
+    # Filter 2: whitelist is empty OR id is in whitelist (single-element subset test)
+    local candidates_json
+    if ! candidates_json=$(jq -c \
+        --argjson whitelist "$whitelist_json" \
+        --argjson enabled "$enabled_plugins_json" \
+        '
+        (.plugins // {})
+        | to_entries
+        | map(select(
+            ($enabled[.key] == true)
+            and (($whitelist | length) == 0 or ([.key] | inside($whitelist)))
+            and ((.value | type) == "array")
+            and ((.value | length) > 0)
+            and (.value[0].installPath != null)
+        ))
+        | map({id: .key, installPath: .value[0].installPath})
+        ' "$plugins_file" 2>/dev/null); then
+        log_warn "Failed to parse installed_plugins.json — skipping plugin hook injection"
+        return 1
+    fi
+
+    local candidate_count
+    candidate_count=$(printf '%s' "$candidates_json" | jq 'length')
+
+    # Audit: log plugins host-enabled but rejected by whitelist
+    if (( whitelist_count > 0 )); then
+        local rejected_ids
+        rejected_ids=$(jq -r \
+            --argjson whitelist "$whitelist_json" \
+            --argjson enabled "$enabled_plugins_json" \
+            '
+            (.plugins // {})
+            | to_entries
+            | map(select(($enabled[.key] == true) and ([.key] | inside($whitelist) | not)))
+            | map(.key)
+            | join(", ")
+            ' "$plugins_file" 2>/dev/null || echo '')
+        if [[ -n "$rejected_ids" ]]; then
+            log_info "Plugin whitelist rejected: ${rejected_ids}"
+        fi
+    fi
+
+    if (( candidate_count == 0 )); then
+        log_info "No plugin hooks to inject (host-enabled & whitelisted: 0)"
+        return 0
+    fi
+
+    # Iterate candidates and merge each one's hooks/hooks.json
+    local merged_count=0
+    local i
+    for (( i = 0; i < candidate_count; i++ )); do
+        local plugin_id install_path hooks_file
+        plugin_id=$(printf '%s' "$candidates_json" | jq -r ".[$i].id")
+        install_path=$(printf '%s' "$candidates_json" | jq -r ".[$i].installPath")
+        hooks_file="${install_path}/hooks/hooks.json"
+
+        if [[ ! -f "$hooks_file" ]]; then
+            log_debug "Plugin ${plugin_id} has no hooks/hooks.json at ${install_path} — skipping"
+            continue
+        fi
+
+        # Validate plugin hooks.json before merging
+        if ! jq -e '.hooks | type == "object"' "$hooks_file" &>/dev/null; then
+            log_warn "Plugin ${plugin_id}: hooks.json is missing top-level 'hooks' object — skipping"
+            continue
+        fi
+
+        # Merge with command-level dedup. For each event/group/hook:
+        # - Substitute ${CLAUDE_PLUGIN_ROOT} -> install_path in command strings.
+        # - For each individual hook command, if it already exists anywhere
+        #   under that event in settings.local.json, drop it.
+        # - If the substituted plugin_group still has at least one hook left,
+        #   append the group (preserving its matcher) to settings.local.json.
+        local tmp_file
+        tmp_file=$(mktemp)
+        if jq \
+            --slurpfile plugin_data "$hooks_file" \
+            --arg plugin_root "$install_path" \
+            '
+            def subst_root($root):
+                walk(
+                    if type == "string"
+                    then gsub("\\$\\{CLAUDE_PLUGIN_ROOT\\}"; $root)
+                    else . end
+                );
+
+            ($plugin_data[0].hooks // {}) as $plugin_hooks
+            | .hooks //= {}
+            | reduce ($plugin_hooks | keys[]) as $event (.;
+                .hooks[$event] //= []
+                | ([.hooks[$event][]? | .hooks[]? | .command] | unique) as $existing_cmds
+                | reduce ($plugin_hooks[$event][] | subst_root($plugin_root)) as $plugin_group (.;
+                    ($plugin_group
+                        | .hooks //= []
+                        | .hooks |= map(select((.command // "") as $c | $existing_cmds | index($c) | not))
+                    ) as $filtered
+                    | if ($filtered.hooks | length) > 0
+                      then .hooks[$event] += [$filtered]
+                      else .
+                      end
+                )
+            )
+            ' \
+            "$settings_local" > "$tmp_file" 2>/dev/null; then
+            mv "$tmp_file" "$settings_local"
+            chmod 600 "$settings_local"
+            local hook_count
+            hook_count=$(jq '[.hooks | to_entries[] | .value[] | .hooks | length] | add // 0' "$hooks_file")
+            log_info "Loaded plugin ${plugin_id} (hooks=${hook_count}, root=${install_path})"
+            merged_count=$((merged_count + 1))
+        else
+            rm -f "$tmp_file"
+            log_warn "Plugin ${plugin_id}: jq merge failed — skipping (other plugins still processed)"
+        fi
+    done
+
+    log_success "Plugin hook injection complete (merged ${merged_count}/${candidate_count})"
+    return 0
+}

--- a/tests/test-plugin-hook-injection.sh
+++ b/tests/test-plugin-hook-injection.sh
@@ -1,0 +1,382 @@
+#!/usr/bin/env bash
+#===============================================================================
+# Tests for Plugin Hook Injection (scripts/lib/inject-plugin-hooks.sh)
+#
+# Verifies that user-installed Claude Code plugin hooks are merged into
+# ~/.claude/settings.local.json alongside Kapsis's own status/gist hooks,
+# with proper filtering by enabledPlugins and the optional whitelist.
+#
+# Run: ./tests/test-plugin-hook-injection.sh
+#===============================================================================
+
+# Intentional single-quoted ${CLAUDE_PLUGIN_ROOT} placeholders in test
+# fixtures — they're JSON-literal strings, NOT shell expansions.
+# shellcheck disable=SC2016
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/test-framework.sh"
+
+LIB_DIR="$KAPSIS_ROOT/scripts/lib"
+
+# Save original values to restore after each test
+_ORIG_HOME="$HOME"
+
+setup_test_home() {
+    TEST_HOME=$(mktemp -d)
+    mkdir -p "$TEST_HOME/.claude/plugins"
+}
+
+cleanup_test_home() {
+    HOME="$_ORIG_HOME"
+    [[ -n "${TEST_HOME:-}" ]] && rm -rf "$TEST_HOME"
+    TEST_HOME=""
+    unset KAPSIS_INSTALL_PLUGINS 2>/dev/null || true
+    unset KAPSIS_PLUGIN_WHITELIST 2>/dev/null || true
+    unset _KAPSIS_INJECT_PLUGIN_HOOKS_LOADED 2>/dev/null || true
+}
+
+# Helpers — build a fully-formed plugin registry / cache fixture.
+#   $1: plugin id (e.g. "foo@m")
+#   $2: install path (absolute)
+#   $3: hooks.json contents (raw JSON)
+make_plugin() {
+    local plugin_id="$1" install_path="$2" hooks_contents="$3"
+    mkdir -p "$install_path/hooks"
+    printf '%s' "$hooks_contents" > "$install_path/hooks/hooks.json"
+}
+
+# Append a plugin to installed_plugins.json. Idempotent enough for tests.
+add_to_registry() {
+    local plugin_id="$1" install_path="$2"
+    local plugins_file="$TEST_HOME/.claude/plugins/installed_plugins.json"
+    if [[ ! -f "$plugins_file" ]]; then
+        echo '{"version":2,"plugins":{}}' > "$plugins_file"
+    fi
+    local tmp
+    tmp=$(mktemp)
+    jq --arg id "$plugin_id" --arg path "$install_path" \
+        '.plugins[$id] = [{"scope":"user","installPath":$path,"version":"1.0.0"}]' \
+        "$plugins_file" > "$tmp" && mv "$tmp" "$plugins_file"
+}
+
+# Set host enabledPlugins. Pass plugin ids as args.
+set_enabled() {
+    local settings="$TEST_HOME/.claude/settings.json"
+    local map='{}'
+    local id
+    for id in "$@"; do
+        map=$(printf '%s' "$map" | jq --arg id "$id" '. + {($id): true}')
+    done
+    printf '{"enabledPlugins":%s}\n' "$map" > "$settings"
+}
+
+# Pre-seed settings.local.json with the Kapsis status hook (simulates running
+# AFTER inject-status-hooks.sh).
+seed_kapsis_settings_local() {
+    cat > "$TEST_HOME/.claude/settings.local.json" <<'JSON'
+{"hooks":{"PostToolUse":[{"matcher":"*","hooks":[{"type":"command","command":"/opt/kapsis/hooks/kapsis-status-hook.sh","timeout":5}]}]}}
+JSON
+}
+
+# Run the function under test in a subshell so the source guard resets per-test.
+run_inject() {
+    unset _KAPSIS_INJECT_PLUGIN_HOOKS_LOADED 2>/dev/null || true
+    HOME="$TEST_HOME" \
+    KAPSIS_INSTALL_PLUGINS="${KAPSIS_INSTALL_PLUGINS:-true}" \
+    KAPSIS_PLUGIN_WHITELIST="${KAPSIS_PLUGIN_WHITELIST:-}" \
+    bash -c "
+        source '$LIB_DIR/inject-plugin-hooks.sh'
+        inject_plugin_hooks
+    "
+}
+
+count_commands() {
+    jq '[.hooks // {} | to_entries[] | .value[] | .hooks | length] | add // 0' \
+        "$TEST_HOME/.claude/settings.local.json"
+}
+
+#===============================================================================
+# TEST: Single enabled plugin, no whitelist → merged with concrete path
+#===============================================================================
+
+test_single_plugin_no_whitelist() {
+    log_test "Single host-enabled plugin, no whitelist, merges with concrete path"
+    setup_test_home
+
+    local foo_path="$TEST_HOME/.claude/plugins/cache/m/foo/1.0.0"
+    make_plugin "foo@m" "$foo_path" \
+        '{"hooks":{"PostToolUse":[{"matcher":"Edit","hooks":[{"type":"command","command":"python3 ${CLAUDE_PLUGIN_ROOT}/hooks/lint.py"}]}]}}'
+    add_to_registry "foo@m" "$foo_path"
+    set_enabled "foo@m"
+    seed_kapsis_settings_local
+
+    run_inject
+
+    local result
+    result=$(cat "$TEST_HOME/.claude/settings.local.json")
+    assert_contains "$result" "$foo_path/hooks/lint.py" "Concrete path should be substituted into command"
+    assert_not_contains "$result" 'CLAUDE_PLUGIN_ROOT' "Placeholder should be fully substituted"
+    assert_contains "$result" "kapsis-status-hook.sh" "Kapsis hook should be preserved"
+
+    cleanup_test_home
+}
+
+#===============================================================================
+# TEST: Plugin disabled in host enabledPlugins → NOT merged
+#===============================================================================
+
+test_disabled_plugin_not_merged() {
+    log_test "Host-disabled plugin is skipped even if installed"
+    setup_test_home
+
+    local bar_path="$TEST_HOME/.claude/plugins/cache/m/bar/1.0.0"
+    make_plugin "bar@m" "$bar_path" \
+        '{"hooks":{"PostToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"echo ${CLAUDE_PLUGIN_ROOT}"}]}]}}'
+    add_to_registry "bar@m" "$bar_path"
+    # NOT calling set_enabled — host has no enabledPlugins entry for bar@m
+    set_enabled  # writes empty enabledPlugins
+    seed_kapsis_settings_local
+
+    run_inject
+
+    local result
+    result=$(cat "$TEST_HOME/.claude/settings.local.json")
+    assert_not_contains "$result" "$bar_path" "Disabled plugin's path should not appear"
+    # Kapsis hook still present
+    assert_contains "$result" "kapsis-status-hook.sh" "Kapsis hook preserved"
+
+    cleanup_test_home
+}
+
+#===============================================================================
+# TEST: Whitelist=[a], two enabled plugins → only a merged
+#===============================================================================
+
+test_whitelist_filters() {
+    log_test "Whitelist limits to listed plugins only"
+    setup_test_home
+
+    local a_path="$TEST_HOME/.claude/plugins/cache/m/a/1.0.0"
+    local b_path="$TEST_HOME/.claude/plugins/cache/m/b/1.0.0"
+    make_plugin "a@m" "$a_path" \
+        '{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"${CLAUDE_PLUGIN_ROOT}/a.sh"}]}]}}'
+    make_plugin "b@m" "$b_path" \
+        '{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"${CLAUDE_PLUGIN_ROOT}/b.sh"}]}]}}'
+    add_to_registry "a@m" "$a_path"
+    add_to_registry "b@m" "$b_path"
+    set_enabled "a@m" "b@m"
+    seed_kapsis_settings_local
+
+    KAPSIS_PLUGIN_WHITELIST='["a@m"]' run_inject
+
+    local result
+    result=$(cat "$TEST_HOME/.claude/settings.local.json")
+    assert_contains "$result" "$a_path/a.sh" "Whitelisted plugin a should be merged"
+    assert_not_contains "$result" "$b_path/b.sh" "Non-whitelisted plugin b should be skipped"
+
+    cleanup_test_home
+}
+
+#===============================================================================
+# TEST: Whitelist=[] (empty) → behaves like unset (all host-enabled merged)
+#===============================================================================
+
+test_empty_whitelist_allows_all() {
+    log_test "Empty whitelist array is treated as 'no filter' (allow all)"
+    setup_test_home
+
+    local a_path="$TEST_HOME/.claude/plugins/cache/m/a/1.0.0"
+    local b_path="$TEST_HOME/.claude/plugins/cache/m/b/1.0.0"
+    make_plugin "a@m" "$a_path" \
+        '{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"${CLAUDE_PLUGIN_ROOT}/a.sh"}]}]}}'
+    make_plugin "b@m" "$b_path" \
+        '{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"${CLAUDE_PLUGIN_ROOT}/b.sh"}]}]}}'
+    add_to_registry "a@m" "$a_path"
+    add_to_registry "b@m" "$b_path"
+    set_enabled "a@m" "b@m"
+    seed_kapsis_settings_local
+
+    KAPSIS_PLUGIN_WHITELIST='[]' run_inject
+
+    local result
+    result=$(cat "$TEST_HOME/.claude/settings.local.json")
+    assert_contains "$result" "$a_path/a.sh" "Plugin a should be merged"
+    assert_contains "$result" "$b_path/b.sh" "Plugin b should be merged"
+
+    cleanup_test_home
+}
+
+#===============================================================================
+# TEST: Whitelist references plugin not installed → no error
+#===============================================================================
+
+test_whitelist_missing_plugin_no_error() {
+    log_test "Whitelist references an uninstalled plugin — handled silently"
+    setup_test_home
+
+    local a_path="$TEST_HOME/.claude/plugins/cache/m/a/1.0.0"
+    make_plugin "a@m" "$a_path" \
+        '{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"${CLAUDE_PLUGIN_ROOT}/a.sh"}]}]}}'
+    add_to_registry "a@m" "$a_path"
+    set_enabled "a@m"
+    seed_kapsis_settings_local
+
+    KAPSIS_PLUGIN_WHITELIST='["nonexistent@m","a@m"]' \
+        assert_command_succeeds "$(declare -f run_inject); run_inject" \
+        "Whitelist with one missing plugin should not error"
+
+    local result
+    result=$(cat "$TEST_HOME/.claude/settings.local.json")
+    assert_contains "$result" "$a_path/a.sh" "Plugin a (in whitelist + installed) should still merge"
+
+    cleanup_test_home
+}
+
+#===============================================================================
+# TEST: Plugin with malformed hooks.json → warning + others still merged
+#===============================================================================
+
+test_malformed_hooks_json() {
+    log_test "Malformed plugin hooks.json doesn't break injection of other plugins"
+    setup_test_home
+
+    local bad_path="$TEST_HOME/.claude/plugins/cache/m/bad/1.0.0"
+    local good_path="$TEST_HOME/.claude/plugins/cache/m/good/1.0.0"
+    mkdir -p "$bad_path/hooks"
+    echo 'this is not valid JSON {' > "$bad_path/hooks/hooks.json"
+    make_plugin "good@m" "$good_path" \
+        '{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"${CLAUDE_PLUGIN_ROOT}/good.sh"}]}]}}'
+    add_to_registry "bad@m" "$bad_path"
+    add_to_registry "good@m" "$good_path"
+    set_enabled "bad@m" "good@m"
+    seed_kapsis_settings_local
+
+    run_inject
+
+    local result
+    result=$(cat "$TEST_HOME/.claude/settings.local.json")
+    assert_contains "$result" "$good_path/good.sh" "Good plugin should still merge"
+    assert_not_contains "$result" "$bad_path" "Bad plugin should not appear"
+
+    cleanup_test_home
+}
+
+#===============================================================================
+# TEST: Idempotency — second run produces identical settings.local.json
+#===============================================================================
+
+test_idempotency() {
+    log_test "Running injection twice produces identical settings.local.json"
+    setup_test_home
+
+    local foo_path="$TEST_HOME/.claude/plugins/cache/m/foo/1.0.0"
+    make_plugin "foo@m" "$foo_path" \
+        '{"hooks":{"PostToolUse":[{"matcher":"Edit","hooks":[{"type":"command","command":"${CLAUDE_PLUGIN_ROOT}/lint.sh"}]}],"SessionStart":[{"hooks":[{"type":"command","command":"${CLAUDE_PLUGIN_ROOT}/start.sh"}]}]}}'
+    add_to_registry "foo@m" "$foo_path"
+    set_enabled "foo@m"
+    seed_kapsis_settings_local
+
+    run_inject
+    local first_run
+    first_run=$(cat "$TEST_HOME/.claude/settings.local.json")
+    local count_after_first
+    count_after_first=$(count_commands)
+
+    run_inject
+    local second_run
+    second_run=$(cat "$TEST_HOME/.claude/settings.local.json")
+    local count_after_second
+    count_after_second=$(count_commands)
+
+    assert_equals "$count_after_first" "$count_after_second" \
+        "Command count should be identical after running injection twice"
+    assert_equals "$first_run" "$second_run" \
+        "settings.local.json byte-identical after re-run"
+
+    cleanup_test_home
+}
+
+#===============================================================================
+# TEST: KAPSIS_INSTALL_PLUGINS=false → settings.local.json untouched
+#===============================================================================
+
+test_gate_off_no_op() {
+    log_test "Gate off (KAPSIS_INSTALL_PLUGINS=false): settings.local.json untouched"
+    setup_test_home
+
+    local foo_path="$TEST_HOME/.claude/plugins/cache/m/foo/1.0.0"
+    make_plugin "foo@m" "$foo_path" \
+        '{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"${CLAUDE_PLUGIN_ROOT}/start.sh"}]}]}}'
+    add_to_registry "foo@m" "$foo_path"
+    set_enabled "foo@m"
+    seed_kapsis_settings_local
+
+    local before
+    before=$(cat "$TEST_HOME/.claude/settings.local.json")
+
+    KAPSIS_INSTALL_PLUGINS=false run_inject
+
+    local after
+    after=$(cat "$TEST_HOME/.claude/settings.local.json")
+
+    assert_equals "$before" "$after" "settings.local.json should be byte-identical when gate is off"
+    assert_not_contains "$after" "$foo_path" "Plugin should NOT be merged when gate is off"
+
+    cleanup_test_home
+}
+
+#===============================================================================
+# TEST: Plugin with missing hooks.json → skipped silently
+#===============================================================================
+
+test_missing_hooks_json() {
+    log_test "Plugin without hooks.json is skipped (no error)"
+    setup_test_home
+
+    local nohooks_path="$TEST_HOME/.claude/plugins/cache/m/nohooks/1.0.0"
+    mkdir -p "$nohooks_path"
+    # No hooks/hooks.json created
+    add_to_registry "nohooks@m" "$nohooks_path"
+    set_enabled "nohooks@m"
+    seed_kapsis_settings_local
+
+    local before
+    before=$(cat "$TEST_HOME/.claude/settings.local.json")
+    run_inject
+    local after
+    after=$(cat "$TEST_HOME/.claude/settings.local.json")
+
+    assert_equals "$before" "$after" \
+        "Plugin without hooks.json shouldn't change settings.local.json"
+
+    cleanup_test_home
+}
+
+#===============================================================================
+# MAIN
+#===============================================================================
+
+main() {
+    print_test_header "Plugin Hook Injection (inject-plugin-hooks.sh)"
+
+    log_info "=== Basic injection ==="
+    run_test test_single_plugin_no_whitelist
+    run_test test_disabled_plugin_not_merged
+
+    log_info "=== Whitelist filtering ==="
+    run_test test_whitelist_filters
+    run_test test_empty_whitelist_allows_all
+    run_test test_whitelist_missing_plugin_no_error
+
+    log_info "=== Robustness ==="
+    run_test test_malformed_hooks_json
+    run_test test_missing_hooks_json
+    run_test test_idempotency
+    run_test test_gate_off_no_op
+
+    print_summary
+}
+
+main "$@"

--- a/tests/test-plugin-hook-injection.sh
+++ b/tests/test-plugin-hook-injection.sh
@@ -80,7 +80,11 @@ seed_kapsis_settings_local() {
 JSON
 }
 
-# Run the function under test in a subshell so the source guard resets per-test.
+# Run the function under test in a subshell. The source guard
+# (_KAPSIS_INJECT_PLUGIN_HOOKS_LOADED) is reset in the parent so the module
+# is re-evaluated for every test rather than carrying state across runs.
+# Captures stderr to $TEST_HOME/inject.stderr so tests can assert log_warn
+# messages appeared (run_inject_stderr returns the captured path).
 run_inject() {
     unset _KAPSIS_INJECT_PLUGIN_HOOKS_LOADED 2>/dev/null || true
     HOME="$TEST_HOME" \
@@ -89,7 +93,13 @@ run_inject() {
     bash -c "
         source '$LIB_DIR/inject-plugin-hooks.sh'
         inject_plugin_hooks
-    "
+    " 2> "$TEST_HOME/inject.stderr"
+}
+
+# Run inject AND return the captured stderr for WARN assertions.
+run_inject_stderr() {
+    run_inject
+    cat "$TEST_HOME/inject.stderr"
 }
 
 count_commands() {
@@ -355,6 +365,301 @@ test_missing_hooks_json() {
 }
 
 #===============================================================================
+# TEST: Whitelist must do EXACT match, NOT substring (regression for
+# jq inside() bug — see PR #326 review)
+#===============================================================================
+
+test_whitelist_exact_match_not_substring() {
+    log_test "Whitelist uses exact-match (substring 'a@b' must NOT match ['alpha@beta'])"
+    setup_test_home
+
+    local short_path="$TEST_HOME/.claude/plugins/cache/m/a/1.0.0"
+    local long_path="$TEST_HOME/.claude/plugins/cache/m/alpha/1.0.0"
+    make_plugin "a@b" "$short_path" \
+        '{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"${CLAUDE_PLUGIN_ROOT}/short.sh"}]}]}}'
+    make_plugin "alpha@beta" "$long_path" \
+        '{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"${CLAUDE_PLUGIN_ROOT}/long.sh"}]}]}}'
+    add_to_registry "a@b" "$short_path"
+    add_to_registry "alpha@beta" "$long_path"
+    set_enabled "a@b" "alpha@beta"
+    seed_kapsis_settings_local
+
+    # Whitelist contains ONLY the longer id. The shorter id is a substring,
+    # so a `jq inside()` based check would erroneously let it through.
+    KAPSIS_PLUGIN_WHITELIST='["alpha@beta"]' run_inject
+
+    local result
+    result=$(cat "$TEST_HOME/.claude/settings.local.json")
+    assert_contains "$result" "$long_path/long.sh" "Whitelisted plugin must merge"
+    assert_not_contains "$result" "$short_path/short.sh" \
+        "Substring-only plugin id must NOT merge (regression for substring bypass)"
+
+    cleanup_test_home
+}
+
+#===============================================================================
+# TEST: installPath outside ~/.claude/plugins/ is rejected
+#===============================================================================
+
+test_installpath_containment() {
+    log_test "Plugin with installPath outside ~/.claude/plugins/ is refused"
+    setup_test_home
+
+    # Plugin "lives" outside the trusted cache prefix
+    local evil_path="$TEST_HOME/elsewhere/plugins/evil/1.0.0"
+    make_plugin "evil@m" "$evil_path" \
+        '{"hooks":{"PostToolUse":[{"matcher":"Edit","hooks":[{"type":"command","command":"${CLAUDE_PLUGIN_ROOT}/evil.sh"}]}]}}'
+    add_to_registry "evil@m" "$evil_path"
+    set_enabled "evil@m"
+    seed_kapsis_settings_local
+
+    local stderr
+    stderr=$(run_inject_stderr)
+    local result
+    result=$(cat "$TEST_HOME/.claude/settings.local.json")
+
+    assert_not_contains "$result" "$evil_path" \
+        "Plugin outside trusted cache prefix must NOT be merged"
+    assert_contains "$stderr" "outside" \
+        "Must log a warning when refusing an installPath outside the cache prefix"
+
+    cleanup_test_home
+}
+
+#===============================================================================
+# TEST: installPath traversal (../) is rejected (realpath normalization)
+#===============================================================================
+
+test_installpath_traversal_blocked() {
+    log_test "installPath with ../ that escapes the cache prefix is refused"
+    setup_test_home
+
+    # Build a real plugin OUTSIDE the cache, then reference it via a path
+    # that LOOKS rooted at .claude/plugins/cache/ but escapes via .. components.
+    local real_path="$TEST_HOME/escaped/plugin/1.0.0"
+    make_plugin "trav@m" "$real_path" \
+        '{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"${CLAUDE_PLUGIN_ROOT}/x.sh"}]}]}}'
+
+    # Reference path with .. that escapes the trusted prefix
+    local traversed="$TEST_HOME/.claude/plugins/cache/../../../escaped/plugin/1.0.0"
+    add_to_registry "trav@m" "$traversed"
+    set_enabled "trav@m"
+    seed_kapsis_settings_local
+
+    run_inject
+    local result
+    result=$(cat "$TEST_HOME/.claude/settings.local.json")
+    assert_not_contains "$result" "/escaped/plugin" \
+        "Traversed installPath must NOT bypass the trusted prefix check"
+
+    cleanup_test_home
+}
+
+#===============================================================================
+# TEST: Corrupted KAPSIS_PLUGIN_WHITELIST fails CLOSED (no plugins injected)
+#===============================================================================
+
+test_whitelist_corruption_fails_closed() {
+    log_test "Corrupted KAPSIS_PLUGIN_WHITELIST fails closed (refuses all plugins)"
+    setup_test_home
+
+    local foo_path="$TEST_HOME/.claude/plugins/cache/m/foo/1.0.0"
+    make_plugin "foo@m" "$foo_path" \
+        '{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"${CLAUDE_PLUGIN_ROOT}/x.sh"}]}]}}'
+    add_to_registry "foo@m" "$foo_path"
+    set_enabled "foo@m"
+    seed_kapsis_settings_local
+
+    local before
+    before=$(cat "$TEST_HOME/.claude/settings.local.json")
+
+    # Not a JSON array — should be treated as a hard error, not "allow all".
+    KAPSIS_PLUGIN_WHITELIST='"not-an-array"' run_inject || true
+
+    local after
+    after=$(cat "$TEST_HOME/.claude/settings.local.json")
+    assert_equals "$before" "$after" \
+        "Corrupted whitelist must NOT cause plugin hooks to be injected (fail closed)"
+
+    cleanup_test_home
+}
+
+#===============================================================================
+# TEST: Whitelist with non-string entries also fails closed
+#===============================================================================
+
+test_whitelist_non_string_entries_fail_closed() {
+    log_test "Whitelist with non-string entries (e.g. numbers) fails closed"
+    setup_test_home
+
+    local foo_path="$TEST_HOME/.claude/plugins/cache/m/foo/1.0.0"
+    make_plugin "foo@m" "$foo_path" \
+        '{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"${CLAUDE_PLUGIN_ROOT}/x.sh"}]}]}}'
+    add_to_registry "foo@m" "$foo_path"
+    set_enabled "foo@m"
+    seed_kapsis_settings_local
+
+    local before
+    before=$(cat "$TEST_HOME/.claude/settings.local.json")
+
+    KAPSIS_PLUGIN_WHITELIST='[42,"foo@m"]' run_inject || true
+
+    local after
+    after=$(cat "$TEST_HOME/.claude/settings.local.json")
+    assert_equals "$before" "$after" \
+        "Whitelist with non-string entry must NOT inject any plugin (fail closed)"
+
+    cleanup_test_home
+}
+
+#===============================================================================
+# TEST: ${CLAUDE_PLUGIN_ROOT} appearing TWICE in one command is substituted both times
+#===============================================================================
+
+test_multiple_plugin_root_occurrences() {
+    log_test "Multiple \${CLAUDE_PLUGIN_ROOT} occurrences in one command are all substituted"
+    setup_test_home
+
+    local foo_path="$TEST_HOME/.claude/plugins/cache/m/foo/1.0.0"
+    make_plugin "foo@m" "$foo_path" \
+        '{"hooks":{"PostToolUse":[{"matcher":"Edit","hooks":[{"type":"command","command":"bash ${CLAUDE_PLUGIN_ROOT}/run.sh --lib ${CLAUDE_PLUGIN_ROOT}/lib/x.so"}]}]}}'
+    add_to_registry "foo@m" "$foo_path"
+    set_enabled "foo@m"
+    seed_kapsis_settings_local
+
+    run_inject
+    local merged_cmd
+    merged_cmd=$(jq -r '.hooks.PostToolUse[] | .hooks[]? | .command | select(contains("run.sh"))' \
+                 "$TEST_HOME/.claude/settings.local.json")
+
+    assert_contains "$merged_cmd" "$foo_path/run.sh" "First \${CLAUDE_PLUGIN_ROOT} substituted"
+    assert_contains "$merged_cmd" "$foo_path/lib/x.so" "Second \${CLAUDE_PLUGIN_ROOT} also substituted"
+    assert_not_contains "$merged_cmd" 'CLAUDE_PLUGIN_ROOT' \
+        "No \${CLAUDE_PLUGIN_ROOT} placeholder should remain"
+
+    cleanup_test_home
+}
+
+#===============================================================================
+# TEST: settings.local.json absent at start — created by injection
+#===============================================================================
+
+test_settings_local_absent_at_start() {
+    log_test "settings.local.json absent at start is created during injection"
+    setup_test_home
+
+    local foo_path="$TEST_HOME/.claude/plugins/cache/m/foo/1.0.0"
+    make_plugin "foo@m" "$foo_path" \
+        '{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"${CLAUDE_PLUGIN_ROOT}/x.sh"}]}]}}'
+    add_to_registry "foo@m" "$foo_path"
+    set_enabled "foo@m"
+    # NOTE: deliberately NOT calling seed_kapsis_settings_local — file absent
+    assert_file_not_exists "$TEST_HOME/.claude/settings.local.json" "Precondition: settings.local.json absent"
+
+    run_inject
+
+    assert_file_exists "$TEST_HOME/.claude/settings.local.json" "settings.local.json created"
+    local result
+    result=$(cat "$TEST_HOME/.claude/settings.local.json")
+    assert_contains "$result" "$foo_path/x.sh" "Plugin hook merged into new settings.local.json"
+
+    cleanup_test_home
+}
+
+#===============================================================================
+# TEST: Multi-plugin (5 plugins) — order preserved + all merged
+#===============================================================================
+
+test_multi_plugin_merge() {
+    log_test "Five plugins merged in one run — all present, kapsis hook first"
+    setup_test_home
+
+    local p
+    for p in p1 p2 p3 p4 p5; do
+        local pp="$TEST_HOME/.claude/plugins/cache/m/$p/1.0.0"
+        make_plugin "$p@m" "$pp" \
+            "$(printf '{"hooks":{"PostToolUse":[{"matcher":"Edit","hooks":[{"type":"command","command":"%s"}]}]}}' \
+                '${CLAUDE_PLUGIN_ROOT}/'"$p"'.sh')"
+        add_to_registry "$p@m" "$pp"
+    done
+    set_enabled "p1@m" "p2@m" "p3@m" "p4@m" "p5@m"
+    seed_kapsis_settings_local
+
+    run_inject
+
+    # kapsis-status-hook must be FIRST in PostToolUse (ordering invariant)
+    local first_cmd
+    first_cmd=$(jq -r '.hooks.PostToolUse[0].hooks[0].command' "$TEST_HOME/.claude/settings.local.json")
+    assert_contains "$first_cmd" "kapsis-status-hook.sh" "kapsis-status-hook must remain at index 0 in PostToolUse"
+
+    # All 5 plugin commands present
+    local result
+    result=$(cat "$TEST_HOME/.claude/settings.local.json")
+    for p in p1 p2 p3 p4 p5; do
+        assert_contains "$result" "/$p.sh" "Plugin $p@m's command present"
+    done
+
+    cleanup_test_home
+}
+
+#===============================================================================
+# TEST: Malformed hooks.json triggers WARN message (not just silent skip)
+#===============================================================================
+
+test_malformed_hooks_logs_warn() {
+    log_test "Malformed hooks.json logs a WARN message (audit signal)"
+    setup_test_home
+
+    local bad_path="$TEST_HOME/.claude/plugins/cache/m/bad/1.0.0"
+    mkdir -p "$bad_path/hooks"
+    echo 'this is not valid JSON {' > "$bad_path/hooks/hooks.json"
+    add_to_registry "bad@m" "$bad_path"
+    set_enabled "bad@m"
+    seed_kapsis_settings_local
+
+    local stderr
+    stderr=$(run_inject_stderr)
+
+    assert_contains "$stderr" "bad@m" \
+        "WARN must name the offending plugin id"
+    assert_contains "$stderr" "WARN" \
+        "Must log at WARN level (not silently skipped)"
+
+    cleanup_test_home
+}
+
+#===============================================================================
+# TEST: Intra-plugin duplicate commands are deduped in a single run
+#===============================================================================
+
+test_intra_plugin_dedup() {
+    log_test "Plugin with two groups referencing the same command — dedupes in a single run"
+    setup_test_home
+
+    local foo_path="$TEST_HOME/.claude/plugins/cache/m/foo/1.0.0"
+    # Two PostToolUse groups, different matchers, SAME command. After
+    # substitution both reference the same concrete path; the merger should
+    # dedupe within this single run, not just on a second pass.
+    make_plugin "foo@m" "$foo_path" \
+        '{"hooks":{"PostToolUse":[
+          {"matcher":"Edit","hooks":[{"type":"command","command":"${CLAUDE_PLUGIN_ROOT}/lint.sh"}]},
+          {"matcher":"Write","hooks":[{"type":"command","command":"${CLAUDE_PLUGIN_ROOT}/lint.sh"}]}
+        ]}}'
+    add_to_registry "foo@m" "$foo_path"
+    set_enabled "foo@m"
+    seed_kapsis_settings_local
+
+    run_inject
+    local occurrences
+    occurrences=$(jq '[.hooks.PostToolUse[] | .hooks[]? | .command | select(contains("lint.sh"))] | length' \
+                  "$TEST_HOME/.claude/settings.local.json")
+    assert_equals "1" "$occurrences" \
+        "lint.sh command must appear exactly once even though plugin lists it in two groups"
+
+    cleanup_test_home
+}
+
+#===============================================================================
 # MAIN
 #===============================================================================
 
@@ -364,14 +669,28 @@ main() {
     log_info "=== Basic injection ==="
     run_test test_single_plugin_no_whitelist
     run_test test_disabled_plugin_not_merged
+    run_test test_settings_local_absent_at_start
 
     log_info "=== Whitelist filtering ==="
     run_test test_whitelist_filters
     run_test test_empty_whitelist_allows_all
     run_test test_whitelist_missing_plugin_no_error
+    run_test test_whitelist_exact_match_not_substring
+    run_test test_whitelist_corruption_fails_closed
+    run_test test_whitelist_non_string_entries_fail_closed
+
+    log_info "=== installPath containment (security) ==="
+    run_test test_installpath_containment
+    run_test test_installpath_traversal_blocked
+
+    log_info "=== Substitution + merge correctness ==="
+    run_test test_multiple_plugin_root_occurrences
+    run_test test_intra_plugin_dedup
+    run_test test_multi_plugin_merge
 
     log_info "=== Robustness ==="
     run_test test_malformed_hooks_json
+    run_test test_malformed_hooks_logs_warn
     run_test test_missing_hooks_json
     run_test test_idempotency
     run_test test_gate_off_no_op


### PR DESCRIPTION
## Summary

Kapsis bypasses Claude Code's native plugin loader so the container can run safely in `--print`/headless mode. Side effect: **user-installed plugins like `deeperdive-java-linter` have their `hooks/hooks.json` on disk but nothing wires them into the active hook chain** — SessionStart, PreToolUse, PostToolUse all silently miss inside the container, while they fire correctly when running Claude Code interactively on the host.

This PR adds an opt-in injection step that runs inside the container after `inject-status-hooks.sh`:

1. Read `~/.claude/plugins/installed_plugins.json` (paths already rewritten by `rewrite-plugin-paths.sh`).
2. Filter to plugins that are (a) host-enabled in `~/.claude/settings.json::enabledPlugins` AND (b) in the optional `KAPSIS_PLUGIN_WHITELIST` (when set; empty/unset = allow all).
3. Read each plugin's `hooks/hooks.json`, substitute `${CLAUDE_PLUGIN_ROOT}` with the concrete installPath, and `jq`-merge the events into the same `settings.local.json` Kapsis already maintains.

Whitelist rationale: unattended runners (Slack bots, CI agents) want to lock the in-container plugin surface to a vetted set even when the host has more plugins enabled. Interactive use leaves the whitelist unset to inherit the host's full plugin set.

## Configuration

```yaml
agent:
  type: claude-cli
  install_plugins: true            # default true for claude-cli, false otherwise
  plugin_whitelist:                # optional; unset/[] = allow all host-enabled
    - "deeperdive-java-linter@deeperdive"
```

Plumbed via `launch-agent.sh` → `KAPSIS_INSTALL_PLUGINS` + `KAPSIS_PLUGIN_WHITELIST` env vars (same pattern as the existing `KAPSIS_INJECT_GIST` / `KAPSIS_GIST_LLM`).

## Ordering

`kapsis-status` and `kapsis-gist` hooks stay first in `PostToolUse` so the status hook can read `/workspace/.kapsis/gist.txt` before any plugin hook mutates it. Plugin hooks append after.

## Tests

9 new test cases in `tests/test-plugin-hook-injection.sh` covering:

- Single plugin, no whitelist → merged with concrete path
- Host-disabled plugin → NOT merged
- Whitelist filtering (only listed plugins merged)
- Empty whitelist (`[]`) → behaves like unset (allow all)
- Whitelist references uninstalled plugin → silently skipped
- Plugin with malformed `hooks.json` → warn + continue with others
- Plugin without `hooks.json` → skipped (no error)
- Idempotency: two runs produce byte-identical `settings.local.json`
- `KAPSIS_INSTALL_PLUGINS=false` → `settings.local.json` untouched

All 9 pass locally. Existing test suites (`test-plugin-path-rewrite.sh`, `test-status-hooks.sh`, `test-agent-type-detection.sh`) still pass — no regressions.

## What is NOT included

Only plugin **hooks** are injected. Plugin skills (`skills/`), slash commands (`commands/`), subagents (`agents/`), and plugin-declared MCP servers are still loader-territory and stay out of scope. Hooks referencing their own plugin's skills via relative paths work, because hooks are anchored to the plugin's concrete installPath after substitution.

## Test plan

- [x] `bash -n` syntax check on all modified/new files
- [x] `shellcheck -x` clean on new files; no new warnings around edited lines
- [x] New test file: 9/9 PASS
- [x] Regression: `test-plugin-path-rewrite.sh` (10/10), `test-agent-type-detection.sh` (17/17), `test-status-hooks.sh` (61/61)
- [ ] After merge: enable in `slack-bot-agent.yaml` (`install_plugins: true` + `plugin_whitelist`), restart the bot, verify `deeperdive-java-linter`'s `SessionStart` and `PostToolUse` Edit/Write hooks actually fire on a real agent run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)