### PR TITLE
fix(mount): skip write probe in overlay mode — workspace is read-only by design (#341)

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1684,9 +1684,11 @@ validate_workspace_mount() {
 # the agent command. On macOS virtio-fs can degrade during that window too.
 #
 # This probe runs immediately before exec and uses `timeout` so a hung virtio-
-# fs transport cannot freeze the container. A write probe is required (not
-# just stat) because the failure mode in #276 is that bash's `>` redirect open
-# fails even when stat succeeds on the parent dir.
+# fs transport cannot freeze the container. In worktree mode a write probe is
+# required (not just stat) because the failure mode in #276 is that bash's `>`
+# redirect open fails even when stat succeeds on the parent dir. In overlay
+# mode the workspace is read-only by design (Issue #341) so only the stat
+# probe runs — see the overlay short-circuit in the function body below.
 #
 # On failure, emits the same KAPSIS_MOUNT_FAILURE: sentinel to stderr that the
 # liveness monitor uses (scripts/lib/liveness-monitor.sh:613), so the existing

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1743,9 +1743,27 @@ probe_mount_readiness() {
         return 1
     fi
 
-    # Write probe: the real failure mode is that bash cannot open files for
-    # output redirect. Verify that the agent will be able to create files
-    # under the workspace before we exec into it.
+    # Issue #341: in overlay mode the workspace is read-only by design — the
+    # agent's writes go to the host-side upperdir (via :O,upperdir=,workdir=),
+    # to $HOME for staged-config CoW overlays (.claude, .ssh, …), and to
+    # /kapsis-status for task progress. The agent never writes to /workspace
+    # directly. A write probe here would always fail with EROFS regardless of
+    # mount health, masking the stat probe above and producing false-positive
+    # mount failures (exit 4) for every overlay-mode launch on macOS where
+    # podman 5.x mounts ":O,upperdir=,workdir=" as ro under --userns=keep-id.
+    # The mid-run liveness-monitor follows the same mode-aware pattern — see
+    # scripts/lib/liveness-monitor.sh::_mount_check_probe (uses stat + ls -A
+    # for both modes, only adds a git sentinel check in worktree mode).
+    # Mirrors the existing overlay short-circuit in
+    # scripts/lib/inject-status-hooks.sh:325.
+    if [[ "${KAPSIS_SANDBOX_MODE:-}" == "overlay" ]]; then
+        log_debug "Pre-agent mount readiness probe: stat passed; skipping write probe in overlay mode (read-only by design)"
+        return 0
+    fi
+
+    # Write probe (worktree mode): the real failure mode is that bash cannot
+    # open files for output redirect. Verify that the agent will be able to
+    # create files under the workspace before we exec into it.
     # Use mktemp for an unpredictable filename; fall back to PID-suffix on
     # systems where mktemp is unavailable inside the container (extremely rare).
     local probe_file

--- a/tests/test-workspace-mount-validation.sh
+++ b/tests/test-workspace-mount-validation.sh
@@ -446,8 +446,9 @@ test_probe_mount_readiness_overlay_skips_write_probe() {
     local saved_mode="${KAPSIS_SANDBOX_MODE:-}"
     export KAPSIS_SANDBOX_MODE="overlay"
 
+    local stderr_output
     local exit_code=0
-    probe_mount_readiness "$test_dir/workspace" 2>/dev/null || exit_code=$?
+    stderr_output=$(probe_mount_readiness "$test_dir/workspace" 2>&1 >/dev/null) || exit_code=$?
 
     chmod 0755 "$test_dir/workspace"
     if [[ -n "$saved_mode" ]]; then
@@ -458,6 +459,12 @@ test_probe_mount_readiness_overlay_skips_write_probe() {
 
     assert_equals "0" "$exit_code" \
         "Overlay-mode read-only workspace should pass probe (stat OK, write probe skipped)"
+    # Issue #341 user-facing fix: the original bug was the spurious sentinel
+    # appearing on every overlay-mode launch. Lock that in — a future change
+    # that re-emits the sentinel while still returning 0 would re-introduce
+    # the false-positive mount_failure on the host side.
+    assert_not_contains "$stderr_output" "KAPSIS_MOUNT_FAILURE[probe_mount_readiness]:" \
+        "Overlay-mode probe must NOT emit the false-positive sentinel"
 }
 
 test_probe_mount_readiness_overlay_still_detects_missing_workspace() {

--- a/tests/test-workspace-mount-validation.sh
+++ b/tests/test-workspace-mount-validation.sh
@@ -392,7 +392,7 @@ test_probe_mount_readiness_missing() {
 }
 
 test_probe_mount_readiness_readonly() {
-    log_test "probe_mount_readiness returns 1 + sentinel when workspace is read-only"
+    log_test "probe_mount_readiness returns 1 + sentinel when workspace is read-only (worktree mode)"
     # Skip the write-probe case when running as root — root bypasses mode bits.
     if [[ $(id -u) -eq 0 ]]; then
         log_skip "Skipping read-only probe test — running as root, mode bits bypassed"
@@ -403,14 +403,84 @@ test_probe_mount_readiness_readonly() {
     mkdir -p "$test_dir/workspace"
     chmod 0555 "$test_dir/workspace"
 
+    # Issue #341: write probe is worktree-mode behavior; make the test's
+    # assumption explicit so it doesn't silently change semantics if the
+    # default mode flips.
+    local saved_mode="${KAPSIS_SANDBOX_MODE:-}"
+    export KAPSIS_SANDBOX_MODE="worktree"
+
     local stderr_output
     local exit_code=0
     stderr_output=$(probe_mount_readiness "$test_dir/workspace" 2>&1 >/dev/null) || exit_code=$?
     # Restore write so cleanup can rm -rf.
     chmod 0755 "$test_dir/workspace"
-    assert_equals "1" "$exit_code" "Read-only workspace should fail probe"
+    if [[ -n "$saved_mode" ]]; then
+        export KAPSIS_SANDBOX_MODE="$saved_mode"
+    else
+        unset KAPSIS_SANDBOX_MODE
+    fi
+    assert_equals "1" "$exit_code" "Read-only workspace should fail probe in worktree mode"
     assert_contains "$stderr_output" "KAPSIS_MOUNT_FAILURE[probe_mount_readiness]:" \
         "Should emit tagged KAPSIS_MOUNT_FAILURE sentinel when write probe fails"
+}
+
+#===============================================================================
+# Issue #341: overlay-mode workspace is read-only by design — the write probe
+# would always fail with EROFS, masking the stat probe's signal. Verify the
+# mode-aware short-circuit short-circuits ONLY the write probe, not the stat
+# probe.
+#===============================================================================
+
+test_probe_mount_readiness_overlay_skips_write_probe() {
+    log_test "probe_mount_readiness skips write probe in overlay mode (Issue #341)"
+    # Skip when running as root — root bypasses mode bits so chmod 0555 is a no-op.
+    if [[ $(id -u) -eq 0 ]]; then
+        log_skip "Skipping overlay write-probe test — running as root, mode bits bypassed"
+        return 0
+    fi
+    local test_dir
+    test_dir=$(make_test_dir)
+    mkdir -p "$test_dir/workspace"
+    chmod 0555 "$test_dir/workspace"
+
+    local saved_mode="${KAPSIS_SANDBOX_MODE:-}"
+    export KAPSIS_SANDBOX_MODE="overlay"
+
+    local exit_code=0
+    probe_mount_readiness "$test_dir/workspace" 2>/dev/null || exit_code=$?
+
+    chmod 0755 "$test_dir/workspace"
+    if [[ -n "$saved_mode" ]]; then
+        export KAPSIS_SANDBOX_MODE="$saved_mode"
+    else
+        unset KAPSIS_SANDBOX_MODE
+    fi
+
+    assert_equals "0" "$exit_code" \
+        "Overlay-mode read-only workspace should pass probe (stat OK, write probe skipped)"
+}
+
+test_probe_mount_readiness_overlay_still_detects_missing_workspace() {
+    log_test "probe_mount_readiness in overlay mode still fails when workspace is missing (Issue #341)"
+    local saved_mode="${KAPSIS_SANDBOX_MODE:-}"
+    export KAPSIS_SANDBOX_MODE="overlay"
+
+    local stderr_output
+    local exit_code=0
+    stderr_output=$(probe_mount_readiness "/nonexistent/workspace-overlay-$$" 2>&1 >/dev/null) || exit_code=$?
+
+    if [[ -n "$saved_mode" ]]; then
+        export KAPSIS_SANDBOX_MODE="$saved_mode"
+    else
+        unset KAPSIS_SANDBOX_MODE
+    fi
+
+    assert_equals "1" "$exit_code" \
+        "Overlay-mode missing workspace should fail (stat probe still fires)"
+    assert_contains "$stderr_output" "KAPSIS_MOUNT_FAILURE[probe_mount_readiness]:" \
+        "Should emit tagged KAPSIS_MOUNT_FAILURE sentinel when stat probe fails"
+    assert_contains "$stderr_output" "inaccessible at startup" \
+        "Sentinel should indicate stat-probe failure (not write-probe failure)"
 }
 
 test_probe_mount_readiness_skips_probe_container() {
@@ -640,6 +710,10 @@ main() {
     run_test test_probe_mount_readiness_readonly
     run_test test_probe_mount_readiness_skips_probe_container
     run_test test_probe_mount_readiness_sentinel_host_compatible
+
+    log_info "=== Overlay-Mode Write-Probe Skip (Issue #341) ==="
+    run_test test_probe_mount_readiness_overlay_skips_write_probe
+    run_test test_probe_mount_readiness_overlay_still_detects_missing_workspace
     run_test test_sentinel_rejects_arbitrary_log_line
     run_test test_sentinel_rejects_spoofed_early_line
     run_test test_sentinel_not_honored_on_exit_1


### PR DESCRIPTION
## Summary

`probe_mount_readiness` rejects every overlay-mode workspace on macOS with a false-positive `mount_failure` (exit 4). The probe runs an unconditional write check (`mktemp $workspace/.kapsis-probe-XXXXXX && : > probe_file`), but in overlay mode `/workspace` is read-only by design — the agent's writes go to the host upperdir (via `:O,upperdir=,workdir=`), to `$HOME` for staged-config CoW overlays, and to `/kapsis-status` for task progress. The write probe always fails with EROFS, masks the stat probe above, and produces a `KAPSIS_MOUNT_FAILURE[probe_mount_readiness]: /workspace is read-only or write failed at startup` sentinel even when virtio-fs is perfectly healthy.

Fixes #341.

## Root cause

`probe_mount_readiness` was added in #280 / #276 to detect macOS virtio-fs drops where `/workspace` appears mounted but writes silently fail — a real failure mode for **worktree mode** (`-v $WORKTREE:/workspace` — read-write bind). In **overlay mode** (`-v $REPO:/workspace:O,upperdir=,workdir=`), `/workspace` is intentionally read-only from the agent's perspective, as already encoded in:
- `scripts/lib/inject-status-hooks.sh:321-328` ("In overlay mode the workspace is read-only by design. Skip workspace-side writes entirely")
- `scripts/launch-agent.sh:1828` ("Overlay mode: /workspace is read-only, so re-home the runtime gist file")
- `scripts/entrypoint.sh:1245`, `:1370` (overlay short-circuits for gist writes)

The write probe therefore has no signal in overlay mode — it returns the same failure whether virtio-fs is healthy or degraded.

On the host side, podman 5.x mounts `-v X:/workspace:O,upperdir=Y,workdir=Z` as `(ro,relatime,...,upperdir=...,workdir=...)` under `--userns=keep-id` on macOS — directly observable with `mount | grep workspace` inside any such container.

The mid-run liveness-monitor already gets this right: `scripts/lib/liveness-monitor.sh::_mount_check_probe` (lines 530-561) uses `stat` + `ls -A` for both modes and only adds a worktree-specific git sentinel check (`test -d /workspace/.git-safe`). `probe_mount_readiness` is the outlier.

## The change

Add a mode-aware short-circuit before the write probe in `probe_mount_readiness`. Stat probe still runs for both modes — virtio-fs drops surface as `ENOENT` or hang on `stat` regardless of mode.

```diff
     if [[ $rc -ne 0 ]]; then
         echo "KAPSIS_MOUNT_FAILURE[probe_mount_readiness]: $workspace inaccessible at startup (stat rc=$rc, virtio-fs drop)" >&2
         return 1
     fi

+    # Issue #341: in overlay mode the workspace is read-only by design — the
+    # agent's writes go to the host-side upperdir (via :O,upperdir=,workdir=),
+    # to $HOME for staged-config CoW overlays (.claude, .ssh, …), and to
+    # /kapsis-status for task progress. The agent never writes to /workspace
+    # directly. A write probe here would always fail with EROFS regardless of
+    # mount health, masking the stat probe above and producing false-positive
+    # mount failures (exit 4) for every overlay-mode launch on macOS where
+    # podman 5.x mounts ":O,upperdir=,workdir=" as ro under --userns=keep-id.
+    if [[ "${KAPSIS_SANDBOX_MODE:-}" == "overlay" ]]; then
+        log_debug "Pre-agent mount readiness probe: stat passed; skipping write probe in overlay mode (read-only by design)"
+        return 0
+    fi
+
-    # Write probe: the real failure mode is that bash cannot open files for
+    # Write probe (worktree mode): the real failure mode is that bash cannot
+    # open files for output redirect. Verify that the agent will be able to
+    # create files under the workspace before we exec into it.
```

## Tests

`tests/test-workspace-mount-validation.sh` — **26/26 green** (24 existing + 2 new):

| Test | Setup | Expected |
|------|-------|----------|
| `test_probe_mount_readiness_overlay_skips_write_probe` (new) | overlay mode + `chmod 0555 workspace` | rc=0 (write probe skipped, stat OK) |
| `test_probe_mount_readiness_overlay_still_detects_missing_workspace` (new) | overlay mode + non-existent workspace | rc=1 + `KAPSIS_MOUNT_FAILURE[probe_mount_readiness]:` + `inaccessible at startup` (stat-probe sentinel, not write-probe sentinel) |
| `test_probe_mount_readiness_readonly` (tightened) | `KAPSIS_SANDBOX_MODE=worktree` made explicit + `chmod 0555 workspace` | rc=1 + sentinel (regression guard — same semantics as before, just no longer relies on the env-var default) |

The remaining 23 tests are untouched and still pass.

## Why not "make overlay /workspace writable instead"

`:O,upperdir=,workdir=` mounting as `ro` on macOS+keep-id+podman 5.x is a separate concern (`:rw,O,upperdir=,workdir=` is rejected with "can't use 'O' with other options"), and the existing kapsis design already treats overlay `/workspace` as read-only from the agent's perspective — see references in the root-cause section. Reversing that design is a much bigger change with downstream impact on staged-config CoW, status writes, and the upperdir-collection workflow. The surgical fix is to make `probe_mount_readiness` mode-aware like `_mount_check_probe` already is.

## Risk

- **False negatives in overlay mode?** No new ones — the stat probe still runs and catches the same class of mid-virtio-fs drops it did before (mount disappears entirely → `stat` fails). The write probe had no signal in overlay mode (always EROFS), so removing it removes only noise. Mid-run liveness checks are unchanged.
- **Worktree mode regression?** None — the existing `test_probe_mount_readiness_readonly` still passes (the only behavioral change in that test is making the mode assumption explicit; the chmod-0555 / rc=1 / sentinel assertions are unchanged).
- **Tests rely on `KAPSIS_SANDBOX_MODE` env-var leakage?** No — both new tests save and restore the prior value (or unset it) so test ordering doesn't matter.

## Consumer status

Unblocks slack-bot's overlay-mode Q&A flow on macOS 2.28.x. Two prior issues in the same chain (#338 / #339, #340) were masking this one. With #339 merged and #340 outstanding (separate PR), this is the last blocker for overlay-mode end-to-end.

Closes #341
