### PR TITLE
fix(atomic-copy): tolerate benign cp stderr from unstattable readdir entries (#328 root cause)

### DIFF
--- a/scripts/lib/atomic-copy.sh
+++ b/scripts/lib/atomic-copy.sh
@@ -141,6 +141,42 @@ _atomic_run_mktemp() {
 }
 
 #-------------------------------------------------------------------------------
+# _atomic_cp_stat_only_failures <cp_stderr>
+#
+# Returns 0 when every non-empty line of the captured cp stderr is a
+# benign "cp: cannot stat 'X': No such file or directory" entry —
+# meaning cp's non-zero exit is explained entirely by readdir/stat
+# mismatch on transient or unstattable entries (sockets, FIFOs, files
+# deleted mid-copy). Caller MUST still validate the payload via the
+# regular-file count comparison; this helper only certifies that the
+# stderr signal is non-fatal.
+#
+# Returns 1 if stderr is empty (no signal to whitelist) OR if any line
+# is unrecognized — caller must treat as a real failure.
+#
+# Motivating case (issue #328): on macOS hosts, virtio-fs returns
+# AF_UNIX socket entries from readdir() but ENOENT from stat(). cp -rp
+# emits one "cannot stat" line per socket and exits 1, but every
+# regular file IS copied byte-for-byte. Refusing to recognize this
+# pattern makes overlay-mode staged-config copy unusable on every host
+# that has git fsmonitor (`.claude`), an ssh-agent socket (`.ssh`), or
+# any other live IPC in a staged dir.
+#-------------------------------------------------------------------------------
+_atomic_cp_stat_only_failures() {
+    local stderr="$1"
+    [[ -z "$stderr" ]] && return 1
+    while IFS= read -r line; do
+        [[ -z "$line" ]] && continue
+        # GNU cp stderr format: cp: cannot stat 'PATH': No such file or directory
+        if [[ "$line" =~ ^cp:[[:space:]]cannot[[:space:]]stat[[:space:]].+:[[:space:]]No[[:space:]]such[[:space:]]file[[:space:]]or[[:space:]]directory$ ]]; then
+            continue
+        fi
+        return 1
+    done <<< "$stderr"
+    return 0
+}
+
+#-------------------------------------------------------------------------------
 # atomic_copy_file <src> <dst>
 #
 # Atomically copies a single file with validation.
@@ -282,6 +318,12 @@ atomic_copy_dir() {
             mkdir -p "$dst" 2>/dev/null || true
             direct_err=$(cp -rp "$src/." "$dst/" 2>&1) && direct_rc=0 || direct_rc=$?
             find "$dst" -type d -exec chmod u+w {} + 2>/dev/null || true
+            # Issue #328: tolerate benign cp stderr from virtio-fs (sockets/FIFOs
+            # readdir-visible but stat-invisible). See helper docstring.
+            if [[ $direct_rc -ne 0 ]] && _atomic_cp_stat_only_failures "$direct_err"; then
+                log_debug "atomic_copy_dir: last-resort direct cp non-zero for $(basename "$dst") but stderr is benign; deferring to count check"
+                direct_rc=0
+            fi
             if [[ $direct_rc -ne 0 ]]; then
                 log_warn "atomic_copy_dir: direct cp failed for $(basename "$dst"): ${direct_err:-no stderr}"
                 return 1
@@ -299,8 +341,15 @@ atomic_copy_dir() {
         fi
 
         log_debug "atomic_copy_dir: using cross-fs scratch ${tmp_dir} for $(basename "$dst")"
-        local cp_err
-        if cp_err=$(cp -rp "$src/." "$tmp_dir/" 2>&1); then
+        # Issue #328: tolerate benign cp stderr from virtio-fs (sockets/FIFOs
+        # readdir-visible but stat-invisible). See helper docstring.
+        local cp_err cp_rc
+        cp_err=$(cp -rp "$src/." "$tmp_dir/" 2>&1) && cp_rc=0 || cp_rc=$?
+        if [[ $cp_rc -ne 0 ]] && _atomic_cp_stat_only_failures "$cp_err"; then
+            log_debug "atomic_copy_dir: scratch-stage cp non-zero for $(basename "$dst") but stderr is benign; deferring to count check"
+            cp_rc=0
+        fi
+        if [[ $cp_rc -eq 0 ]]; then
             find "$tmp_dir" -type d -exec chmod u+w {} + 2>/dev/null || true
 
             # Issue #328 (review finding #2): the stage cp into dst must not
@@ -347,9 +396,20 @@ atomic_copy_dir() {
         return 1
     fi
 
-    # Copy contents to temp directory (preserve permissions)
-    local cp_err
-    if cp_err=$(cp -rp "$src/." "$tmp_dir/" 2>&1); then
+    # Copy contents to temp directory (preserve permissions).
+    # Issue #328 (root cause comment): cp may exit non-zero solely because
+    # virtio-fs returns AF_UNIX socket entries from readdir() but ENOENT
+    # from stat() (typical on macOS host → Linux guest). Every regular
+    # file IS still copied. Tolerate that exact signal and let the count
+    # validation below be the final arbiter.
+    local cp_err cp_rc
+    cp_err=$(cp -rp "$src/." "$tmp_dir/" 2>&1) && cp_rc=0 || cp_rc=$?
+    if [[ $cp_rc -ne 0 ]] && _atomic_cp_stat_only_failures "$cp_err"; then
+        log_debug "atomic_copy_dir: cp non-zero for $(basename "$dst") but stderr is benign (unstattable entries skipped); deferring to count check"
+        cp_rc=0
+    fi
+
+    if [[ $cp_rc -eq 0 ]]; then
         find "$tmp_dir" -type d -exec chmod u+w {} + 2>/dev/null || true
 
         # Validate: compare file counts

--- a/scripts/lib/atomic-copy.sh
+++ b/scripts/lib/atomic-copy.sh
@@ -140,19 +140,42 @@ _atomic_run_mktemp() {
     return "$rc"
 }
 
+# GNU coreutils cp emits this exact format for ENOENT during recursive
+# copy: `cp: cannot stat 'PATH': No such file or directory`. atomic_copy_dir
+# always runs inside the Linux container (GNU cp), never against BSD cp on
+# a macOS host — atomic_copy_dir is invoked only from scripts/entrypoint.sh
+# inside the kapsis sandbox. BSD cp's `cp: PATH: cannot stat` form would
+# fail this match and be treated as a real failure (fail-safe).
+#
+# Caller pins LC_ALL=C around the cp invocation so locale translations
+# can't defeat the regex on non-English container images.
+# Guard against `readonly` failing on re-source (tests use _reset_atomic_copy_lib).
+if [[ -z "${_ATOMIC_CP_STAT_ENOENT_REGEX:-}" ]]; then
+    readonly _ATOMIC_CP_STAT_ENOENT_REGEX='^cp:[[:space:]]cannot[[:space:]]stat[[:space:]].+:[[:space:]]No[[:space:]]such[[:space:]]file[[:space:]]or[[:space:]]directory$'
+fi
+
 #-------------------------------------------------------------------------------
-# _atomic_cp_stat_only_failures <cp_stderr>
+# _atomic_cp_stderr_is_stat_enoent_only <cp_stderr>
 #
-# Returns 0 when every non-empty line of the captured cp stderr is a
-# benign "cp: cannot stat 'X': No such file or directory" entry —
-# meaning cp's non-zero exit is explained entirely by readdir/stat
-# mismatch on transient or unstattable entries (sockets, FIFOs, files
-# deleted mid-copy). Caller MUST still validate the payload via the
-# regular-file count comparison; this helper only certifies that the
-# stderr signal is non-fatal.
+# Returns 0 when the captured cp stderr contains at least one non-empty
+# line AND every non-empty line is a benign "cp: cannot stat 'X': No
+# such file or directory" entry — meaning cp's non-zero exit is
+# explained entirely by readdir/stat mismatch on unstattable entries
+# (sockets, FIFOs, files deleted mid-copy). The caller MUST still
+# validate the payload via the regular-file count comparison; this
+# helper only certifies that the stderr signal is non-fatal.
 #
-# Returns 1 if stderr is empty (no signal to whitelist) OR if any line
-# is unrecognized — caller must treat as a real failure.
+# Returns 1 if stderr is empty, contains only whitespace, OR has any
+# unrecognized line — caller must treat as a real failure.
+#
+# Limitation (issue #328 root-cause comment): _atomic_count_files uses
+# `find -type f`, which itself calls stat(). If a REGULAR file in the
+# source tree exhibits the same readdir-visible-but-stat-ENOENT
+# pathology (vs. just sockets), it would be excluded from BOTH source
+# and destination counts — and slip through silently. In the
+# motivating macOS+virtio-fs case the ENOENT pattern is restricted to
+# AF_UNIX socket inodes, so this is theoretical; documenting for
+# future hardening.
 #
 # Motivating case (issue #328): on macOS hosts, virtio-fs returns
 # AF_UNIX socket entries from readdir() but ENOENT from stat(). cp -rp
@@ -162,18 +185,54 @@ _atomic_run_mktemp() {
 # that has git fsmonitor (`.claude`), an ssh-agent socket (`.ssh`), or
 # any other live IPC in a staged dir.
 #-------------------------------------------------------------------------------
-_atomic_cp_stat_only_failures() {
+_atomic_cp_stderr_is_stat_enoent_only() {
     local stderr="$1"
     [[ -z "$stderr" ]] && return 1
+    local saw_line=0
     while IFS= read -r line; do
         [[ -z "$line" ]] && continue
-        # GNU cp stderr format: cp: cannot stat 'PATH': No such file or directory
-        if [[ "$line" =~ ^cp:[[:space:]]cannot[[:space:]]stat[[:space:]].+:[[:space:]]No[[:space:]]such[[:space:]]file[[:space:]]or[[:space:]]directory$ ]]; then
+        saw_line=1
+        if [[ "$line" =~ $_ATOMIC_CP_STAT_ENOENT_REGEX ]]; then
             continue
         fi
         return 1
     done <<< "$stderr"
-    return 0
+    # Reject whitespace-only / newline-only stderr (no signal to whitelist).
+    [[ $saw_line -eq 1 ]] && return 0
+    return 1
+}
+
+#-------------------------------------------------------------------------------
+# _atomic_cp_with_enoent_tolerance <site_label> <cp_args...>
+#
+# Wraps `cp $cp_args` to centralize the issue #328 stat-ENOENT
+# tolerance pattern across atomic_copy_dir's three cp call sites
+# (main path, scratch-fallback, last-resort direct cp).
+#
+# Behavior:
+#   1. Runs `LC_ALL=C cp "$@"` with stderr captured (LC_ALL=C pins the
+#      diagnostic format so locale translations cannot defeat the
+#      classifier).
+#   2. If cp exits non-zero AND every stderr line matches the benign
+#      stat-ENOENT signature, treat as success — caller's regular-file
+#      count comparison is the final guard.
+#   3. Sets _ATOMIC_CP_STDERR so the caller can include the raw stderr
+#      in a log_warn message on real failures.
+#
+# Returns: cp's exit code, possibly rewritten 1→0 by the tolerance
+# rule. <site_label> is included in the log_debug message so operators
+# can identify which patched path activated tolerance.
+#-------------------------------------------------------------------------------
+_atomic_cp_with_enoent_tolerance() {
+    local site="$1"; shift
+    local cp_err cp_rc
+    cp_err=$(LC_ALL=C cp "$@" 2>&1) && cp_rc=0 || cp_rc=$?
+    if [[ $cp_rc -ne 0 ]] && _atomic_cp_stderr_is_stat_enoent_only "$cp_err"; then
+        log_debug "atomic_copy_dir: cp non-zero in ${site} but stderr is stat-ENOENT only; deferring to count check"
+        cp_rc=0
+    fi
+    _ATOMIC_CP_STDERR="$cp_err"
+    return "$cp_rc"
 }
 
 #-------------------------------------------------------------------------------
@@ -314,18 +373,13 @@ atomic_copy_dir() {
             # Issue #328 (review finding #1): return reflects whether the
             # direct cp actually succeeded, so callers don't log a false
             # "validation failed" for data that's intact on disk.
-            local direct_err direct_rc
             mkdir -p "$dst" 2>/dev/null || true
-            direct_err=$(cp -rp "$src/." "$dst/" 2>&1) && direct_rc=0 || direct_rc=$?
+            _atomic_cp_with_enoent_tolerance "last-resort direct cp for $(basename "$dst")" \
+                -rp "$src/." "$dst/"
+            local direct_rc=$?
             find "$dst" -type d -exec chmod u+w {} + 2>/dev/null || true
-            # Issue #328: tolerate benign cp stderr from virtio-fs (sockets/FIFOs
-            # readdir-visible but stat-invisible). See helper docstring.
-            if [[ $direct_rc -ne 0 ]] && _atomic_cp_stat_only_failures "$direct_err"; then
-                log_debug "atomic_copy_dir: last-resort direct cp non-zero for $(basename "$dst") but stderr is benign; deferring to count check"
-                direct_rc=0
-            fi
             if [[ $direct_rc -ne 0 ]]; then
-                log_warn "atomic_copy_dir: direct cp failed for $(basename "$dst"): ${direct_err:-no stderr}"
+                log_warn "atomic_copy_dir: direct cp failed for $(basename "$dst"): ${_ATOMIC_CP_STDERR:-no stderr}"
                 return 1
             fi
             # Validate file count matches; only then can we report success.
@@ -342,14 +396,11 @@ atomic_copy_dir() {
 
         log_debug "atomic_copy_dir: using cross-fs scratch ${tmp_dir} for $(basename "$dst")"
         # Issue #328: tolerate benign cp stderr from virtio-fs (sockets/FIFOs
-        # readdir-visible but stat-invisible). See helper docstring.
-        local cp_err cp_rc
-        cp_err=$(cp -rp "$src/." "$tmp_dir/" 2>&1) && cp_rc=0 || cp_rc=$?
-        if [[ $cp_rc -ne 0 ]] && _atomic_cp_stat_only_failures "$cp_err"; then
-            log_debug "atomic_copy_dir: scratch-stage cp non-zero for $(basename "$dst") but stderr is benign; deferring to count check"
-            cp_rc=0
-        fi
-        if [[ $cp_rc -eq 0 ]]; then
+        # readdir-visible but stat-invisible). See _atomic_cp_with_enoent_tolerance.
+        _atomic_cp_with_enoent_tolerance "scratch-stage cp src→tmp for $(basename "$dst")" \
+            -rp "$src/." "$tmp_dir/"
+        local scratch_cp_rc=$?
+        if [[ $scratch_cp_rc -eq 0 ]]; then
             find "$tmp_dir" -type d -exec chmod u+w {} + 2>/dev/null || true
 
             # Issue #328 (review finding #2): the stage cp into dst must not
@@ -371,6 +422,8 @@ atomic_copy_dir() {
                 fi
             fi
 
+            # tmp_dir → dst: scratch is local FS we just populated, no
+            # virtio-fs socket pathology — keep plain cp rc semantics.
             local stage_err
             stage_err=$(cp -rp "$tmp_dir/." "$dst/" 2>&1) || {
                 log_warn "atomic_copy_dir: stage cp into $dst failed: ${stage_err:-no stderr}"
@@ -380,8 +433,7 @@ atomic_copy_dir() {
             find "$dst" -type d -exec chmod u+w {} + 2>/dev/null || true
             rm -rf "$tmp_dir" 2>/dev/null || true
 
-            # Compare tmp_dir (what we staged) vs dst — would be src vs dst
-            # but tmp_dir was already validated against src above via cp rc.
+            # Compare src vs dst regular-file counts as the final guard.
             local src_count dst_count
             src_count=$(_atomic_count_files "$src")
             dst_count=$(_atomic_count_files "$dst")
@@ -391,23 +443,17 @@ atomic_copy_dir() {
             log_warn "atomic_copy_dir: scratch-path file count mismatch (src=${src_count} dst=${dst_count}) for $(basename "$dst")"
             return 1
         fi
-        log_warn "atomic_copy_dir: scratch-stage cp failed for $(basename "$dst"): ${cp_err:-no stderr}"
+        log_warn "atomic_copy_dir: scratch-stage cp failed for $(basename "$dst"): ${_ATOMIC_CP_STDERR:-no stderr}"
         rm -rf "$tmp_dir" 2>/dev/null || true
         return 1
     fi
 
     # Copy contents to temp directory (preserve permissions).
-    # Issue #328 (root cause comment): cp may exit non-zero solely because
-    # virtio-fs returns AF_UNIX socket entries from readdir() but ENOENT
-    # from stat() (typical on macOS host → Linux guest). Every regular
-    # file IS still copied. Tolerate that exact signal and let the count
-    # validation below be the final arbiter.
-    local cp_err cp_rc
-    cp_err=$(cp -rp "$src/." "$tmp_dir/" 2>&1) && cp_rc=0 || cp_rc=$?
-    if [[ $cp_rc -ne 0 ]] && _atomic_cp_stat_only_failures "$cp_err"; then
-        log_debug "atomic_copy_dir: cp non-zero for $(basename "$dst") but stderr is benign (unstattable entries skipped); deferring to count check"
-        cp_rc=0
-    fi
+    # Issue #328: tolerate benign cp stderr from virtio-fs (sockets/FIFOs
+    # readdir-visible but stat-invisible). See _atomic_cp_with_enoent_tolerance.
+    _atomic_cp_with_enoent_tolerance "main path cp src→tmp for $(basename "$dst")" \
+        -rp "$src/." "$tmp_dir/"
+    local cp_rc=$?
 
     if [[ $cp_rc -eq 0 ]]; then
         find "$tmp_dir" -type d -exec chmod u+w {} + 2>/dev/null || true
@@ -428,7 +474,7 @@ atomic_copy_dir() {
         rm -rf "$tmp_dir" 2>/dev/null || true
     else
         rm -rf "$tmp_dir" 2>/dev/null || true
-        log_warn "atomic_copy_dir: cp failed for $(basename "$dst"): ${cp_err:-no stderr}"
+        log_warn "atomic_copy_dir: cp failed for $(basename "$dst"): ${_ATOMIC_CP_STDERR:-no stderr}"
     fi
 
     # Fallback: copy directly (better to have potentially incomplete files than none)

--- a/tests/test-atomic-copy.sh
+++ b/tests/test-atomic-copy.sh
@@ -844,161 +844,219 @@ test_atomic_copy_dir_mktemp_stderr_does_not_corrupt_path_on_success() {
 #===============================================================================
 # Issue #328 root-cause follow-up: tolerate benign cp stderr from
 # virtio-fs (sockets/FIFOs readdir-visible but stat-invisible).
+#
+# Helper unit tests are split into focused functions so a failure in one
+# scenario does not mask failures in subsequent ones.
 #===============================================================================
 
-test_atomic_cp_stat_only_failures_helper() {
-    log_test "_atomic_cp_stat_only_failures: classifies cp stderr correctly"
+# Shared cp override builder for benign-stat scenarios. Simulates a
+# virtio-fs source that emits "cannot stat" lines for fake socket
+# entries when read by cp, but otherwise copies regular files. The mock
+# only fires when SOURCE (second-to-last argv after `-rp $src/.`) starts
+# with $BENIGN_STAT_SRC_PREFIX — so scratch-path's second cp
+# ($tmp_dir/. → $dst/) is unaffected, as expected for a local-FS copy
+# with no host-side sockets.
+#
+# Caller exports before invoking _install_benign_stat_cp_mock:
+#   BENIGN_STAT_NAMES       — space-separated fake socket basenames
+#   BENIGN_STAT_SRC_PREFIX  — prefix of the source argv to trigger on
+#   EXTRA_STDERR            — (optional) extra real-error line(s)
+#
+# Detection of the recursive form looks for `-rp` anywhere in argv (not
+# just $1), so a future refactor that moves the flag does not silently
+# turn the mock into a no-op.
 
-    # Empty stderr → no signal to whitelist → returns 1 (caller must treat
-    # as real failure rather than silently succeeding on missing signal).
-    _atomic_cp_stat_only_failures "" && {
-        echo "  FAIL: empty stderr should NOT be treated as benign"
-        return 1
+# shellcheck disable=SC2317  # invoked indirectly via shell override
+_install_benign_stat_cp_mock() {
+    cp() {
+        local args=("$@")
+        local n=${#args[@]}
+        local last=${args[n-1]}
+        local src_arg=""
+        [[ $n -ge 2 ]] && src_arg=${args[n-2]}
+        local has_rp=0
+        local a
+        for a in "$@"; do
+            [[ "$a" == "-rp" ]] && has_rp=1 && break
+        done
+        local should_fire=0
+        if [[ $has_rp -eq 1 ]]; then
+            if [[ -z "${BENIGN_STAT_SRC_PREFIX:-}" ]] \
+                || [[ "$src_arg" == "${BENIGN_STAT_SRC_PREFIX}"* ]]; then
+                should_fire=1
+            fi
+        fi
+        if [[ $should_fire -eq 1 ]]; then
+            command cp "$@"
+            local name
+            for name in $BENIGN_STAT_NAMES; do
+                echo "cp: cannot stat '$last/$name': No such file or directory" >&2
+            done
+            if [[ -n "${EXTRA_STDERR:-}" ]]; then
+                printf '%s\n' "$EXTRA_STDERR" >&2
+            fi
+            return 1
+        fi
+        command cp "$@"
     }
+}
 
-    # Single benign line → 0.
-    local one_line
-    one_line=$'cp: cannot stat \'/x/foo.ipc\': No such file or directory'
-    if ! _atomic_cp_stat_only_failures "$one_line"; then
-        echo "  FAIL: single 'cannot stat ENOENT' line should be benign"
+test_atomic_cp_stderr_empty_is_not_benign() {
+    log_test "_atomic_cp_stderr_is_stat_enoent_only: empty stderr → not benign"
+    if _atomic_cp_stderr_is_stat_enoent_only ""; then
+        echo "  FAIL: empty stderr should NOT be treated as benign (no signal to whitelist)"
         return 1
     fi
-
-    # Multiple benign lines (blank line in middle should be tolerated) → 0.
-    local many_benign
-    many_benign=$'cp: cannot stat \'/x/a.ipc\': No such file or directory\n\ncp: cannot stat \'/x/b.ipc\': No such file or directory'
-    if ! _atomic_cp_stat_only_failures "$many_benign"; then
-        echo "  FAIL: multiple 'cannot stat ENOENT' lines should be benign"
-        return 1
-    fi
-
-    # Benign + real error mixed → 1.
-    local mixed
-    mixed=$'cp: cannot stat \'/x/a.ipc\': No such file or directory\ncp: cannot create regular file \'/x/y\': Permission denied'
-    if _atomic_cp_stat_only_failures "$mixed"; then
-        echo "  FAIL: mixed stderr (benign + real error) should NOT be benign"
-        return 1
-    fi
-
-    # Unrelated cp failure (no "cannot stat" lines at all) → 1.
-    local real_err
-    real_err=$'cp: cannot create directory \'/x\': Read-only file system'
-    if _atomic_cp_stat_only_failures "$real_err"; then
-        echo "  FAIL: real cp error should NOT be classified benign"
-        return 1
-    fi
-
-    # Different ENOENT subject (e.g. cannot open) → 1.
-    local enoent_other
-    enoent_other=$'cp: cannot open \'/x/a\': No such file or directory'
-    if _atomic_cp_stat_only_failures "$enoent_other"; then
-        echo "  FAIL: only 'cannot stat ... ENOENT' should be benign, not 'cannot open'"
-        return 1
-    fi
-
     return 0
 }
 
-test_atomic_copy_dir_tolerates_benign_stat_errors() {
-    log_test "atomic_copy_dir: main path treats cp ENOENT-on-readdir-entries as benign when count matches (Issue #328)"
+test_atomic_cp_stderr_whitespace_only_is_not_benign() {
+    log_test "_atomic_cp_stderr_is_stat_enoent_only: newline-only stderr → not benign (review finding)"
+    # All-whitespace stderr previously bypassed the empty-string guard and
+    # was classified benign — covered here so a regression reintroduces it.
+    if _atomic_cp_stderr_is_stat_enoent_only $'\n\n'; then
+        echo "  FAIL: stderr of '\\n\\n' must NOT be treated as benign"
+        return 1
+    fi
+    return 0
+}
 
-    local src="$TEST_TEMP_DIR/src/benign_stat_src"
-    local dst="$TEST_TEMP_DIR/dst/benign_stat_dst"
+test_atomic_cp_stderr_single_benign_line() {
+    log_test "_atomic_cp_stderr_is_stat_enoent_only: single 'cannot stat ENOENT' line → benign"
+    local line=$'cp: cannot stat \'/x/foo.ipc\': No such file or directory'
+    if ! _atomic_cp_stderr_is_stat_enoent_only "$line"; then
+        echo "  FAIL: single benign line should be classified benign"
+        return 1
+    fi
+    return 0
+}
+
+test_atomic_cp_stderr_multiple_benign_lines() {
+    log_test "_atomic_cp_stderr_is_stat_enoent_only: multiple benign lines (with blank in middle) → benign"
+    local many=$'cp: cannot stat \'/x/a.ipc\': No such file or directory\n\ncp: cannot stat \'/x/b.ipc\': No such file or directory'
+    if ! _atomic_cp_stderr_is_stat_enoent_only "$many"; then
+        echo "  FAIL: multiple benign lines should be classified benign"
+        return 1
+    fi
+    return 0
+}
+
+test_atomic_cp_stderr_mixed_benign_and_real_is_not_benign() {
+    log_test "_atomic_cp_stderr_is_stat_enoent_only: benign + Permission denied → not benign"
+    local mixed=$'cp: cannot stat \'/x/a.ipc\': No such file or directory\ncp: cannot create regular file \'/x/y\': Permission denied'
+    if _atomic_cp_stderr_is_stat_enoent_only "$mixed"; then
+        echo "  FAIL: mixed benign+real stderr must NOT be benign"
+        return 1
+    fi
+    return 0
+}
+
+test_atomic_cp_stderr_unrelated_failure_is_not_benign() {
+    log_test "_atomic_cp_stderr_is_stat_enoent_only: unrelated cp error → not benign"
+    local real_err=$'cp: cannot create directory \'/x\': Read-only file system'
+    if _atomic_cp_stderr_is_stat_enoent_only "$real_err"; then
+        echo "  FAIL: unrelated cp error must NOT be benign"
+        return 1
+    fi
+    return 0
+}
+
+test_atomic_cp_stderr_different_enoent_verb_is_not_benign() {
+    log_test "_atomic_cp_stderr_is_stat_enoent_only: 'cannot open ENOENT' → not benign (only 'cannot stat' qualifies)"
+    local enoent_other=$'cp: cannot open \'/x/a\': No such file or directory'
+    if _atomic_cp_stderr_is_stat_enoent_only "$enoent_other"; then
+        echo "  FAIL: only 'cannot stat ... ENOENT' should be benign, not 'cannot open ... ENOENT'"
+        return 1
+    fi
+    return 0
+}
+
+# ----- Integration: main atomic-copy path (no scratch, no last-resort) -----
+
+test_atomic_copy_dir_main_path_tolerates_benign_stat_errors() {
+    log_test "atomic_copy_dir: main path tolerates benign cp ENOENT when count matches (Issue #328)"
+
+    local src="$TEST_TEMP_DIR/src/main_benign_src"
+    local dst="$TEST_TEMP_DIR/dst/main_benign_dst"
 
     mkdir -p "$src"
     echo "alpha" > "$src/a.txt"
     echo "beta" > "$src/b.txt"
 
-    # Simulate the virtio-fs-on-macOS pattern: cp emits "cannot stat"
-    # errors for entries we pretend are AF_UNIX sockets (readdir
-    # returned them, stat ENOENT), but actually copies every regular
-    # file. Then cp exits 1.
-    # shellcheck disable=SC2317  # invoked indirectly via shell override
-    cp() {
-        local args=("$@")
-        local n=${#args[@]}
-        local last=${args[n-1]}
-        # Recursive-copy invocation: relay the real cp for the content,
-        # then emit fake "cannot stat" lines + exit 1.
-        if [[ "${args[0]}" == "-rp" ]]; then
-            command cp "$@"
-            echo "cp: cannot stat '$last/.fake-socket-a.ipc': No such file or directory" >&2
-            echo "cp: cannot stat '$last/.fake-socket-b.ipc': No such file or directory" >&2
-            return 1
-        fi
-        command cp "$@"
-    }
+    BENIGN_STAT_NAMES=".fake-socket-a.ipc .fake-socket-b.ipc"
+    _install_benign_stat_cp_mock
 
     atomic_copy_dir "$src" "$dst" 2>/dev/null
     local rc=$?
 
     _reset_atomic_copy_lib
+    unset BENIGN_STAT_NAMES EXTRA_STDERR
 
-    assert_equals "0" "$rc" "Should succeed: cp's non-zero is benign and counts match"
-    assert_file_exists "$dst/a.txt" "Regular files must be present in dst"
-    assert_file_exists "$dst/b.txt" "Regular files must be present in dst"
+    assert_equals "0" "$rc" "Should succeed: cp non-zero is benign and counts match"
+    assert_file_exists "$dst/a.txt" "Regular file a.txt must be present in dst"
+    assert_file_exists "$dst/b.txt" "Regular file b.txt must be present in dst"
 }
 
-test_atomic_copy_dir_real_cp_errors_still_fail() {
-    log_test "atomic_copy_dir: real cp errors are NOT swallowed by benign-stat tolerance (Issue #328)"
+test_atomic_copy_dir_main_path_rejects_mixed_real_error() {
+    log_test "atomic_copy_dir: main path rejects mixed benign+real cp stderr (classifier path) (Issue #328)"
 
-    local src="$TEST_TEMP_DIR/src/real_err_src"
-    local dst="$TEST_TEMP_DIR/dst/real_err_dst"
+    local src="$TEST_TEMP_DIR/src/main_mixed_src"
+    local dst="$TEST_TEMP_DIR/dst/main_mixed_dst"
 
     mkdir -p "$src"
     echo "x" > "$src/file.txt"
 
-    # cp emits one "cannot stat ENOENT" (benign) plus one
-    # "Permission denied" (real). Helper must reject the mix.
-    # shellcheck disable=SC2317  # invoked indirectly via shell override
-    cp() {
-        local args=("$@")
-        local n=${#args[@]}
-        local last=${args[n-1]}
-        if [[ "${args[0]}" == "-rp" ]]; then
-            command cp "$@"
-            echo "cp: cannot stat '$last/.benign.ipc': No such file or directory" >&2
-            echo "cp: cannot create regular file '$last/blocked': Permission denied" >&2
-            return 1
-        fi
-        command cp "$@"
-    }
+    BENIGN_STAT_NAMES=".benign.ipc"
+    EXTRA_STDERR="cp: cannot create regular file 'blocked': Permission denied"
+    _install_benign_stat_cp_mock
 
-    atomic_copy_dir "$src" "$dst" 2>/dev/null
+    # Capture atomic_copy_dir's stderr (log lines) to pin the failure mode.
+    local out
+    out=$(atomic_copy_dir "$src" "$dst" 2>&1)
     local rc=$?
 
     _reset_atomic_copy_lib
+    unset BENIGN_STAT_NAMES EXTRA_STDERR
 
-    # Real failure → either count check catches the missing file OR the
-    # benign-filter rejects the mixed stderr. Either way: rc==1.
-    [[ "$rc" -ne 0 ]] || {
-        echo "  FAIL: rc should be non-zero when cp emits real (non-benign) errors"
+    assert_not_equals "0" "$rc" "Mixed benign+real cp stderr must NOT succeed"
+    # Pin failure to the classifier-rejection path (not count mismatch).
+    # Main-path failure emits "atomic_copy_dir: cp failed for <dst>",
+    # distinct from the trailing-fallback's "atomic_copy_dir: fallback
+    # cp failed for <dst>". A count-mismatch path would instead emit
+    # "file count mismatch" and would NOT emit the main-path "cp failed".
+    assert_contains "$out" "atomic_copy_dir: cp failed for" \
+        "Mixed benign+real stderr must log main-path 'cp failed for' (classifier rejection)"
+    if [[ "$out" == *"file count mismatch"* ]]; then
+        echo "  FAIL: log contains 'file count mismatch' but failure should be from classifier rejection"
         return 1
-    }
+    fi
     return 0
 }
 
-test_atomic_copy_dir_benign_errors_with_count_mismatch_fails() {
-    log_test "atomic_copy_dir: benign cp errors are still rejected when regular-file count differs (Issue #328)"
+test_atomic_copy_dir_main_path_rejects_benign_with_count_mismatch() {
+    log_test "atomic_copy_dir: main path count check catches dropped file even with benign stderr (Issue #328)"
 
-    local src="$TEST_TEMP_DIR/src/count_mismatch_src"
-    local dst="$TEST_TEMP_DIR/dst/count_mismatch_dst"
+    local src="$TEST_TEMP_DIR/src/main_count_src"
+    local dst="$TEST_TEMP_DIR/dst/main_count_dst"
 
     mkdir -p "$src"
     echo "a" > "$src/a.txt"
     echo "b" > "$src/b.txt"
     echo "c" > "$src/c.txt"
 
-    # cp emits only benign stderr but ALSO actually drops a regular file
-    # — count check must catch this (helper says "benign", count says
-    # "no — data missing"). Net: rc=1.
+    # cp emits ONLY benign stderr but actually drops a regular file.
+    # Classifier says "benign"; count check (3 vs 2) must reject.
     # shellcheck disable=SC2317  # invoked indirectly via shell override
     cp() {
         local args=("$@")
         local n=${#args[@]}
         local last=${args[n-1]}
-        if [[ "${args[0]}" == "-rp" ]]; then
-            # Copy only 2 of the 3 files, then emit benign stderr + exit 1.
+        local has_rp=0
+        local a
+        for a in "$@"; do
+            [[ "$a" == "-rp" ]] && has_rp=1 && break
+        done
+        if [[ $has_rp -eq 1 ]]; then
             command cp -p "$src/a.txt" "${last}/a.txt"
             command cp -p "$src/b.txt" "${last}/b.txt"
             echo "cp: cannot stat '$last/.fake.ipc': No such file or directory" >&2
@@ -1007,16 +1065,111 @@ test_atomic_copy_dir_benign_errors_with_count_mismatch_fails() {
         command cp "$@"
     }
 
-    atomic_copy_dir "$src" "$dst" 2>/dev/null
+    local out
+    out=$(atomic_copy_dir "$src" "$dst" 2>&1)
     local rc=$?
 
     _reset_atomic_copy_lib
 
-    [[ "$rc" -ne 0 ]] || {
-        echo "  FAIL: rc should be non-zero when count check fails even if cp stderr was benign"
+    assert_not_equals "0" "$rc" "Count mismatch must reject even when cp stderr is benign"
+    # Pin failure to the count-mismatch path. Classifier rejection would
+    # log "atomic_copy_dir: cp failed for"; count mismatch logs "file
+    # count mismatch" (and falls through to "atomic_copy_dir: fallback
+    # cp failed for", which is a different message we tolerate).
+    assert_contains "$out" "file count mismatch" \
+        "Benign stderr with dropped file must log 'file count mismatch' (count check)"
+    if [[ "$out" == *"atomic_copy_dir: cp failed for"* ]]; then
+        echo "  FAIL: log contains main-path 'cp failed for' but failure should be count mismatch"
         return 1
-    }
+    fi
     return 0
+}
+
+# ----- Integration: scratch-fallback path (mktemp-in-parent fails) -----
+
+test_atomic_copy_dir_scratch_path_tolerates_benign_stat_errors() {
+    log_test "atomic_copy_dir: scratch-fallback path tolerates benign cp ENOENT (Issue #328 coverage gap)"
+
+    local src="$TEST_TEMP_DIR/src/scratch_benign_src"
+    local parent="$TEST_TEMP_DIR/dst/scratch_benign_case"
+    local dst="$parent/payload"
+
+    mkdir -p "$src" "$dst"
+    echo "alpha" > "$src/a.txt"
+    echo "beta" > "$src/b.txt"
+
+    # Force the primary mktemp to fail (simulating an RO dirname(dst))
+    # so atomic_copy_dir enters the scratch-fallback branch.
+    # shellcheck disable=SC2317  # invoked indirectly via shell override
+    mktemp() {
+        local args=("$@")
+        for a in "${args[@]}"; do
+            if [[ "$a" == "$parent/"* ]]; then
+                echo "mktemp: failed to create directory via template '$a': Read-only file system" >&2
+                return 1
+            fi
+        done
+        command mktemp "$@"
+    }
+
+    BENIGN_STAT_NAMES=".scratch-socket.ipc"
+    BENIGN_STAT_SRC_PREFIX="$src/"  # only fire on src→scratch leg
+    _install_benign_stat_cp_mock
+
+    KAPSIS_SCRATCH_DIR="$TEST_TEMP_DIR/scratch_benign" \
+        atomic_copy_dir "$src" "$dst" 2>/dev/null
+    local rc=$?
+
+    _reset_atomic_copy_lib
+    unset BENIGN_STAT_NAMES BENIGN_STAT_SRC_PREFIX
+
+    assert_equals "0" "$rc" "Scratch-fallback path should succeed when cp's non-zero is benign"
+    assert_file_exists "$dst/a.txt" "a.txt should land via scratch path despite benign stderr"
+    assert_file_exists "$dst/b.txt" "b.txt should land via scratch path despite benign stderr"
+}
+
+# ----- Integration: last-resort direct-cp path (both mktemps fail) -----
+
+test_atomic_copy_dir_last_resort_tolerates_benign_stat_errors() {
+    log_test "atomic_copy_dir: last-resort direct cp tolerates benign cp ENOENT (Issue #328 coverage gap)"
+
+    local src="$TEST_TEMP_DIR/src/lastresort_benign_src"
+    local parent="$TEST_TEMP_DIR/dst/lastresort_benign_case"
+    local dst="$parent/payload"
+    local scratch="$TEST_TEMP_DIR/scratch_lastresort"
+
+    mkdir -p "$src" "$dst" "$scratch"
+    echo "alpha" > "$src/a.txt"
+    echo "beta" > "$src/b.txt"
+
+    # Force BOTH mktemps to fail (primary parent AND scratch base) so
+    # atomic_copy_dir enters the last-resort direct-cp branch.
+    # shellcheck disable=SC2317  # invoked indirectly via shell override
+    mktemp() {
+        local args=("$@")
+        for a in "${args[@]}"; do
+            if [[ "$a" == "$parent/"* ]] || [[ "$a" == "$scratch/"* ]]; then
+                echo "mktemp: failed to create directory via template '$a': Read-only file system" >&2
+                return 1
+            fi
+        done
+        command mktemp "$@"
+    }
+
+    BENIGN_STAT_NAMES=".lastresort-socket.ipc"
+    BENIGN_STAT_SRC_PREFIX="$src/"  # only fire on src→dst direct leg
+    _install_benign_stat_cp_mock
+
+    KAPSIS_SCRATCH_DIR="$scratch" \
+        atomic_copy_dir "$src" "$dst" 2>/dev/null
+    local rc=$?
+
+    _reset_atomic_copy_lib
+    unset BENIGN_STAT_NAMES BENIGN_STAT_SRC_PREFIX
+
+    assert_equals "0" "$rc" "Last-resort direct cp should succeed when cp's non-zero is benign"
+    assert_file_exists "$dst/a.txt" "a.txt should land via last-resort direct cp"
+    assert_file_exists "$dst/b.txt" "b.txt should land via last-resort direct cp"
 }
 
 #===============================================================================
@@ -1079,10 +1232,20 @@ main() {
 
     # Issue #328 root-cause follow-up: tolerate benign cp stderr from
     # virtio-fs (sockets/FIFOs readdir-visible but stat-invisible).
-    run_test test_atomic_cp_stat_only_failures_helper
-    run_test test_atomic_copy_dir_tolerates_benign_stat_errors
-    run_test test_atomic_copy_dir_real_cp_errors_still_fail
-    run_test test_atomic_copy_dir_benign_errors_with_count_mismatch_fails
+    # Helper unit tests (split per-scenario for failure-isolation):
+    run_test test_atomic_cp_stderr_empty_is_not_benign
+    run_test test_atomic_cp_stderr_whitespace_only_is_not_benign
+    run_test test_atomic_cp_stderr_single_benign_line
+    run_test test_atomic_cp_stderr_multiple_benign_lines
+    run_test test_atomic_cp_stderr_mixed_benign_and_real_is_not_benign
+    run_test test_atomic_cp_stderr_unrelated_failure_is_not_benign
+    run_test test_atomic_cp_stderr_different_enoent_verb_is_not_benign
+    # Integration tests for the three patched cp call sites:
+    run_test test_atomic_copy_dir_main_path_tolerates_benign_stat_errors
+    run_test test_atomic_copy_dir_main_path_rejects_mixed_real_error
+    run_test test_atomic_copy_dir_main_path_rejects_benign_with_count_mismatch
+    run_test test_atomic_copy_dir_scratch_path_tolerates_benign_stat_errors
+    run_test test_atomic_copy_dir_last_resort_tolerates_benign_stat_errors
 
     # Summary
     print_summary

--- a/tests/test-atomic-copy.sh
+++ b/tests/test-atomic-copy.sh
@@ -842,6 +842,184 @@ test_atomic_copy_dir_mktemp_stderr_does_not_corrupt_path_on_success() {
 }
 
 #===============================================================================
+# Issue #328 root-cause follow-up: tolerate benign cp stderr from
+# virtio-fs (sockets/FIFOs readdir-visible but stat-invisible).
+#===============================================================================
+
+test_atomic_cp_stat_only_failures_helper() {
+    log_test "_atomic_cp_stat_only_failures: classifies cp stderr correctly"
+
+    # Empty stderr → no signal to whitelist → returns 1 (caller must treat
+    # as real failure rather than silently succeeding on missing signal).
+    _atomic_cp_stat_only_failures "" && {
+        echo "  FAIL: empty stderr should NOT be treated as benign"
+        return 1
+    }
+
+    # Single benign line → 0.
+    local one_line
+    one_line=$'cp: cannot stat \'/x/foo.ipc\': No such file or directory'
+    if ! _atomic_cp_stat_only_failures "$one_line"; then
+        echo "  FAIL: single 'cannot stat ENOENT' line should be benign"
+        return 1
+    fi
+
+    # Multiple benign lines (blank line in middle should be tolerated) → 0.
+    local many_benign
+    many_benign=$'cp: cannot stat \'/x/a.ipc\': No such file or directory\n\ncp: cannot stat \'/x/b.ipc\': No such file or directory'
+    if ! _atomic_cp_stat_only_failures "$many_benign"; then
+        echo "  FAIL: multiple 'cannot stat ENOENT' lines should be benign"
+        return 1
+    fi
+
+    # Benign + real error mixed → 1.
+    local mixed
+    mixed=$'cp: cannot stat \'/x/a.ipc\': No such file or directory\ncp: cannot create regular file \'/x/y\': Permission denied'
+    if _atomic_cp_stat_only_failures "$mixed"; then
+        echo "  FAIL: mixed stderr (benign + real error) should NOT be benign"
+        return 1
+    fi
+
+    # Unrelated cp failure (no "cannot stat" lines at all) → 1.
+    local real_err
+    real_err=$'cp: cannot create directory \'/x\': Read-only file system'
+    if _atomic_cp_stat_only_failures "$real_err"; then
+        echo "  FAIL: real cp error should NOT be classified benign"
+        return 1
+    fi
+
+    # Different ENOENT subject (e.g. cannot open) → 1.
+    local enoent_other
+    enoent_other=$'cp: cannot open \'/x/a\': No such file or directory'
+    if _atomic_cp_stat_only_failures "$enoent_other"; then
+        echo "  FAIL: only 'cannot stat ... ENOENT' should be benign, not 'cannot open'"
+        return 1
+    fi
+
+    return 0
+}
+
+test_atomic_copy_dir_tolerates_benign_stat_errors() {
+    log_test "atomic_copy_dir: main path treats cp ENOENT-on-readdir-entries as benign when count matches (Issue #328)"
+
+    local src="$TEST_TEMP_DIR/src/benign_stat_src"
+    local dst="$TEST_TEMP_DIR/dst/benign_stat_dst"
+
+    mkdir -p "$src"
+    echo "alpha" > "$src/a.txt"
+    echo "beta" > "$src/b.txt"
+
+    # Simulate the virtio-fs-on-macOS pattern: cp emits "cannot stat"
+    # errors for entries we pretend are AF_UNIX sockets (readdir
+    # returned them, stat ENOENT), but actually copies every regular
+    # file. Then cp exits 1.
+    # shellcheck disable=SC2317  # invoked indirectly via shell override
+    cp() {
+        local args=("$@")
+        local n=${#args[@]}
+        local last=${args[n-1]}
+        # Recursive-copy invocation: relay the real cp for the content,
+        # then emit fake "cannot stat" lines + exit 1.
+        if [[ "${args[0]}" == "-rp" ]]; then
+            command cp "$@"
+            echo "cp: cannot stat '$last/.fake-socket-a.ipc': No such file or directory" >&2
+            echo "cp: cannot stat '$last/.fake-socket-b.ipc': No such file or directory" >&2
+            return 1
+        fi
+        command cp "$@"
+    }
+
+    atomic_copy_dir "$src" "$dst" 2>/dev/null
+    local rc=$?
+
+    _reset_atomic_copy_lib
+
+    assert_equals "0" "$rc" "Should succeed: cp's non-zero is benign and counts match"
+    assert_file_exists "$dst/a.txt" "Regular files must be present in dst"
+    assert_file_exists "$dst/b.txt" "Regular files must be present in dst"
+}
+
+test_atomic_copy_dir_real_cp_errors_still_fail() {
+    log_test "atomic_copy_dir: real cp errors are NOT swallowed by benign-stat tolerance (Issue #328)"
+
+    local src="$TEST_TEMP_DIR/src/real_err_src"
+    local dst="$TEST_TEMP_DIR/dst/real_err_dst"
+
+    mkdir -p "$src"
+    echo "x" > "$src/file.txt"
+
+    # cp emits one "cannot stat ENOENT" (benign) plus one
+    # "Permission denied" (real). Helper must reject the mix.
+    # shellcheck disable=SC2317  # invoked indirectly via shell override
+    cp() {
+        local args=("$@")
+        local n=${#args[@]}
+        local last=${args[n-1]}
+        if [[ "${args[0]}" == "-rp" ]]; then
+            command cp "$@"
+            echo "cp: cannot stat '$last/.benign.ipc': No such file or directory" >&2
+            echo "cp: cannot create regular file '$last/blocked': Permission denied" >&2
+            return 1
+        fi
+        command cp "$@"
+    }
+
+    atomic_copy_dir "$src" "$dst" 2>/dev/null
+    local rc=$?
+
+    _reset_atomic_copy_lib
+
+    # Real failure → either count check catches the missing file OR the
+    # benign-filter rejects the mixed stderr. Either way: rc==1.
+    [[ "$rc" -ne 0 ]] || {
+        echo "  FAIL: rc should be non-zero when cp emits real (non-benign) errors"
+        return 1
+    }
+    return 0
+}
+
+test_atomic_copy_dir_benign_errors_with_count_mismatch_fails() {
+    log_test "atomic_copy_dir: benign cp errors are still rejected when regular-file count differs (Issue #328)"
+
+    local src="$TEST_TEMP_DIR/src/count_mismatch_src"
+    local dst="$TEST_TEMP_DIR/dst/count_mismatch_dst"
+
+    mkdir -p "$src"
+    echo "a" > "$src/a.txt"
+    echo "b" > "$src/b.txt"
+    echo "c" > "$src/c.txt"
+
+    # cp emits only benign stderr but ALSO actually drops a regular file
+    # — count check must catch this (helper says "benign", count says
+    # "no — data missing"). Net: rc=1.
+    # shellcheck disable=SC2317  # invoked indirectly via shell override
+    cp() {
+        local args=("$@")
+        local n=${#args[@]}
+        local last=${args[n-1]}
+        if [[ "${args[0]}" == "-rp" ]]; then
+            # Copy only 2 of the 3 files, then emit benign stderr + exit 1.
+            command cp -p "$src/a.txt" "${last}/a.txt"
+            command cp -p "$src/b.txt" "${last}/b.txt"
+            echo "cp: cannot stat '$last/.fake.ipc': No such file or directory" >&2
+            return 1
+        fi
+        command cp "$@"
+    }
+
+    atomic_copy_dir "$src" "$dst" 2>/dev/null
+    local rc=$?
+
+    _reset_atomic_copy_lib
+
+    [[ "$rc" -ne 0 ]] || {
+        echo "  FAIL: rc should be non-zero when count check fails even if cp stderr was benign"
+        return 1
+    }
+    return 0
+}
+
+#===============================================================================
 # TEST RUNNER
 #===============================================================================
 
@@ -898,6 +1076,13 @@ main() {
     run_test test_atomic_copy_dir_scratch_resets_prepopulated_dst
     run_test test_atomic_copy_dir_last_resort_returns_success_when_cp_works
     run_test test_atomic_copy_dir_mktemp_stderr_does_not_corrupt_path_on_success
+
+    # Issue #328 root-cause follow-up: tolerate benign cp stderr from
+    # virtio-fs (sockets/FIFOs readdir-visible but stat-invisible).
+    run_test test_atomic_cp_stat_only_failures_helper
+    run_test test_atomic_copy_dir_tolerates_benign_stat_errors
+    run_test test_atomic_copy_dir_real_cp_errors_still_fail
+    run_test test_atomic_copy_dir_benign_errors_with_count_mismatch_fails
 
     # Summary
     print_summary


### PR DESCRIPTION
## Summary

Closes the actual root cause of #328 that survived PR #332. On macOS hosts, virtio-fs returns `AF_UNIX` socket entries from `readdir()` but ENOENT from `stat()` — so `cp -rp` emits one `cannot stat ... No such file or directory` line per host-side socket and exits 1. Every regular file IS copied byte-for-byte, but `atomic_copy_dir`'s `cp_err=$(cp ...) || ...` branches all abort before the file-count validation ever runs.

`.config/*` succeeds today because it contains no sockets. `.claude` and `.ssh` always fail because:
- `.claude` has 7 git `core.fsmonitor` IPC sockets (main repo + 1 worktree + 5 marketplace clones on my host).
- `.ssh` has the active ssh-agent control socket (`agent/s.*`).

See [#328 root-cause comment](https://github.com/aviadshiber/kapsis/issues/328#issuecomment-4437866180) for the exact reproduction and stderr trace (src 12815 == dst 12815 — payload is complete; only cp's exit code is misleading).

## Fix

Add `_atomic_cp_stat_only_failures` classifier — when `cp` exits non-zero, check whether **every** stderr line matches the exact benign signature `cp: cannot stat 'X': No such file or directory`. If so, treat as success and let the regular-file count comparison be the final arbiter. Sockets are not counted by `find -type f`, so a complete-payload copy with N skipped sockets satisfies the count check.

Applied to all three `cp -rp` sites in `atomic_copy_dir`:
- **Main path** (line 405): primary atomic copy into same-FS `tmp_dir`.
- **Scratch-fallback stage cp** (line 347): src → `XDG_RUNTIME_DIR` scratch (PR #332's path).
- **Last-resort direct cp** (line 319): when both same-FS mktemp and scratch mktemp fail.

`atomic_copy_file` is intentionally unchanged — if a single file can't be stat'd, it really is missing.

## What it does NOT change

- **Real cp failures still bail.** The helper rejects any stderr line that isn't an exact "cannot stat ... ENOENT" match. `Permission denied`, `Read-only file system`, `No space left on device` etc. continue to fail loudly.
- **Benign stderr with count mismatch still bails.** The count check is the final guard — the helper only certifies that the stderr signal alone isn't fatal.
- No semantic change for `.config/*` (cp exits 0, helper isn't invoked).

## Tests

`tests/test-atomic-copy.sh` gets 4 new cases:

| Test | Asserts |
|---|---|
| `test_atomic_cp_stat_only_failures_helper` | Classifier across empty / single-benign / multi-benign / mixed-benign-and-real / unrelated-error / different-ENOENT-verb inputs. |
| `test_atomic_copy_dir_tolerates_benign_stat_errors` | Simulates virtio-fs via `cp` override emitting `cannot stat` lines + exit 1; main path succeeds when counts match. |
| `test_atomic_copy_dir_real_cp_errors_still_fail` | Mixed benign + `Permission denied` stderr does NOT silently succeed. |
| `test_atomic_copy_dir_benign_errors_with_count_mismatch_fails` | Benign stderr but cp actually drops a file → count check catches it. |

All 35 tests pass locally (4 new + 31 pre-existing).

## Test plan

- [x] Unit tests: `bash tests/test-atomic-copy.sh` → 35/35 pass.
- [ ] On-host integration: rebuild kapsis-sandbox image with this branch, run a non-repo task (overlay mode) on a host with live git fsmonitor in `.claude`. Should now complete without `Atomic copy validation failed` and the downstream `inject-lsp-config.sh: line 82: settings.local.json: Permission denied` cascade.
- [ ] Verify no regression for `.config/*` paths (no sockets) — still succeed via the existing happy path.

## Lossiness analysis

Skipping sockets/FIFOs is **functionally lossless** in this context:
- `fsmonitor--daemon.ipc` is bound to a macOS process. The Linux container can never use it; git inside the container will start its own fsmonitor daemon (or fall back to non-fsmonitor mode) automatically.
- `~/.ssh/agent/s.*` is bound to a macOS ssh-agent. Even with a perfectly copied inode the container couldn't speak the protocol; ssh-agent forwarding into the container has to use `-v $SSH_AUTH_SOCK:...`, not staged-config copy.
- Char/block devices, FIFOs: same shape — meaningful only with their owning kernel/process.

A `find -type f -o -type d -o -type l | cpio -p0d` rewrite (option 2 in the issue thread) would handle this more generally but is a much larger refactor; this PR is the smallest patch that closes the user-visible breakage.

Fixes #328.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
