### PR TITLE
feat(plugins): inject Claude Code plugin hooks into settings.local.json

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,7 @@ kapsis/
 │   │   ├── progress-monitor.sh # Progress tracking
 │   │   ├── inject-status-hooks.sh # Status hook injection
 │   │   ├── inject-lsp-config.sh   # LSP configuration injection
+│   │   ├── inject-plugin-hooks.sh # Plugin hook injection (Claude Code plugins)
 │   │   ├── build-config.sh     # Build configuration parser
 │   │   ├── atomic-copy.sh      # Atomic file copy operations
 │   │   ├── audit.sh            # Audit trail recording
@@ -144,6 +145,7 @@ kapsis/
 | Security vulnerability scan | `docs/SECURITY-VULNERABILITY-SCAN.md` |
 | Agent profiles design | `docs/designs/agent-profiles-architecture.md` |
 | Agent profiles | `configs/agents/*.yaml` |
+| Plugin hook injection | `docs/PLUGINS.md` |
 | Security policy | `SECURITY.md` |
 | AI agent guidelines | `AGENTS.md` |
 
@@ -240,6 +242,7 @@ Status is written as JSON to `~/.kapsis/status/`.
 | `scripts/lib/podman-health.sh` | Podman VM health probe & auto-heal (macOS pre-launch mount check) |
 | `scripts/lib/status-sync.sh` | Mirrors per-agent named volumes to `~/.kapsis/status/` (macOS) |
 | `scripts/lib/inject-lsp-config.sh` | LSP config injection — editor integration inside containers |
+| `scripts/lib/inject-plugin-hooks.sh` | Plugin hook injection — merges Claude Code plugin hooks into settings.local.json |
 | `scripts/lib/rewrite-plugin-paths.sh` | Plugin path rewriting — adjusts paths for container mounts |
 | `scripts/lib/ssh-config-compat.sh` | SSH config portability — normalizes SSH config across environments |
 | `scripts/backends/podman.sh` | Podman backend — local container execution |

--- a/docs/CONFIG-REFERENCE.md
+++ b/docs/CONFIG-REFERENCE.md
@@ -166,6 +166,20 @@ agent:
   # Default: 60
   gist_llm_interval: 60
 
+  # Inject Claude Code plugin hooks from the host into the container.
+  # When true, Kapsis merges hooks from each host-enabled (and whitelisted) plugin's
+  # hooks/hooks.json into ~/.claude/settings.local.json at container startup.
+  # Only applies to claude-cli / claude / claude-code agent types.
+  # Default: false (opt-in)
+  install_plugins: false
+
+  # Restrict which plugins may be injected (optional allowlist).
+  # Must be a JSON array of exact plugin ids (e.g. ["deeperdive-java-linter@m"]).
+  # Empty array [] or omitting the key allows all host-enabled plugins.
+  # Corrupted (non-array) value is fail-closed: no plugins are injected.
+  # Default: [] (allow all host-enabled plugins)
+  plugin_whitelist: []
+
 #===============================================================================
 # FILESYSTEM MOUNTS
 #===============================================================================

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -1,6 +1,6 @@
 # Claude Code plugin support
 
-Claude Code's `--print` / headless mode does load plugins from settings as interactive mode would. The reason Kapsis needs its own plugin-hook injection step is that the container starts from a CoW-filtered subset of `~/.claude/` and runs without the interactive trust dialog plugins rely on at first install, so the loader sees an environment in which the host's plugin hooks are not auto-registered into the active hook chain. This page describes the opt-in mechanism Kapsis provides to bring **plugin hooks** back into the container.
+Claude Code's `--print` / headless mode does **not** load plugins from settings as interactive mode would. The reason Kapsis needs its own plugin-hook injection step is that the container starts from a CoW-filtered subset of `~/.claude/` and runs without the interactive trust dialog plugins rely on at first install, so the loader sees an environment in which the host's plugin hooks are not auto-registered into the active hook chain. This page describes the opt-in mechanism Kapsis provides to bring **plugin hooks** back into the container.
 
 ## What gets loaded
 

