### PR TITLE
fix(overlay): make status tracking work with read-only workspace (#328)

### DIFF
--- a/configs/aider.yaml
+++ b/configs/aider.yaml
@@ -3,7 +3,10 @@
 
 agent:
   # Aider with message file input and auto-yes
-  command: "aider --yes-always --message-file /task-spec.md"
+  # KAPSIS_INJECTED_TASK_SPEC is set by entrypoint.sh when status injection
+  # appends progress/gist guidance to a writable copy of the task spec. Falls
+  # back to the read-only /task-spec.md mount when no injection happened.
+  command: "aider --yes-always --message-file \"${KAPSIS_INJECTED_TASK_SPEC:-/task-spec.md}\""
   workdir: /workspace
 
 filesystem:

--- a/configs/claude.yaml
+++ b/configs/claude.yaml
@@ -3,7 +3,10 @@
 
 agent:
   # Claude Code with spec file input
-  command: "claude --dangerously-skip-permissions -p \"$(cat /task-spec.md)\""
+  # KAPSIS_INJECTED_TASK_SPEC is set by entrypoint.sh when status injection
+  # appends progress/gist guidance to a writable copy of the task spec. Falls
+  # back to the read-only /task-spec.md mount when no injection happened.
+  command: "claude --dangerously-skip-permissions -p \"$(cat \"${KAPSIS_INJECTED_TASK_SPEC:-/task-spec.md}\")\""
   workdir: /workspace
 
 filesystem:

--- a/configs/codex.yaml
+++ b/configs/codex.yaml
@@ -3,7 +3,10 @@
 
 agent:
   # Codex CLI with full auto approval
-  command: "codex --approval-mode full-auto \"$(cat /task-spec.md)\""
+  # KAPSIS_INJECTED_TASK_SPEC is set by entrypoint.sh when status injection
+  # appends progress/gist guidance to a writable copy of the task spec. Falls
+  # back to the read-only /task-spec.md mount when no injection happened.
+  command: "codex --approval-mode full-auto \"$(cat \"${KAPSIS_INJECTED_TASK_SPEC:-/task-spec.md}\")\""
   workdir: /workspace
 
 filesystem:

--- a/docs/STATUS-TRACKING.md
+++ b/docs/STATUS-TRACKING.md
@@ -245,9 +245,20 @@ Each write overwrites the previous gist, so `kapsis-status` always shows the age
 ### Configuration
 
 ```bash
-# Default path (can be overridden)
+# Worktree mode default (writable /workspace)
 export KAPSIS_GIST_FILE=/workspace/.kapsis/gist.txt
+
+# Overlay mode default — /workspace is read-only, so the gist file lives on
+# the per-agent /kapsis-status volume (set automatically by launch-agent.sh)
+export KAPSIS_GIST_FILE=/kapsis-status/gist.txt
 ```
+
+In overlay mode, agents are told the active path via the injected task spec
+(rendered from `scripts/lib/gist-instructions.md` with `@@KAPSIS_GIST_FILE@@`
+substituted). `kapsis-status-hook.sh` reads whichever path
+`$KAPSIS_GIST_FILE` points to, and `status_read_gist_file()` in
+`scripts/lib/status.sh` accepts both `/workspace/.kapsis/` and
+`/kapsis-status/` (traversal still blocked by `realpath -m` canonicalization).
 
 ### Viewing Gists
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1334,15 +1334,19 @@ inject_progress_instructions() {
 
     # Append instructions to task spec (copy to writable location first)
     local injected_spec="$kapsis_dir/task-spec-with-progress.md"
+    local write_err
+    write_err=$(mktemp)
     if ! {
         cat "$task_spec"
         echo ""
         echo ""
         cat "$instructions"
-    } > "$injected_spec" 2>/dev/null; then
-        log_warn "Could not write $injected_spec — skipping progress injection"
+    } > "$injected_spec" 2>"$write_err"; then
+        log_warn "Could not write $injected_spec — skipping progress injection: $(tr '\n' ' ' <"$write_err")"
+        rm -f "$write_err"
         return 0
     fi
+    rm -f "$write_err"
 
     # If gist tracking is enabled, render gist instructions with the live
     # $KAPSIS_GIST_FILE path substituted and append onto the same spec. This is
@@ -1350,15 +1354,19 @@ inject_progress_instructions() {
     # since CLAUDE.md / AGENTS.md appends are skipped there.
     if [[ "${KAPSIS_INJECT_GIST:-false}" == "true" ]]; then
         local inject_script="$KAPSIS_HOME/lib/inject-status-hooks.sh"
+        local rendered_gist append_err
         if [[ -x "$inject_script" ]]; then
             if rendered_gist=$("$inject_script" --render-gist-instructions 2>/dev/null); then
-                {
+                append_err=$(mktemp)
+                if ! {
                     echo ""
                     echo "---"
                     echo ""
                     echo "$rendered_gist"
-                } >> "$injected_spec" 2>/dev/null \
-                    || log_warn "Could not append gist instructions to $injected_spec"
+                } >> "$injected_spec" 2>"$append_err"; then
+                    log_warn "Could not append gist instructions to $injected_spec: $(tr '\n' ' ' <"$append_err")"
+                fi
+                rm -f "$append_err"
             fi
         fi
     fi

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1190,6 +1190,14 @@ gemini-cli|Gemini CLI"
                 fi
                 ;;
         esac
+
+        # Overlay mode: workspace-side gist surfacing (CLAUDE.md / AGENTS.md
+        # appends) is skipped because /workspace is read-only. Surface the
+        # gist & progress instructions via the injected task spec instead
+        # so the agent still gets the guidance in-band (issue #328).
+        if [[ "${KAPSIS_SANDBOX_MODE:-}" == "overlay" ]]; then
+            inject_progress_instructions
+        fi
     elif [[ " $python_agents " == *" $agent_type "* ]]; then
         # Python agent - status.py library available
         log_info "Python agent - status.py library available for direct integration"
@@ -1286,7 +1294,17 @@ start_progress_monitor() {
     log_debug "Progress monitor started (PID: $PROGRESS_MONITOR_PID)"
 }
 
-# Inject progress reporting instructions into task spec
+# Inject progress reporting instructions into task spec.
+#
+# Worktree mode: writes to /workspace/.kapsis/task-spec-with-progress.md
+#                (workspace is writable).
+# Overlay  mode: writes to /kapsis-status/task-spec-with-progress.md
+#                (workspace is read-only; /kapsis-status is the writable
+#                status volume — see issue #328).
+#
+# When KAPSIS_INJECT_GIST=true, gist instructions are appended to the same
+# injected spec so the agent learns both how to report progress and how to
+# update its activity gist via $KAPSIS_GIST_FILE.
 inject_progress_instructions() {
     local task_spec="/task-spec.md"
     local instructions="$KAPSIS_HOME/lib/progress-instructions.md"
@@ -1301,28 +1319,49 @@ inject_progress_instructions() {
         return 0
     fi
 
-    # Skip progress injection in overlay mode — workspace is read-only (kapsis#204)
+    local kapsis_dir
     if [[ "${KAPSIS_SANDBOX_MODE:-}" == "overlay" ]]; then
-        log_info "Skipping progress injection (overlay mode — read-only workspace)"
-        return 0
-    fi
-
-    log_info "Injecting progress reporting instructions..."
-
-    local kapsis_dir="/workspace/.kapsis"
-    if ! mkdir -p "$kapsis_dir" 2>/dev/null; then
-        log_warn "Could not create /workspace/.kapsis — skipping progress injection"
-        return 0
+        kapsis_dir="/kapsis-status"
+        log_info "Injecting progress reporting instructions (overlay mode → $kapsis_dir)..."
+    else
+        kapsis_dir="/workspace/.kapsis"
+        log_info "Injecting progress reporting instructions..."
+        if ! mkdir -p "$kapsis_dir" 2>/dev/null; then
+            log_warn "Could not create $kapsis_dir — skipping progress injection"
+            return 0
+        fi
     fi
 
     # Append instructions to task spec (copy to writable location first)
     local injected_spec="$kapsis_dir/task-spec-with-progress.md"
-    {
+    if ! {
         cat "$task_spec"
         echo ""
         echo ""
         cat "$instructions"
-    } > "$injected_spec"
+    } > "$injected_spec" 2>/dev/null; then
+        log_warn "Could not write $injected_spec — skipping progress injection"
+        return 0
+    fi
+
+    # If gist tracking is enabled, render gist instructions with the live
+    # $KAPSIS_GIST_FILE path substituted and append onto the same spec. This is
+    # the in-band channel that tells the agent the gist path in overlay mode,
+    # since CLAUDE.md / AGENTS.md appends are skipped there.
+    if [[ "${KAPSIS_INJECT_GIST:-false}" == "true" ]]; then
+        local inject_script="$KAPSIS_HOME/lib/inject-status-hooks.sh"
+        if [[ -x "$inject_script" ]]; then
+            if rendered_gist=$("$inject_script" --render-gist-instructions 2>/dev/null); then
+                {
+                    echo ""
+                    echo "---"
+                    echo ""
+                    echo "$rendered_gist"
+                } >> "$injected_spec" 2>/dev/null \
+                    || log_warn "Could not append gist instructions to $injected_spec"
+            fi
+        fi
+    fi
 
     # Export path to injected spec
     export KAPSIS_INJECTED_TASK_SPEC="$injected_spec"

--- a/scripts/launch-agent.sh
+++ b/scripts/launch-agent.sh
@@ -1799,6 +1799,11 @@ generate_env_vars() {
     ENV_VARS+=("-e" "KAPSIS_STATUS_AGENT_ID=${AGENT_ID}")
     ENV_VARS+=("-e" "KAPSIS_STATUS_BRANCH=${BRANCH:-}")
     ENV_VARS+=("-e" "KAPSIS_INJECT_GIST=${INJECT_GIST:-false}")
+    # Overlay mode: /workspace is read-only, so re-home the runtime gist file
+    # onto the always-writable /kapsis-status volume (issue #328).
+    if [[ "${SANDBOX_MODE}" == "overlay" ]]; then
+        ENV_VARS+=("-e" "KAPSIS_GIST_FILE=/kapsis-status/gist.txt")
+    fi
     ENV_VARS+=("-e" "KAPSIS_GIST_LLM=${GIST_LLM:-false}")
     ENV_VARS+=("-e" "KAPSIS_GIST_LLM_INTERVAL=${GIST_LLM_INTERVAL:-60}")
     ENV_VARS+=("-e" "KAPSIS_INSTALL_PLUGINS=${INSTALL_PLUGINS:-false}")

--- a/scripts/lib/gist-instructions.md
+++ b/scripts/lib/gist-instructions.md
@@ -1,11 +1,11 @@
 # Kapsis Activity Gist
 
-Update `/workspace/.kapsis/gist.txt` with your current activity at the START of each significant work phase. This helps users monitor your progress in real-time.
+Update `@@KAPSIS_GIST_FILE@@` with your current activity at the START of each significant work phase. This helps users monitor your progress in real-time.
 
 ## How to Update
 
 ```bash
-echo "your current activity" > /workspace/.kapsis/gist.txt
+echo "your current activity" > @@KAPSIS_GIST_FILE@@
 ```
 
 ## When to Update
@@ -24,5 +24,5 @@ echo "your current activity" > /workspace/.kapsis/gist.txt
 ## Example
 
 ```bash
-echo "Analyzing authentication flow in UserService" > /workspace/.kapsis/gist.txt
+echo "Analyzing authentication flow in UserService" > @@KAPSIS_GIST_FILE@@
 ```

--- a/scripts/lib/inject-status-hooks.sh
+++ b/scripts/lib/inject-status-hooks.sh
@@ -274,10 +274,37 @@ EOF
 # Gist Instructions (All Agents)
 #===============================================================================
 
+#-------------------------------------------------------------------------------
+# Render the gist-instructions.md template with the live $KAPSIS_GIST_FILE
+# value substituted for the @@KAPSIS_GIST_FILE@@ placeholder. Prints the
+# rendered text to stdout. Shared between workspace-side injection (CLAUDE.md /
+# AGENTS.md) and task-spec injection (overlay mode).
+#-------------------------------------------------------------------------------
+render_gist_instructions() {
+    local template="${1:-${KAPSIS_LIB:-/opt/kapsis/lib}/gist-instructions.md}"
+    local gist_file="${KAPSIS_GIST_FILE:-/workspace/.kapsis/gist.txt}"
+
+    if [[ ! -f "$template" ]]; then
+        return 1
+    fi
+
+    # Use awk so we don't need to escape sed delimiters; gist_file is a path.
+    awk -v gf="$gist_file" '{ gsub(/@@KAPSIS_GIST_FILE@@/, gf); print }' "$template"
+}
+
 inject_gist_instructions() {
     # Requires opt-in via config (default: false for safe rollout)
     if [[ "${KAPSIS_INJECT_GIST:-false}" != "true" ]]; then
         log_debug "Gist injection disabled (set agent.inject_gist: true to enable)"
+        return 0
+    fi
+
+    # In overlay mode the workspace is read-only by design. Skip workspace-side
+    # writes entirely; the agent gets gist guidance via the injected task spec
+    # (see inject_progress_instructions in entrypoint.sh). Mirrors the existing
+    # overlay short-circuit pattern.
+    if [[ "${KAPSIS_SANDBOX_MODE:-}" == "overlay" ]]; then
+        log_info "Skipping gist instructions injection (overlay mode — read-only workspace)"
         return 0
     fi
 
@@ -301,16 +328,23 @@ inject_gist_instructions() {
 
     local marker="Kapsis Activity Gist"
     local injected=false
+    local rendered
+    rendered=$(render_gist_instructions "$gist_instructions") || {
+        log_warn "Failed to render gist instructions -- skipping"
+        return 0
+    }
 
     # Append to CLAUDE.md if it exists (for Claude Code)
     local claude_md="${workspace}/CLAUDE.md"
     if [[ -f "$claude_md" ]]; then
-        if ! grep -q "$marker" "$claude_md" 2>/dev/null; then
+        if [[ ! -w "$claude_md" ]]; then
+            log_warn "$claude_md is not writable -- skipping gist append"
+        elif ! grep -q "$marker" "$claude_md" 2>/dev/null; then
             {
                 echo ""
                 echo "---"
                 echo ""
-                cat "$gist_instructions"
+                echo "$rendered"
             } >> "$claude_md"
             log_debug "Gist instructions appended to $claude_md"
             injected=true
@@ -320,12 +354,14 @@ inject_gist_instructions() {
     # Append to AGENTS.md if it exists (for Gemini CLI, Codex CLI)
     local agents_md="${workspace}/AGENTS.md"
     if [[ -f "$agents_md" ]]; then
-        if ! grep -q "$marker" "$agents_md" 2>/dev/null; then
+        if [[ ! -w "$agents_md" ]]; then
+            log_warn "$agents_md is not writable -- skipping gist append"
+        elif ! grep -q "$marker" "$agents_md" 2>/dev/null; then
             {
                 echo ""
                 echo "---"
                 echo ""
-                cat "$gist_instructions"
+                echo "$rendered"
             } >> "$agents_md"
             log_debug "Gist instructions appended to $agents_md"
             injected=true
@@ -335,9 +371,12 @@ inject_gist_instructions() {
     # Always create .kapsis/README.md as fallback for agents that explore workspace
     local kapsis_readme="${kapsis_dir}/README.md"
     if [[ ! -f "$kapsis_readme" ]]; then
-        cp "$gist_instructions" "$kapsis_readme"
-        log_debug "Gist instructions placed in $kapsis_readme"
-        injected=true
+        if printf '%s\n' "$rendered" > "$kapsis_readme" 2>/dev/null; then
+            log_debug "Gist instructions placed in $kapsis_readme"
+            injected=true
+        else
+            log_warn "Could not write $kapsis_readme -- skipping"
+        fi
     fi
 
     if [[ "$injected" == "true" ]]; then
@@ -390,5 +429,13 @@ inject_kapsis_hooks() {
 
 # Run if executed directly (not sourced)
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-    inject_kapsis_hooks "$@"
+    case "${1:-}" in
+        --render-gist-instructions)
+            shift
+            render_gist_instructions "$@"
+            ;;
+        *)
+            inject_kapsis_hooks "$@"
+            ;;
+    esac
 fi

--- a/scripts/lib/inject-status-hooks.sh
+++ b/scripts/lib/inject-status-hooks.sh
@@ -12,6 +12,10 @@
 #
 # Usage: Called automatically by entrypoint.sh for supported agents
 #        Or call directly: ./inject-status-hooks.sh [agent-type]
+#        Or render the gist preamble standalone (used by entrypoint.sh to
+#        append it onto the injected task spec in overlay mode):
+#          ./inject-status-hooks.sh --render-gist-instructions
+#        Honours $KAPSIS_GIST_FILE for placeholder substitution.
 #
 # Environment:
 #   KAPSIS_STATUS_AGENT_ID - Required: Agent ID for status tracking
@@ -288,8 +292,23 @@ render_gist_instructions() {
         return 1
     fi
 
-    # Use awk so we don't need to escape sed delimiters; gist_file is a path.
-    awk -v gf="$gist_file" '{ gsub(/@@KAPSIS_GIST_FILE@@/, gf); print }' "$template"
+    # Use index()-based splitting rather than gsub() so neither the path nor
+    # the placeholder is parsed for special characters (gsub's replacement
+    # parser would consume `&` and `\`; awk's `-v` would consume `\s`, `\n`,
+    # ...). Pass the path via ENVIRON to skip -v's escape processing too.
+    # Today the only callers set paths like /kapsis-status/gist.txt — this
+    # keeps the helper safe for any future caller without an escape audit.
+    KAPSIS_GIST_FILE_RENDER="$gist_file" awk '
+        BEGIN { gf = ENVIRON["KAPSIS_GIST_FILE_RENDER"]; needle = "@@KAPSIS_GIST_FILE@@"; nlen = length(needle) }
+        {
+            out = ""; line = $0
+            while ((pos = index(line, needle)) > 0) {
+                out = out substr(line, 1, pos - 1) gf
+                line = substr(line, pos + nlen)
+            }
+            print out line
+        }
+    ' "$template"
 }
 
 inject_gist_instructions() {

--- a/scripts/lib/status.sh
+++ b/scripts/lib/status.sh
@@ -460,7 +460,7 @@ status_set_heartbeat() {
 #   $1 - Path to gist file (default: $KAPSIS_GIST_FILE)
 # Security:
 #   - Path is canonicalized with realpath to prevent traversal attacks
-#   - Only reads files within /workspace/.kapsis/ directory
+#   - Only reads files within /workspace/.kapsis/ or /kapsis-status/ (overlay mode)
 # Rate Limiting:
 #   - Time debounce: Skip read if read within last N seconds (KAPSIS_GIST_DEBOUNCE, default: 5)
 #   - Mtime bypass: If file changed (different mtime), read immediately
@@ -473,8 +473,10 @@ status_read_gist_file() {
     canonical_path=$(realpath -m "$gist_file" 2>/dev/null) || return 0
 
     # Security: Only allow gist files within the workspace .kapsis directory
-    local allowed_prefix="/workspace/.kapsis/"
-    if [[ "$canonical_path" != "${allowed_prefix}"* ]]; then
+    # (worktree mode) or the dedicated status volume (overlay mode, where
+    # /workspace is read-only and gist files live on /kapsis-status).
+    if [[ "$canonical_path" != "/workspace/.kapsis/"* \
+       && "$canonical_path" != "/kapsis-status/"* ]]; then
         # Path escapes allowed directory - silently ignore for security
         return 0
     fi

--- a/tests/test-status-hooks.sh
+++ b/tests/test-status-hooks.sh
@@ -893,6 +893,39 @@ test_status_read_gist_accepts_kapsis_status_volume() {
     status_read_gist_file "/kapsis-status/../etc/passwd" >/dev/null 2>&1 || true
     assert_equals "$before" "${_KAPSIS_GIST:-}" "Traversal must still be rejected"
 
+    # Positive acceptance: a real file under /kapsis-status/ must be read and
+    # update _KAPSIS_GIST. Skip gracefully if the test environment can't create
+    # /kapsis-status/ (non-root host, no sudo) — exercised in container CI.
+    if mkdir -p /kapsis-status 2>/dev/null && [[ -w /kapsis-status ]]; then
+        local gist_file="/kapsis-status/gist-test-$$.txt"
+        echo "exploring authentication flow" > "$gist_file"
+        # Reset rate-limit state and re-read
+        _KAPSIS_GIST_LAST_READ=""
+        _KAPSIS_GIST_LAST_MTIME=""
+        status_read_gist_file "$gist_file" >/dev/null 2>&1 || true
+        assert_contains "${_KAPSIS_GIST:-}" "authentication" \
+            "Real file under /kapsis-status/ must be accepted and read"
+        rm -f "$gist_file"
+    fi
+
+    cleanup_inject_test_env
+}
+
+test_render_gist_instructions_escapes_special_chars() {
+    # Issue #328 review feedback: awk gsub() treats `&` and `\` specially in
+    # the replacement string. Verify paths containing them substitute
+    # literally (defensive — production paths never contain these).
+    setup_inject_test_env
+    source "$LIB_DIR/inject-status-hooks.sh"
+
+    local rendered
+    rendered=$(KAPSIS_GIST_FILE='/tmp/has&amp/gist.txt' render_gist_instructions)
+    assert_contains "$rendered" "/tmp/has&amp/gist.txt" "& must be substituted literally"
+    assert_not_contains "$rendered" "@@KAPSIS_GIST_FILE@@" "Placeholder must be fully replaced"
+
+    rendered=$(KAPSIS_GIST_FILE='/tmp/back\slash/gist.txt' render_gist_instructions)
+    assert_contains "$rendered" '/tmp/back\slash/gist.txt' "Backslash must be substituted literally"
+
     cleanup_inject_test_env
 }
 
@@ -1588,6 +1621,7 @@ run_tests() {
     run_test test_inject_gist_readonly_workspace
     run_test test_inject_gist_overlay_mode_skipped
     run_test test_render_gist_instructions_substitutes_path
+    run_test test_render_gist_instructions_escapes_special_chars
     run_test test_status_read_gist_accepts_kapsis_status_volume
 
     log_info "=== Agent Type Inference ==="

--- a/tests/test-status-hooks.sh
+++ b/tests/test-status-hooks.sh
@@ -868,11 +868,11 @@ test_render_gist_instructions_substitutes_path() {
     source "$LIB_DIR/inject-status-hooks.sh"
 
     local rendered
-    KAPSIS_GIST_FILE="/kapsis-status/gist.txt" rendered=$(render_gist_instructions)
+    rendered=$(KAPSIS_GIST_FILE="/kapsis-status/gist.txt" render_gist_instructions)
     assert_contains "$rendered" "/kapsis-status/gist.txt" "Overlay path should be substituted"
     assert_not_contains "$rendered" "@@KAPSIS_GIST_FILE@@" "Placeholder must be fully replaced"
 
-    KAPSIS_GIST_FILE="/workspace/.kapsis/gist.txt" rendered=$(render_gist_instructions)
+    rendered=$(KAPSIS_GIST_FILE="/workspace/.kapsis/gist.txt" render_gist_instructions)
     assert_contains "$rendered" "/workspace/.kapsis/gist.txt" "Worktree path should be substituted"
 
     cleanup_inject_test_env

--- a/tests/test-status-hooks.sh
+++ b/tests/test-status-hooks.sh
@@ -829,6 +829,73 @@ test_inject_gist_explicit_false() {
     cleanup_inject_test_env
 }
 
+test_inject_gist_overlay_mode_skipped() {
+    # Issue #328: in overlay mode the workspace is read-only by design, so
+    # inject_gist_instructions must skip all workspace writes (CLAUDE.md /
+    # AGENTS.md / .kapsis) cleanly — the agent gets gist guidance via the
+    # task-spec injection path instead.
+    setup_inject_test_env
+    export KAPSIS_STATUS_AGENT_ID="test-gist-overlay"
+    export KAPSIS_INJECT_GIST="true"
+    export KAPSIS_SANDBOX_MODE="overlay"
+
+    local workspace
+    workspace=$(mktemp -d)
+    export KAPSIS_WORKSPACE="$workspace"
+    echo "# Project" > "$workspace/CLAUDE.md"
+    echo "# Agents" > "$workspace/AGENTS.md"
+
+    source "$LIB_DIR/inject-status-hooks.sh"
+    local exit_code
+    inject_gist_instructions >/dev/null 2>&1
+    exit_code=$?
+
+    assert_equals "0" "$exit_code" "Should exit 0 in overlay mode (graceful skip)"
+    assert_equals "# Project" "$(cat "$workspace/CLAUDE.md")" "CLAUDE.md must be unchanged in overlay mode"
+    assert_equals "# Agents" "$(cat "$workspace/AGENTS.md")" "AGENTS.md must be unchanged in overlay mode"
+    assert_true "[[ ! -d '$workspace/.kapsis' ]]" ".kapsis directory must not be created in overlay mode"
+
+    unset KAPSIS_SANDBOX_MODE
+    rm -rf "$workspace"
+    cleanup_inject_test_env
+}
+
+test_render_gist_instructions_substitutes_path() {
+    # Issue #328: render_gist_instructions replaces @@KAPSIS_GIST_FILE@@ with
+    # the live $KAPSIS_GIST_FILE so overlay-mode agents see /kapsis-status/...
+    # while worktree-mode agents see /workspace/.kapsis/...
+    setup_inject_test_env
+    source "$LIB_DIR/inject-status-hooks.sh"
+
+    local rendered
+    KAPSIS_GIST_FILE="/kapsis-status/gist.txt" rendered=$(render_gist_instructions)
+    assert_contains "$rendered" "/kapsis-status/gist.txt" "Overlay path should be substituted"
+    assert_not_contains "$rendered" "@@KAPSIS_GIST_FILE@@" "Placeholder must be fully replaced"
+
+    KAPSIS_GIST_FILE="/workspace/.kapsis/gist.txt" rendered=$(render_gist_instructions)
+    assert_contains "$rendered" "/workspace/.kapsis/gist.txt" "Worktree path should be substituted"
+
+    cleanup_inject_test_env
+}
+
+test_status_read_gist_accepts_kapsis_status_volume() {
+    # Issue #328: status_read_gist_file() must accept paths under
+    # /kapsis-status/ (overlay mode) in addition to /workspace/.kapsis/
+    # (worktree mode), while still rejecting traversal attempts.
+    setup_inject_test_env
+    # shellcheck source=/dev/null
+    source "$LIB_DIR/status.sh"
+
+    local before="${_KAPSIS_GIST:-}"
+    status_read_gist_file "/etc/passwd" >/dev/null 2>&1 || true
+    assert_equals "$before" "${_KAPSIS_GIST:-}" "Non-allowed path must not update gist state"
+
+    status_read_gist_file "/kapsis-status/../etc/passwd" >/dev/null 2>&1 || true
+    assert_equals "$before" "${_KAPSIS_GIST:-}" "Traversal must still be rejected"
+
+    cleanup_inject_test_env
+}
+
 test_inject_gist_readonly_workspace() {
     setup_inject_test_env
     export KAPSIS_STATUS_AGENT_ID="test-gist-7"
@@ -1519,6 +1586,9 @@ run_tests() {
     run_test test_inject_gist_no_markdown_files
     run_test test_inject_gist_explicit_false
     run_test test_inject_gist_readonly_workspace
+    run_test test_inject_gist_overlay_mode_skipped
+    run_test test_render_gist_instructions_substitutes_path
+    run_test test_status_read_gist_accepts_kapsis_status_volume
 
     log_info "=== Agent Type Inference ==="
     run_test test_agent_type_inference_from_image_name


### PR DESCRIPTION
## Summary

Fixes the entrypoint crash that makes pure overlay-mode launches 100% broken on macOS (issue #328) while preserving the read-only guarantee of overlay mode. The whole point of overlay is that `/workspace` is RO — so status tracking now lives off-workspace, on the always-writable `/kapsis-status` named volume that's already mounted for status JSON.

**Scope:** status side only. The companion `fuse-overlayfs` / `atomic_copy_dir` failures for HOME-side staged configs (`.claude`, `.ssh`, ...) are a separate code path and stay out of this PR — they need their own follow-up.

## What was broken

In overlay mode:
1. `inject-status-hooks.sh` unconditionally appended a gist preamble to `/workspace/CLAUDE.md`. Read-only mount → raw bash redirect error → entrypoint exits 1 before the agent runs.
2. `KAPSIS_GIST_FILE` defaulted to `/workspace/.kapsis/gist.txt` — also unwritable.
3. `KAPSIS_INJECTED_TASK_SPEC` was exported but no consumer read it, so even the existing progress-instructions injection never actually reached the agent.

## What changed

| File | Change |
|------|--------|
| `scripts/lib/inject-status-hooks.sh` | Short-circuit `inject_gist_instructions()` in overlay mode (mirrors existing pattern); `[[ -w ]]` guards on `CLAUDE.md` / `AGENTS.md` appends; new `render_gist_instructions()` helper (substitutes `@@KAPSIS_GIST_FILE@@`), exposed via `--render-gist-instructions` |
| `scripts/launch-agent.sh` | In overlay mode, also export `KAPSIS_GIST_FILE=/kapsis-status/gist.txt` |
| `scripts/lib/status.sh` | `status_read_gist_file()` allow-prefix accepts `/kapsis-status/` in addition to `/workspace/.kapsis/`; `realpath` canonicalization still blocks traversal |
| `scripts/lib/gist-instructions.md` | `/workspace/.kapsis/gist.txt` → `@@KAPSIS_GIST_FILE@@` placeholder |
| `scripts/entrypoint.sh` | `inject_progress_instructions()` writes to `/kapsis-status` in overlay mode and appends rendered gist instructions; now called from the hook-capable branch in overlay mode so claude/codex/gemini agents get gist guidance in-band when CLAUDE.md/AGENTS.md surfacing is unavailable |
| `configs/{claude,codex,aider}.yaml` | Read task spec from `${KAPSIS_INJECTED_TASK_SPEC:-/task-spec.md}` so the rendered spec actually reaches the agent |
| `tests/test-status-hooks.sh` | +3 tests: overlay short-circuit, placeholder substitution, allow-prefix accepts `/kapsis-status/` and still rejects traversal |

## After this change

| Path | Worktree mode | Overlay mode |
|------|---------------|--------------|
| Status JSON | `/kapsis-status/...json` | `/kapsis-status/...json` |
| Agent gist file | `/workspace/.kapsis/gist.txt` | `/kapsis-status/gist.txt` |
| Task spec (rendered) | `/workspace/.kapsis/task-spec-with-progress.md` | `/kapsis-status/task-spec-with-progress.md` |
| `CLAUDE.md` / `AGENTS.md` gist preamble | appended (existing behaviour) | skipped (workspace stays untouched) |
| Entrypoint exit on RO `/workspace` | n/a | clean — no more "Read-only file system" |

## Test plan

- [x] `bash -n` syntax check on all modified scripts — clean
- [x] `bash ./tests/test-status-reporting.sh` — 27/27 pass
- [x] `bash ./tests/test-status-hooks.sh` — 64/64 pass (was 61, +3 new)
- [x] Manual render check: `KAPSIS_GIST_FILE=/kapsis-status/gist.txt ./scripts/lib/inject-status-hooks.sh --render-gist-instructions` produces the right path
- [x] Manual security check: `status_read_gist_file /kapsis-status/../etc/passwd` returns 0 with no state change
- [ ] **Container smoke (needs Podman host)**: launch any agent in overlay mode against a directory containing a `CLAUDE.md`; expect entrypoint completes with `Skipping gist instructions injection (overlay mode — read-only workspace)` and the agent runs to completion (`status.json` reaches phase `complete`, no `Read-only file system` error).
- [ ] **Worktree regression**: same launch with `--branch foo --base-branch main` still appends the gist preamble to `/workspace/CLAUDE.md` and writes `/workspace/.kapsis/gist.txt`.
- [ ] **Gist flow in overlay**: inside the container, `echo "doing X" > "$KAPSIS_GIST_FILE"` succeeds and the next `kapsis-status.sh --json` reports the gist text.
- [ ] **Task-spec delivery**: in overlay mode, `cat "$KAPSIS_INJECTED_TASK_SPEC"` shows the original task + progress instructions + gist instructions with `/kapsis-status/gist.txt` substituted.

## Out of scope

- HOME-side `fuse-overlayfs` / `atomic_copy_dir` failures for staged configs (issue #328 fix candidates #1–#3). Those need their own PR.
- Surfacing rendered instructions via `~/.claude/settings.local.json` system-prompt addition — the task-spec channel covers all three hook-capable agents uniformly, so no per-agent surfacing is needed for this fix.

https://claude.ai/code/session_01Sbaa3HjXG5RoraUN65iQ1s

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sbaa3HjXG5RoraUN65iQ1s)_