### PR TITLE
fix(staging): pre-filter directory snapshots on macOS to keep :U safe (#338)

### DIFF
--- a/scripts/launch-agent.sh
+++ b/scripts/launch-agent.sh
@@ -1456,6 +1456,13 @@ _snapshot_dir_filtered() {
     fi
 
     local snapshot_path="${SNAPSHOT_DIR}/${relative_name}"
+
+    # Pre-clean to avoid stale-entry merge on re-runs / agent resume.
+    # cp -Rp src/. dst/ merges files into an existing dst, so entries
+    # deleted from the host between launches would persist in the
+    # snapshot and be visible to the new container.
+    rm -rf "$snapshot_path" 2>/dev/null || true
+
     if ! mkdir -p "$snapshot_path" 2>/dev/null; then
         log_warn "Snapshot dir mkdir failed for ${snapshot_path}, falling back to live mount"
         echo "$host_path"
@@ -1468,13 +1475,31 @@ _snapshot_dir_filtered() {
     cp -Rp "${host_path}/." "${snapshot_path}/" 2>/dev/null || true
     find "$snapshot_path" \( -type s -o -type p -o -type c -o -type b \) -delete 2>/dev/null || true
 
-    # Only treat the snapshot as a fallback miss if the source had
-    # content but the snapshot is empty (cp produced nothing).
-    if [[ -z "$(ls -A "$snapshot_path" 2>/dev/null)" ]] && [[ -n "$(ls -A "$host_path" 2>/dev/null)" ]]; then
-        log_warn "Snapshot of ${host_path} is empty, falling back to live mount"
+    # Harden the snapshot subtree AFTER cp -Rp (which would otherwise
+    # propagate the source dir's mode onto snapshot_path and undo any
+    # earlier chmod). Inner file modes are preserved by `-p` (so
+    # id_rsa stays 0600), but the ancestor SNAPSHOT_DIR is created by
+    # the caller with the default umask (typically 0755). chmod 0700
+    # here keeps the credential contents enumerable only by the
+    # current user even if the parent is loose.
+    chmod 0700 "$snapshot_path" 2>/dev/null || true
+
+    # Validate completeness via regular-file count parity. This subsumes
+    # an "is the snapshot empty?" check and catches:
+    #   - cp entirely failed (src=N, dst=0)
+    #   - cp partial failure / mid-copy ENOSPC (src=N, dst=K, K<N)
+    #   - source contained only sockets (src=0, dst=0 — match, no fallback;
+    #     an empty snapshot is still a valid socket-free :U source)
+    # Mirrors atomic-copy.sh's count-based guard (issues #328, #335).
+    local _src_count _dst_count
+    _src_count=$(find "$host_path" -type f 2>/dev/null | wc -l | tr -d ' \n')
+    _dst_count=$(find "$snapshot_path" -type f 2>/dev/null | wc -l | tr -d ' \n')
+    if [[ "$_src_count" != "$_dst_count" ]]; then
+        log_warn "Snapshot file count mismatch for ${host_path} (src=${_src_count} dst=${_dst_count}), falling back to live mount"
         echo "$host_path"
         return 1
     fi
+
     echo "$snapshot_path"
 }
 
@@ -1525,12 +1550,22 @@ generate_filesystem_includes() {
                 # those entry types, aborting container-prepare. Other
                 # directories keep the live mount + fuse-overlayfs CoW path.
                 local mount_source="$expanded_path"
+                local _dir_snapshot_fallback=0
                 if [[ -f "$expanded_path" ]]; then
                     mount_source=$(_snapshot_file "$expanded_path" "$relative_path")
                     log_debug "Snapshot (file): ${expanded_path} -> ${mount_source}"
                 elif [[ -d "$expanded_path" ]] && is_macos && _path_has_unstattable_entries "$expanded_path"; then
-                    mount_source=$(_snapshot_dir_filtered "$expanded_path" "$relative_path")
-                    log_debug "Snapshot (dir, socket-free): ${expanded_path} -> ${mount_source}"
+                    if mount_source=$(_snapshot_dir_filtered "$expanded_path" "$relative_path"); then
+                        log_debug "Snapshot (dir, socket-free): ${expanded_path} -> ${mount_source}"
+                    else
+                        # Fallback returned live host_path; mounting it with :U
+                        # would re-trip the chown-walk on virtio-fs ENOENT (the
+                        # bug this code prevents). Drop :U for THIS entry; the
+                        # in-container atomic-copy classifier (#336) handles
+                        # the remaining cp-stage socket failures.
+                        _dir_snapshot_fallback=1
+                        log_warn "Directory snapshot for ${expanded_path} fell back to live mount; :U dropped on this entry to avoid #338 chown-walk"
+                    fi
                 fi
 
                 # Mount to staging directory (read-only).
@@ -1546,9 +1581,10 @@ generate_filesystem_includes() {
                 # Issue #338: :U makes podman chown-walk the source via lstat(),
                 # which trips on virtio-fs ENOENT for AF_UNIX sockets. The
                 # directory-snapshot above produces a socket-free source for
-                # affected dirs so :U traversal succeeds.
+                # affected dirs so :U traversal succeeds. If the snapshot
+                # itself fell back to the live path, drop :U for that entry.
                 local _staging_mount_opts="ro"
-                if is_macos; then
+                if is_macos && [[ "$_dir_snapshot_fallback" -eq 0 ]]; then
                     _staging_mount_opts="ro,U"
                 fi
                 VOLUME_MOUNTS+=("-v" "${mount_source}:${staging_path}:${_staging_mount_opts}")

--- a/scripts/launch-agent.sh
+++ b/scripts/launch-agent.sh
@@ -1408,6 +1408,76 @@ _snapshot_file() {
     fi
 }
 
+#-------------------------------------------------------------------------------
+# _path_has_unstattable_entries <host_path>
+#
+# Returns 0 if the subtree under <host_path> contains any AF_UNIX socket,
+# FIFO, or device entry — the entry classes that virtio-fs on macOS
+# returns from readdir() but errors on stat()/lstat() (issue #338).
+# Used by generate_filesystem_includes() to decide whether a directory
+# source needs pre-filter snapshotting before applying the :U mount
+# flag (which makes podman chown-walk the source via lstat).
+#
+# Uses `find ... -print -quit` so it returns after the first match —
+# fast even on large trees like ~/.claude/projects.
+#-------------------------------------------------------------------------------
+_path_has_unstattable_entries() {
+    local p="$1"
+    [[ -d "$p" ]] || return 1
+    [[ -n "$(find "$p" \( -type s -o -type p -o -type c -o -type b \) -print -quit 2>/dev/null)" ]]
+}
+
+#-------------------------------------------------------------------------------
+# _snapshot_dir_filtered <host_path> <relative_name>
+#
+# Snapshots a host directory tree to ${SNAPSHOT_DIR}/<relative_name>,
+# omitting AF_UNIX sockets / FIFOs / devices. Returns the snapshot path
+# on success, falls back to <host_path> (live mount) on failure with a
+# log_warn.
+#
+# Issue #338: when the resulting mount is given the :U flag, podman
+# walks the source via lstat() to chown it. AF_UNIX sockets visible
+# from readdir() on macOS virtio-fs return ENOENT from lstat(),
+# aborting the container-prepare phase before entrypoint runs. By
+# producing a socket-free snapshot here, the :U traversal succeeds.
+#
+# Mode bits are preserved via `cp -Rp` (BSD + GNU compatible). Sockets
+# / FIFOs / devices are pruned post-cp to defend against platform
+# variance in how cp handles them. The in-container atomic-copy
+# classifier (scripts/lib/atomic-copy.sh) remains as defense in depth.
+#-------------------------------------------------------------------------------
+_snapshot_dir_filtered() {
+    local host_path="$1"
+    local relative_name="$2"
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        echo "$host_path"
+        return 0
+    fi
+
+    local snapshot_path="${SNAPSHOT_DIR}/${relative_name}"
+    if ! mkdir -p "$snapshot_path" 2>/dev/null; then
+        log_warn "Snapshot dir mkdir failed for ${snapshot_path}, falling back to live mount"
+        echo "$host_path"
+        return 1
+    fi
+
+    # cp -Rp may warn and exit non-zero on socket entries but still
+    # copies all regular files / dirs / symlinks. Suppress the noise
+    # and post-prune to handle any platform variance.
+    cp -Rp "${host_path}/." "${snapshot_path}/" 2>/dev/null || true
+    find "$snapshot_path" \( -type s -o -type p -o -type c -o -type b \) -delete 2>/dev/null || true
+
+    # Only treat the snapshot as a fallback miss if the source had
+    # content but the snapshot is empty (cp produced nothing).
+    if [[ -z "$(ls -A "$snapshot_path" 2>/dev/null)" ]] && [[ -n "$(ls -A "$host_path" 2>/dev/null)" ]]; then
+        log_warn "Snapshot of ${host_path} is empty, falling back to live mount"
+        echo "$host_path"
+        return 1
+    fi
+    echo "$snapshot_path"
+}
+
 generate_filesystem_includes() {
     local staging_dir="/kapsis-staging"
     STAGED_CONFIGS=""
@@ -1447,12 +1517,20 @@ generate_filesystem_includes() {
                 relative_path="${expanded_path#"$HOME"/}"
                 staging_path="${staging_dir}/${relative_path}"
 
-                # Snapshot regular files to prevent torn reads (issue #164)
-                # Directories are left as-is — they use fuse-overlayfs CoW inside the container
+                # Snapshot regular files to prevent torn reads (issue #164).
+                # Issue #338: on macOS, also snapshot directories that contain
+                # AF_UNIX sockets / FIFOs / devices, since podman's :U flag
+                # (added below for the #328 fix) chowns the source recursively
+                # via lstat() — and virtio-fs returns ENOENT from lstat() on
+                # those entry types, aborting container-prepare. Other
+                # directories keep the live mount + fuse-overlayfs CoW path.
                 local mount_source="$expanded_path"
                 if [[ -f "$expanded_path" ]]; then
                     mount_source=$(_snapshot_file "$expanded_path" "$relative_path")
-                    log_debug "Snapshot: ${expanded_path} -> ${mount_source}"
+                    log_debug "Snapshot (file): ${expanded_path} -> ${mount_source}"
+                elif [[ -d "$expanded_path" ]] && is_macos && _path_has_unstattable_entries "$expanded_path"; then
+                    mount_source=$(_snapshot_dir_filtered "$expanded_path" "$relative_path")
+                    log_debug "Snapshot (dir, socket-free): ${expanded_path} -> ${mount_source}"
                 fi
 
                 # Mount to staging directory (read-only).
@@ -1465,6 +1543,10 @@ generate_filesystem_includes() {
                 # that remaps file ownership to the container user so mode-0700 dirs
                 # appear owned by developer and become readable. :ro is preserved;
                 # the host filesystem is never modified.
+                # Issue #338: :U makes podman chown-walk the source via lstat(),
+                # which trips on virtio-fs ENOENT for AF_UNIX sockets. The
+                # directory-snapshot above produces a socket-free source for
+                # affected dirs so :U traversal succeeds.
                 local _staging_mount_opts="ro"
                 if is_macos; then
                     _staging_mount_opts="ro,U"

--- a/tests/test-snapshot-staging.sh
+++ b/tests/test-snapshot-staging.sh
@@ -542,17 +542,14 @@ test_snapshot_dir_filtered_preserves_modes() {
     assert_dir_exists "$result" "Snapshot dir should exist"
     assert_file_exists "$result/id_rsa" "Regular file should be in snapshot"
 
-    local src_dir_mode dst_dir_mode src_file_mode dst_file_mode
-    src_dir_mode=$(stat -c '%a' "$src" 2>/dev/null || stat -f '%A' "$src" 2>/dev/null)
-    dst_dir_mode=$(stat -c '%a' "$result" 2>/dev/null || stat -f '%A' "$result" 2>/dev/null)
+    # Directory mode preservation is best-effort: SNAPSHOT_DIR is created via
+    # mkdir -p (umask-filtered), so the OUTER dir mode is not expected to
+    # match. Only verify file modes here.
+    local src_file_mode dst_file_mode
     src_file_mode=$(stat -c '%a' "$src/id_rsa" 2>/dev/null || stat -f '%A' "$src/id_rsa" 2>/dev/null)
     dst_file_mode=$(stat -c '%a' "$result/id_rsa" 2>/dev/null || stat -f '%A' "$result/id_rsa" 2>/dev/null)
 
     assert_equals "$src_file_mode" "$dst_file_mode" "File mode (e.g. 0600) must be preserved"
-    # Directory mode preservation is best-effort: SNAPSHOT_DIR is created via
-    # mkdir -p (umask-filtered), so the OUTER dir mode is not expected to
-    # match. Only verify file modes here.
-    [[ -n "$src_dir_mode" ]] && log_pass "Source dir mode captured: ${src_dir_mode}"
 }
 
 test_snapshot_dir_filtered_dry_run_passthrough() {

--- a/tests/test-snapshot-staging.sh
+++ b/tests/test-snapshot-staging.sh
@@ -99,6 +99,46 @@ _snapshot_file() {
     fi
 }
 
+# Issue #338: inlined from launch-agent.sh. Returns 0 if subtree contains any
+# AF_UNIX socket, FIFO, or device entry (the classes virtio-fs returns ENOENT
+# for from lstat()). Uses find -print -quit for early exit on first match.
+_path_has_unstattable_entries() {
+    local p="$1"
+    [[ -d "$p" ]] || return 1
+    [[ -n "$(find "$p" \( -type s -o -type p -o -type c -o -type b \) -print -quit 2>/dev/null)" ]]
+}
+
+# Issue #338: inlined from launch-agent.sh. Snapshots a host dir to
+# ${SNAPSHOT_DIR}/<relative_name>, omitting sockets / FIFOs / devices so the
+# resulting mount can take :U without tripping podman's chown-walk on macOS
+# virtio-fs. Falls back to <host_path> on failure.
+_snapshot_dir_filtered() {
+    local host_path="$1"
+    local relative_name="$2"
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        echo "$host_path"
+        return 0
+    fi
+
+    local snapshot_path="${SNAPSHOT_DIR}/${relative_name}"
+    if ! mkdir -p "$snapshot_path" 2>/dev/null; then
+        log_warn "Snapshot dir mkdir failed for ${snapshot_path}, falling back to live mount"
+        echo "$host_path"
+        return 1
+    fi
+
+    cp -Rp "${host_path}/." "${snapshot_path}/" 2>/dev/null || true
+    find "$snapshot_path" \( -type s -o -type p -o -type c -o -type b \) -delete 2>/dev/null || true
+
+    if [[ -z "$(ls -A "$snapshot_path" 2>/dev/null)" ]] && [[ -n "$(ls -A "$host_path" 2>/dev/null)" ]]; then
+        log_warn "Snapshot of ${host_path} is empty, falling back to live mount"
+        echo "$host_path"
+        return 1
+    fi
+    echo "$snapshot_path"
+}
+
 #===============================================================================
 # TESTS
 #===============================================================================
@@ -391,6 +431,197 @@ test_staging_mount_opts_macos_ro_U_combined() {
 }
 
 #===============================================================================
+# Issue #338: pre-filter directory snapshots so :U chown traversal doesn't
+# trip on AF_UNIX sockets / FIFOs / devices that virtio-fs returns ENOENT for.
+#
+# Tests use mkfifo (POSIX, works on Linux + BSD) to stand in for AF_UNIX
+# sockets — both share the find -type s/-type p detection codepath and the
+# same lstat-ENOENT pathology on virtio-fs. AF_UNIX-specific tests would
+# need a live process to bind() the socket, which is over-specified for
+# unit-level coverage of the filter logic.
+#===============================================================================
+
+test_path_has_unstattable_entries_detects_fifo() {
+    log_test "_path_has_unstattable_entries: detects FIFO (Issue #338)"
+    local d="$TEST_TEMP_DIR/has-fifo"
+    mkdir -p "$d"
+    : > "$d/regular.txt"
+    mkfifo "$d/socket-stand-in" 2>/dev/null
+
+    if _path_has_unstattable_entries "$d"; then
+        log_pass "Detected FIFO entry"
+    else
+        log_fail "Failed to detect FIFO entry"
+    fi
+}
+
+test_path_has_unstattable_entries_detects_nested_fifo() {
+    log_test "_path_has_unstattable_entries: detects nested FIFO (Issue #338)"
+    local d="$TEST_TEMP_DIR/nested-fifo/a/b/c"
+    mkdir -p "$d"
+    : > "$TEST_TEMP_DIR/nested-fifo/regular.txt"
+    mkfifo "$d/deep.ipc" 2>/dev/null
+
+    if _path_has_unstattable_entries "$TEST_TEMP_DIR/nested-fifo"; then
+        log_pass "Detected deeply-nested FIFO"
+    else
+        log_fail "Failed to detect deeply-nested FIFO"
+    fi
+}
+
+test_path_has_unstattable_entries_clean_tree_returns_1() {
+    log_test "_path_has_unstattable_entries: returns 1 on socket-free tree (Issue #338)"
+    local d="$TEST_TEMP_DIR/clean-tree"
+    mkdir -p "$d/sub"
+    : > "$d/file.txt"
+    : > "$d/sub/nested.json"
+
+    if _path_has_unstattable_entries "$d"; then
+        log_fail "Should NOT report unstattable entries for a regular-file-only tree"
+    else
+        log_pass "Correctly returned 1 for clean tree"
+    fi
+}
+
+test_path_has_unstattable_entries_handles_missing_path() {
+    log_test "_path_has_unstattable_entries: returns 1 on non-existent path (Issue #338)"
+    if _path_has_unstattable_entries "$TEST_TEMP_DIR/does-not-exist"; then
+        log_fail "Should NOT report unstattable entries for missing path"
+    else
+        log_pass "Correctly returned 1 for missing path"
+    fi
+}
+
+test_snapshot_dir_filtered_excludes_fifos() {
+    log_test "_snapshot_dir_filtered: excludes FIFOs from snapshot (Issue #338)"
+    reset_snapshot_state
+    _init_snapshot_dir
+
+    local src="$TEST_TEMP_DIR/src-with-fifo"
+    mkdir -p "$src/sub"
+    echo "regular content" > "$src/regular.txt"
+    echo '{"k":"v"}' > "$src/sub/nested.json"
+    mkfifo "$src/fsmonitor.ipc" 2>/dev/null
+    mkfifo "$src/sub/agent.sock" 2>/dev/null
+
+    local result
+    result=$(_snapshot_dir_filtered "$src" ".claude")
+
+    assert_dir_exists "$result" "Snapshot dir should exist"
+    assert_file_exists "$result/regular.txt" "Regular file should be in snapshot"
+    assert_file_exists "$result/sub/nested.json" "Nested regular file should be in snapshot"
+
+    if [[ -e "$result/fsmonitor.ipc" ]]; then
+        log_fail "FIFO at root must NOT exist in snapshot"
+    else
+        log_pass "FIFO at root correctly excluded"
+    fi
+
+    if [[ -e "$result/sub/agent.sock" ]]; then
+        log_fail "Nested FIFO must NOT exist in snapshot"
+    else
+        log_pass "Nested FIFO correctly excluded"
+    fi
+}
+
+test_snapshot_dir_filtered_preserves_modes() {
+    log_test "_snapshot_dir_filtered: preserves mode-0700 dirs and mode-0600 files (Issue #338)"
+    reset_snapshot_state
+    _init_snapshot_dir
+
+    local src="$TEST_TEMP_DIR/src-modes"
+    mkdir -p "$src"
+    echo "secret" > "$src/id_rsa"
+    chmod 700 "$src"
+    chmod 600 "$src/id_rsa"
+    mkfifo "$src/agent.sock" 2>/dev/null
+
+    local result
+    result=$(_snapshot_dir_filtered "$src" ".ssh")
+
+    assert_dir_exists "$result" "Snapshot dir should exist"
+    assert_file_exists "$result/id_rsa" "Regular file should be in snapshot"
+
+    local src_dir_mode dst_dir_mode src_file_mode dst_file_mode
+    src_dir_mode=$(stat -c '%a' "$src" 2>/dev/null || stat -f '%A' "$src" 2>/dev/null)
+    dst_dir_mode=$(stat -c '%a' "$result" 2>/dev/null || stat -f '%A' "$result" 2>/dev/null)
+    src_file_mode=$(stat -c '%a' "$src/id_rsa" 2>/dev/null || stat -f '%A' "$src/id_rsa" 2>/dev/null)
+    dst_file_mode=$(stat -c '%a' "$result/id_rsa" 2>/dev/null || stat -f '%A' "$result/id_rsa" 2>/dev/null)
+
+    assert_equals "$src_file_mode" "$dst_file_mode" "File mode (e.g. 0600) must be preserved"
+    # Directory mode preservation is best-effort: SNAPSHOT_DIR is created via
+    # mkdir -p (umask-filtered), so the OUTER dir mode is not expected to
+    # match. Only verify file modes here.
+    [[ -n "$src_dir_mode" ]] && log_pass "Source dir mode captured: ${src_dir_mode}"
+}
+
+test_snapshot_dir_filtered_dry_run_passthrough() {
+    log_test "_snapshot_dir_filtered: returns original path in DRY_RUN mode (Issue #338)"
+    reset_snapshot_state
+    DRY_RUN=true
+    _init_snapshot_dir
+
+    local src="$TEST_TEMP_DIR/dry-run-src"
+    mkdir -p "$src"
+    echo "data" > "$src/file.txt"
+
+    local result
+    result=$(_snapshot_dir_filtered "$src" ".claude")
+
+    assert_equals "$src" "$result" "Should return original path in dry-run mode"
+
+    DRY_RUN=false
+}
+
+test_snapshot_dir_filtered_handles_empty_source() {
+    log_test "_snapshot_dir_filtered: empty source dir produces empty snapshot (Issue #338)"
+    reset_snapshot_state
+    _init_snapshot_dir
+
+    local src="$TEST_TEMP_DIR/empty-src"
+    mkdir -p "$src"
+
+    local result
+    result=$(_snapshot_dir_filtered "$src" ".empty")
+
+    # Empty source is a degenerate but valid case — should return the
+    # snapshot path, not fall back. (Fallback is only for src-non-empty
+    # but dst-empty mismatch.)
+    assert_dir_exists "$result" "Snapshot dir should exist for empty source"
+    if [[ -z "$(ls -A "$result" 2>/dev/null)" ]]; then
+        log_pass "Empty source produced empty snapshot"
+    else
+        log_fail "Snapshot of empty source unexpectedly has content"
+    fi
+}
+
+test_snapshot_dir_filtered_preserves_regular_files() {
+    log_test "_snapshot_dir_filtered: regular file content is byte-identical (Issue #338)"
+    reset_snapshot_state
+    _init_snapshot_dir
+
+    local src="$TEST_TEMP_DIR/src-content"
+    mkdir -p "$src/sub"
+    printf 'line one\nline two\n' > "$src/file.txt"
+    printf '{"deep": "json"}' > "$src/sub/data.json"
+    mkfifo "$src/x.ipc" 2>/dev/null
+
+    local result
+    result=$(_snapshot_dir_filtered "$src" ".content")
+
+    if cmp -s "$src/file.txt" "$result/file.txt"; then
+        log_pass "Top-level file matches byte-for-byte"
+    else
+        log_fail "Top-level file content differs"
+    fi
+    if cmp -s "$src/sub/data.json" "$result/sub/data.json"; then
+        log_pass "Nested file matches byte-for-byte"
+    else
+        log_fail "Nested file content differs"
+    fi
+}
+
+#===============================================================================
 # TEST RUNNER
 #===============================================================================
 
@@ -422,6 +653,17 @@ main() {
     run_test test_staging_mount_opts_macos_includes_U_flag
     run_test test_staging_mount_opts_linux_no_U_flag
     run_test test_staging_mount_opts_macos_ro_U_combined
+
+    # Pre-filtered directory snapshot tests (issue #338)
+    run_test test_path_has_unstattable_entries_detects_fifo
+    run_test test_path_has_unstattable_entries_detects_nested_fifo
+    run_test test_path_has_unstattable_entries_clean_tree_returns_1
+    run_test test_path_has_unstattable_entries_handles_missing_path
+    run_test test_snapshot_dir_filtered_excludes_fifos
+    run_test test_snapshot_dir_filtered_preserves_modes
+    run_test test_snapshot_dir_filtered_dry_run_passthrough
+    run_test test_snapshot_dir_filtered_handles_empty_source
+    run_test test_snapshot_dir_filtered_preserves_regular_files
 
     # Summary
     print_summary

--- a/tests/test-snapshot-staging.sh
+++ b/tests/test-snapshot-staging.sh
@@ -111,7 +111,8 @@ _path_has_unstattable_entries() {
 # Issue #338: inlined from launch-agent.sh. Snapshots a host dir to
 # ${SNAPSHOT_DIR}/<relative_name>, omitting sockets / FIFOs / devices so the
 # resulting mount can take :U without tripping podman's chown-walk on macOS
-# virtio-fs. Falls back to <host_path> on failure.
+# virtio-fs. Falls back to <host_path> on failure. MUST stay byte-equivalent
+# to the production helper — see test_inlined_helpers_match_production below.
 _snapshot_dir_filtered() {
     local host_path="$1"
     local relative_name="$2"
@@ -122,6 +123,9 @@ _snapshot_dir_filtered() {
     fi
 
     local snapshot_path="${SNAPSHOT_DIR}/${relative_name}"
+
+    rm -rf "$snapshot_path" 2>/dev/null || true
+
     if ! mkdir -p "$snapshot_path" 2>/dev/null; then
         log_warn "Snapshot dir mkdir failed for ${snapshot_path}, falling back to live mount"
         echo "$host_path"
@@ -131,11 +135,17 @@ _snapshot_dir_filtered() {
     cp -Rp "${host_path}/." "${snapshot_path}/" 2>/dev/null || true
     find "$snapshot_path" \( -type s -o -type p -o -type c -o -type b \) -delete 2>/dev/null || true
 
-    if [[ -z "$(ls -A "$snapshot_path" 2>/dev/null)" ]] && [[ -n "$(ls -A "$host_path" 2>/dev/null)" ]]; then
-        log_warn "Snapshot of ${host_path} is empty, falling back to live mount"
+    chmod 0700 "$snapshot_path" 2>/dev/null || true
+
+    local _src_count _dst_count
+    _src_count=$(find "$host_path" -type f 2>/dev/null | wc -l | tr -d ' \n')
+    _dst_count=$(find "$snapshot_path" -type f 2>/dev/null | wc -l | tr -d ' \n')
+    if [[ "$_src_count" != "$_dst_count" ]]; then
+        log_warn "Snapshot file count mismatch for ${host_path} (src=${_src_count} dst=${_dst_count}), falling back to live mount"
         echo "$host_path"
         return 1
     fi
+
     echo "$snapshot_path"
 }
 
@@ -618,6 +628,244 @@ test_snapshot_dir_filtered_preserves_regular_files() {
     fi
 }
 
+# AF_UNIX socket coverage (Reviewer ensemble: A/C/E flagged that FIFO is
+# only a proxy for the actual #338 bug case). Binds a real AF_UNIX socket
+# to exercise the `find -type s` arm of the filter end-to-end.
+_have_python3_af_unix() {
+    command -v python3 >/dev/null 2>&1
+}
+
+test_path_has_unstattable_entries_detects_af_unix_socket() {
+    log_test "_path_has_unstattable_entries: detects real AF_UNIX socket (Issue #338 actual case)"
+    if ! _have_python3_af_unix; then
+        log_skip "python3 not available — skipping AF_UNIX-specific test"
+        return 0
+    fi
+    local d="$TEST_TEMP_DIR/has-af-unix"
+    mkdir -p "$d"
+    : > "$d/regular.txt"
+    if ! python3 -c "import socket,sys; s=socket.socket(socket.AF_UNIX); s.bind(sys.argv[1])" "$d/agent.sock" 2>/dev/null; then
+        log_skip "AF_UNIX bind unavailable in this env — skipping"
+        return 0
+    fi
+
+    if _path_has_unstattable_entries "$d"; then
+        log_pass "Detected real AF_UNIX socket"
+    else
+        log_fail "Failed to detect real AF_UNIX socket"
+    fi
+}
+
+test_snapshot_dir_filtered_excludes_af_unix_socket() {
+    log_test "_snapshot_dir_filtered: excludes real AF_UNIX socket (Issue #338 actual case)"
+    if ! _have_python3_af_unix; then
+        log_skip "python3 not available — skipping AF_UNIX-specific test"
+        return 0
+    fi
+    reset_snapshot_state
+    _init_snapshot_dir
+
+    local src="$TEST_TEMP_DIR/af-unix-src"
+    mkdir -p "$src/.git"
+    echo "fake claude config" > "$src/settings.json"
+    if ! python3 -c "import socket,sys; s=socket.socket(socket.AF_UNIX); s.bind(sys.argv[1])" "$src/.git/fsmonitor--daemon.ipc" 2>/dev/null; then
+        log_skip "AF_UNIX bind unavailable in this env — skipping"
+        return 0
+    fi
+
+    local result
+    result=$(_snapshot_dir_filtered "$src" ".claude")
+
+    assert_file_exists "$result/settings.json" "Regular file should be in snapshot"
+    if [[ -S "$result/.git/fsmonitor--daemon.ipc" ]]; then
+        log_fail "AF_UNIX socket must NOT exist in snapshot"
+    else
+        log_pass "AF_UNIX socket correctly excluded from snapshot"
+    fi
+}
+
+# Reviewer C/D: when source contains only sockets/FIFOs (and no regular
+# files), `cp -Rp` plus prune leaves an empty snapshot. The src-empty/dst-
+# empty branch correctly returns the snapshot path (not the live mount),
+# so the caller can safely apply :U to an empty dir without re-tripping
+# #338. Verify the fallback is NOT activated in this case.
+test_snapshot_dir_filtered_socket_only_source_does_not_fall_back() {
+    log_test "_snapshot_dir_filtered: socket-only source produces empty snapshot, NOT fallback (Issue #338)"
+    reset_snapshot_state
+    _init_snapshot_dir
+
+    local src="$TEST_TEMP_DIR/socket-only-src"
+    mkdir -p "$src"
+    mkfifo "$src/a.ipc" 2>/dev/null
+    mkfifo "$src/b.sock" 2>/dev/null
+
+    local result rc=0
+    result=$(_snapshot_dir_filtered "$src" ".socket-only") || rc=$?
+
+    assert_equals "0" "$rc" "Should NOT return non-zero for socket-only source"
+    if [[ "$result" == "$src" ]]; then
+        log_fail "Should NOT fall back to live mount for socket-only source — that re-trips #338"
+    else
+        log_pass "Returned snapshot path (not live fallback) for socket-only source"
+    fi
+}
+
+# Reviewer A/D: a partial cp (ENOSPC, I/O error) was previously silently
+# accepted. Simulate by manually deleting a file from the snapshot after
+# the helper completes, then assert the count check would have caught it.
+# We can't easily inject mid-cp failure, so we verify the count-mismatch
+# branch by post-deletion.
+test_snapshot_dir_filtered_detects_partial_copy_via_count() {
+    log_test "_snapshot_dir_filtered: file-count mismatch triggers fallback (Issue #338 partial-cp guard)"
+    reset_snapshot_state
+    _init_snapshot_dir
+
+    local src="$TEST_TEMP_DIR/count-src"
+    mkdir -p "$src/d1"
+    echo "a" > "$src/f1"
+    echo "b" > "$src/d1/f2"
+    echo "c" > "$src/f3"
+    mkfifo "$src/sock" 2>/dev/null
+
+    # Sanity: helper should succeed for a healthy copy.
+    local first_result first_rc=0
+    first_result=$(_snapshot_dir_filtered "$src" ".count-ok") || first_rc=$?
+    assert_equals "0" "$first_rc" "Healthy copy should succeed"
+    if [[ "$first_result" != "$src" ]]; then
+        log_pass "Healthy copy returned snapshot path"
+    else
+        log_fail "Healthy copy unexpectedly fell back"
+    fi
+
+    # Now manually inject a mismatch by removing a snapshot file post-hoc
+    # then re-running the count branch via direct invocation. The helper
+    # re-runs (rm -rf the dst, mkdir -p, fresh cp) — counts will match
+    # again — so we can't intercept mid-helper. Instead, exercise the
+    # count comparison in isolation: build src, copy 2 of 3 files
+    # manually, then run the count-equivalence assertion.
+    local mismatch_src="$TEST_TEMP_DIR/count-mismatch-src"
+    local mismatch_dst="$TEST_TEMP_DIR/count-mismatch-dst"
+    mkdir -p "$mismatch_src" "$mismatch_dst"
+    echo "1" > "$mismatch_src/a"
+    echo "2" > "$mismatch_src/b"
+    echo "3" > "$mismatch_src/c"
+    echo "1" > "$mismatch_dst/a"
+    echo "2" > "$mismatch_dst/b"
+
+    local sc dc
+    sc=$(find "$mismatch_src" -type f | wc -l | tr -d ' \n')
+    dc=$(find "$mismatch_dst" -type f | wc -l | tr -d ' \n')
+    assert_equals "3" "$sc" "Source has 3 files"
+    assert_equals "2" "$dc" "Destination has 2 files"
+    if [[ "$sc" != "$dc" ]]; then
+        log_pass "Count comparison correctly detects partial copy"
+    else
+        log_fail "Count comparison failed to detect partial copy"
+    fi
+}
+
+# Reviewer B: defensive chmod 0700 on the snapshot_path so credentials
+# remain unenumerable even when SNAPSHOT_DIR has a loose umask-default mode.
+test_snapshot_dir_filtered_hardens_snapshot_mode() {
+    log_test "_snapshot_dir_filtered: snapshot_path is mode 0700 (Issue #338 review hardening)"
+    reset_snapshot_state
+    _init_snapshot_dir
+
+    local src="$TEST_TEMP_DIR/perm-src"
+    mkdir -p "$src"
+    echo "secret" > "$src/cred"
+
+    local result
+    result=$(_snapshot_dir_filtered "$src" ".perm")
+
+    local mode
+    mode=$(stat -c '%a' "$result" 2>/dev/null || stat -f '%A' "$result" 2>/dev/null)
+    assert_equals "700" "$mode" "Snapshot path must be mode 0700 to hide credentials"
+}
+
+# Reviewer D: on resume / re-run, the same SNAPSHOT_DIR is reused. cp -Rp
+# merges into an existing dst, so files deleted from the source would
+# persist as stale entries. The pre-clean (`rm -rf`) before mkdir prevents
+# this. Test: pre-populate snapshot_path with a stale file, then snapshot
+# a source that no longer contains it.
+test_snapshot_dir_filtered_pre_cleans_stale_entries() {
+    log_test "_snapshot_dir_filtered: pre-cleans snapshot_path to prevent stale-merge (Issue #338 review)"
+    reset_snapshot_state
+    _init_snapshot_dir
+
+    local src="$TEST_TEMP_DIR/clean-src"
+    mkdir -p "$src"
+    echo "current" > "$src/keep.txt"
+
+    # Pre-populate the target snapshot path with a stale entry
+    local stale_snapshot="${SNAPSHOT_DIR}/.clean"
+    mkdir -p "$stale_snapshot"
+    echo "stale-from-previous-run" > "$stale_snapshot/deleted.txt"
+    # And a stale FIFO (which the prune would remove but a stale merge would leave)
+    mkfifo "$stale_snapshot/stale.ipc" 2>/dev/null
+
+    local result
+    result=$(_snapshot_dir_filtered "$src" ".clean")
+
+    assert_file_exists "$result/keep.txt" "Current file should be present"
+    if [[ -e "$result/deleted.txt" ]]; then
+        log_fail "Stale file from previous run must NOT persist after re-run"
+    else
+        log_pass "Stale file correctly cleaned before snapshot"
+    fi
+    if [[ -e "$result/stale.ipc" ]]; then
+        log_fail "Stale FIFO from previous run must NOT persist after re-run"
+    else
+        log_pass "Stale FIFO correctly cleaned"
+    fi
+}
+
+# Reviewer E: guard against helper drift. Compare the inlined helper
+# bodies with the production functions in scripts/launch-agent.sh and
+# fail if they diverge (signatures and bodies must match — comments
+# may differ).
+test_inlined_helpers_match_production() {
+    log_test "Inlined helpers in this test file must match production (drift guard)"
+    local launch="$KAPSIS_ROOT/scripts/launch-agent.sh"
+    if [[ ! -f "$launch" ]]; then
+        log_skip "Production launch-agent.sh not found — skipping drift check"
+        return 0
+    fi
+
+    # Extract function bodies from both production and inlined versions
+    # using awk: from "^_FUNC_NAME()" to the matching closing brace at
+    # column 1. Strip blank lines and leading/trailing whitespace for
+    # comparison resilience.
+    _extract_fn_body() {
+        local file="$1" fn="$2"
+        awk -v fn="$fn" '
+            $0 ~ "^"fn"\\(\\) \\{" { in_fn=1; depth=1; next }
+            in_fn && /^}$/ { exit }
+            in_fn { print }
+        ' "$file" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' | grep -v '^$' | grep -v '^#'
+    }
+
+    local prod_body inline_body
+    for fn in _path_has_unstattable_entries _snapshot_dir_filtered; do
+        prod_body=$(_extract_fn_body "$launch" "$fn")
+        inline_body=$(_extract_fn_body "${BASH_SOURCE[0]}" "$fn")
+        if [[ -z "$prod_body" ]]; then
+            log_fail "Could not extract production body for ${fn}"
+            continue
+        fi
+        if [[ -z "$inline_body" ]]; then
+            log_fail "Could not extract inlined body for ${fn}"
+            continue
+        fi
+        if [[ "$prod_body" == "$inline_body" ]]; then
+            log_pass "Inlined ${fn} matches production"
+        else
+            log_fail "Inlined ${fn} has drifted from production"
+            diff <(echo "$prod_body") <(echo "$inline_body") | head -20 || true
+        fi
+    done
+}
+
 #===============================================================================
 # TEST RUNNER
 #===============================================================================
@@ -661,6 +909,15 @@ main() {
     run_test test_snapshot_dir_filtered_dry_run_passthrough
     run_test test_snapshot_dir_filtered_handles_empty_source
     run_test test_snapshot_dir_filtered_preserves_regular_files
+
+    # Review-cycle hardening (issue #338 review feedback)
+    run_test test_path_has_unstattable_entries_detects_af_unix_socket
+    run_test test_snapshot_dir_filtered_excludes_af_unix_socket
+    run_test test_snapshot_dir_filtered_socket_only_source_does_not_fall_back
+    run_test test_snapshot_dir_filtered_detects_partial_copy_via_count
+    run_test test_snapshot_dir_filtered_hardens_snapshot_mode
+    run_test test_snapshot_dir_filtered_pre_cleans_stale_entries
+    run_test test_inlined_helpers_match_production
 
     # Summary
     print_summary


### PR DESCRIPTION
## Summary

Fixes #338 — the `:U` mount flag added in #333 (2.28.4) trips podman's container-prepare step because its recursive chown does `lstat()` on every source entry, and virtio-fs on macOS returns `ENOENT` for AF_UNIX socket entries it lists from `readdir()` (e.g. `.claude/.git/fsmonitor--daemon.ipc`). Container never starts, exit 127. PR #336's in-container classifier can't help — it runs after the container is up.

**Fix approach** (issue's suggested fix #1 / #2(b)): on macOS, when a home-dir mount source is a directory containing AF_UNIX sockets / FIFOs / devices, snapshot it to `$HOME/.kapsis/snapshots/<agent-id>/` with those entries excluded, then mount the snapshot with the existing `:ro,U` flags. The snapshot is socket-free, so the `:U` chown traversal succeeds; the #328 fix (UID remap for mode-0700 dirs) is preserved. Directories without unstattable entries keep the live `:ro,U` mount and the fast fuse-overlayfs CoW path.

**Why this approach for the long term**:
- Removes the bug class — any virtio-fs lstat-quirk on any unusual entry type is pre-empted.
- Preserves the #328 fix instead of trading socket bug for EACCES bug.
- Generalizes the existing `_snapshot_file()` strategy (#164) to directories.
- No new Podman / kernel version dependency.
- Cost-controlled: `find -quit` pre-scan only triggers the slow path when sockets are actually present.
- Defense in depth: PR #336's atomic-copy classifier and `entrypoint.sh:685` chmod stay as the in-container safety net.

## Changes

- **`scripts/launch-agent.sh`** — two new helpers next to `_snapshot_file()`:
  - `_path_has_unstattable_entries()` — `find ... -print -quit` scan (returns on first match).
  - `_snapshot_dir_filtered()` — `cp -Rp` + post-prune of any sockets/FIFOs/devices.
  - `generate_filesystem_includes()` grows an `elif` branch alongside the existing file-snapshot path.
- **`tests/test-snapshot-staging.sh`** — 9 new cases covering FIFO detection (root + nested), clean-tree negative case, missing-path guard, FIFO exclusion from snapshots, mode preservation (0600 files), dry-run passthrough, empty-source handling, byte-identical regular file content. The existing `ro,U` mount-opts tests stay unchanged — mount opts on macOS remain `ro,U`.

## Test plan

- [x] `bash tests/test-snapshot-staging.sh` — 23/23 pass (14 existing + 9 new)
- [x] `bash tests/test-agent-config-mounts.sh` — 10/10 pass (adjacent regression check)
- [x] `bash -n` syntax check on both modified files
- [ ] Manual repro on the affected macOS host (per #338 repro command) — expect: container starts, agent runs, `$HOME/.kapsis/snapshots/<agent-id>/.claude/` exists during run with regular files but no `*.ipc` socket.
- [ ] Regression check on a macOS host that originally manifested #328 — expect: `.claude/settings.local.json` and `.ssh/known_hosts` readable inside the container, no `Permission denied` warnings from `atomic_copy_dir`.

## Notes

- shellcheck wasn't available in this environment; both files pass `bash -n` and match the existing project style.
- Quick test suite (`./tests/run-all-tests.sh --quick`) was killed in this environment after running for 10+ minutes on unrelated tests — recommend running the full suite in CI before merging.

https://claude.ai/code/session_012hmkMKfMNinrzK9D2ngz2E

---
_Generated by [Claude Code](https://claude.ai/code/session_012hmkMKfMNinrzK9D2ngz2E)_