--- a/scripts/lib/inject-plugin-hooks.sh
+++ b/scripts/lib/inject-plugin-hooks.sh
@@ -275,7 +275,7 @@ inject_plugin_hooks() {
         # Emits {settings: <merged>, plugin_hook_count: N} so the caller gets
         # both values without a follow-up jq fork.
         local tmp_file plugin_hook_count
-        tmp_file=$(mktemp)
+        tmp_file=$(mktemp -p "$(dirname "$settings_local")")
         if jq \
             --slurpfile plugin_data "$hooks_file" \
             --arg plugin_root "$install_path" \
@@ -313,17 +313,16 @@ inject_plugin_hooks() {
             )
             | {settings: ., plugin_hook_count: $plugin_hook_count}
             ' \
-            "$settings_local" > "$tmp_file" 2>/dev/null; then
-            # Split combined result into settings (atomic mv) + count (log)
-            plugin_hook_count=$(jq -r '.plugin_hook_count' "$tmp_file")
-            jq -c '.settings' "$tmp_file" > "${tmp_file}.settings" \
-                && mv "${tmp_file}.settings" "$settings_local"
-            rm -f "$tmp_file"
+            "$settings_local" > "$tmp_file" 2>/dev/null \
+            && plugin_hook_count=$(jq -r '.plugin_hook_count' "$tmp_file" 2>/dev/null) \
+            && jq -c '.settings' "$tmp_file" > "${tmp_file}.settings" 2>/dev/null \
+            && mv "${tmp_file}.settings" "$settings_local"; then
+            rm -f "$tmp_file" "${tmp_file}.settings"
             chmod 600 "$settings_local"
             log_info "Loaded plugin ${plugin_id} (plugin_hooks=${plugin_hook_count}, root=${install_path})"
             merged_count=$((merged_count + 1))
         else
-            rm -f "$tmp_file"
+            rm -f "$tmp_file" "${tmp_file}.settings"
             log_warn "Plugin ${plugin_id}: jq merge failed — skipping (other plugins still processed)"
         fi
     done < <(printf '%s' "$candidates_json" | jq -r '.[] | "\(.id)\t\(.installPath)"')

--- a/tests/test-plugin-hook-injection.sh
+++ b/tests/test-plugin-hook-injection.sh
@@ -629,6 +629,99 @@ test_malformed_hooks_logs_warn() {
 }
 
 #===============================================================================
+# TEST: Pre-existing malformed settings.local.json is handled gracefully
+#===============================================================================
+
+test_malformed_settings_local_handled() {
+    log_test "Pre-existing malformed settings.local.json: plugin is skipped with WARN, not crash"
+    setup_test_home
+
+    local foo_path="$TEST_HOME/.claude/plugins/cache/m/foo/1.0.0"
+    make_plugin "foo@m" "$foo_path" \
+        '{"hooks":{"PostToolUse":[{"matcher":"*","hooks":[{"type":"command","command":"${CLAUDE_PLUGIN_ROOT}/run.sh"}]}]}}'
+    add_to_registry "foo@m" "$foo_path"
+    set_enabled "foo@m"
+
+    # Write truncated / corrupted JSON — simulates a crashed prior run
+    printf '{this is not valid JSON' > "$TEST_HOME/.claude/settings.local.json"
+
+    local stderr
+    stderr=$(run_inject_stderr)
+
+    # The jq merge will fail on the corrupted file; plugin must be skipped
+    assert_contains "$stderr" "WARN" \
+        "Must log WARN when merge fails on corrupted settings.local.json"
+    assert_contains "$stderr" "foo@m" \
+        "WARN must name the affected plugin"
+
+    # The corrupted file must not have been silently replaced with a different
+    # truncation — check it still starts with the original corrupt prefix
+    local first_char
+    first_char=$(head -c 1 "$TEST_HOME/.claude/settings.local.json")
+    assert_equals "{" "$first_char" \
+        "Corrupted settings.local.json must not be silently wiped"
+
+    cleanup_test_home
+}
+
+#===============================================================================
+# TEST: Symlink-rejection for settings.local.json, plugins_file, user_settings
+#===============================================================================
+
+test_symlink_settings_local_rejected() {
+    log_test "Symlinked settings.local.json is rejected (security: redirect-write defense)"
+    setup_test_home
+
+    local foo_path="$TEST_HOME/.claude/plugins/cache/m/foo/1.0.0"
+    make_plugin "foo@m" "$foo_path" \
+        '{"hooks":{"PostToolUse":[{"matcher":"*","hooks":[{"type":"command","command":"${CLAUDE_PLUGIN_ROOT}/run.sh"}]}]}}'
+    add_to_registry "foo@m" "$foo_path"
+    set_enabled "foo@m"
+
+    # Create a real target and then symlink settings.local.json to it
+    local real_target="$TEST_HOME/real-settings.json"
+    echo '{}' > "$real_target"
+    ln -s "$real_target" "$TEST_HOME/.claude/settings.local.json"
+
+    local stderr
+    stderr=$(run_inject_stderr)
+
+    assert_contains "$stderr" "symlink" \
+        "Must log symlink refusal message"
+    assert_contains "$stderr" "WARN" \
+        "Symlink refusal must be at WARN level"
+
+    cleanup_test_home
+}
+
+test_symlink_installed_plugins_rejected() {
+    log_test "Symlinked installed_plugins.json is rejected (security: attacker-content defense)"
+    setup_test_home
+
+    local foo_path="$TEST_HOME/.claude/plugins/cache/m/foo/1.0.0"
+    make_plugin "foo@m" "$foo_path" \
+        '{"hooks":{"PostToolUse":[{"matcher":"*","hooks":[{"type":"command","command":"${CLAUDE_PLUGIN_ROOT}/run.sh"}]}]}}'
+
+    # Create a real registry file and symlink installed_plugins.json to it
+    local real_registry="$TEST_HOME/real-registry.json"
+    echo '{"version":2,"plugins":{}}' > "$real_registry"
+    ln -s "$real_registry" "$TEST_HOME/.claude/plugins/installed_plugins.json"
+
+    set_enabled "foo@m"
+    seed_kapsis_settings_local
+
+    local stderr
+    stderr=$(run_inject_stderr)
+
+    assert_contains "$stderr" "symlink" \
+        "Must log symlink refusal for installed_plugins.json"
+    assert_contains "$stderr" "WARN" \
+        "Symlink refusal must be at WARN level"
+
+    cleanup_test_home
+}
+
+#===============================================================================
 # TEST: Intra-plugin duplicate commands are deduped in a single run
 #===============================================================================
 
@@ -691,9 +784,14 @@ main() {
     log_info "=== Robustness ==="
     run_test test_malformed_hooks_json
     run_test test_malformed_hooks_logs_warn
+    run_test test_malformed_settings_local_handled
     run_test test_missing_hooks_json
     run_test test_idempotency
     run_test test_gate_off_no_op
+
+    log_info "=== Symlink rejection (security) ==="
+    run_test test_symlink_settings_local_rejected
+    run_test test_symlink_installed_plugins_rejected
 
     print_summary
 }


### PR DESCRIPTION
## Summary

- Adds `scripts/lib/inject-plugin-hooks.sh` — injects Claude Code plugin hooks (status, stop) into `settings.local.json` inside the container at startup
- Wires hook injection into `scripts/entrypoint.sh` and `scripts/launch-agent.sh`
- Adds comprehensive tests in `tests/test-plugin-hook-injection.sh`
- Adds `docs/PLUGINS.md` reference guide for plugin hook configuration

## Changes

- `scripts/lib/inject-plugin-hooks.sh` — new library for plugin hook injection
- `scripts/entrypoint.sh` — calls hook injection at container startup
- `scripts/launch-agent.sh` — pre-launch plugin hook setup
- `tests/test-plugin-hook-injection.sh` — 701-line test suite
- `docs/PLUGINS.md` — plugin hooks documentation

## Test plan

- [ ] `./tests/run-all-tests.sh --quick` passes
- [ ] `shellcheck scripts/lib/inject-plugin-hooks.sh` passes
- [ ] Plugin hooks are injected correctly inside container at startup

https://claude.ai/code/session_012Gmtu6W93gTxZM99TkxEiP

---
_Generated by [Claude Code](https://claude.ai/code/session_012Gmtu6W93gTxZM99TkxEiP)_