### PR TITLE
docs(mount): clarify worktree-only write probe + lock in #341 sentinel fix in test

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1684,9 +1684,11 @@ validate_workspace_mount() {
 # the agent command. On macOS virtio-fs can degrade during that window too.
 #
 # This probe runs immediately before exec and uses `timeout` so a hung virtio-
-# fs transport cannot freeze the container. A write probe is required (not
-# just stat) because the failure mode in #276 is that bash's `>` redirect open
-# fails even when stat succeeds on the parent dir.
+# fs transport cannot freeze the container. In worktree mode a write probe is
+# required (not just stat) because the failure mode in #276 is that bash's `>`
+# redirect open fails even when stat succeeds on the parent dir. In overlay
+# mode the workspace is read-only by design (Issue #341) so only the stat
+# probe runs — see the overlay short-circuit in the function body below.
 #
 # On failure, emits the same KAPSIS_MOUNT_FAILURE: sentinel to stderr that the
 # liveness monitor uses (scripts/lib/liveness-monitor.sh:613), so the existing

--- a/tests/test-workspace-mount-validation.sh
+++ b/tests/test-workspace-mount-validation.sh
@@ -446,8 +446,9 @@ test_probe_mount_readiness_overlay_skips_write_probe() {
     local saved_mode="${KAPSIS_SANDBOX_MODE:-}"
     export KAPSIS_SANDBOX_MODE="overlay"
 
+    local stderr_output
     local exit_code=0
-    probe_mount_readiness "$test_dir/workspace" 2>/dev/null || exit_code=$?
+    stderr_output=$(probe_mount_readiness "$test_dir/workspace" 2>&1 >/dev/null) || exit_code=$?
 
     chmod 0755 "$test_dir/workspace"
     if [[ -n "$saved_mode" ]]; then
@@ -458,6 +459,12 @@ test_probe_mount_readiness_overlay_skips_write_probe() {
 
     assert_equals "0" "$exit_code" \
         "Overlay-mode read-only workspace should pass probe (stat OK, write probe skipped)"
+    # Issue #341 user-facing fix: the original bug was the spurious sentinel
+    # appearing on every overlay-mode launch. Lock that in — a future change
+    # that re-emits the sentinel while still returning 0 would re-introduce
+    # the false-positive mount_failure on the host side.
+    assert_not_contains "$stderr_output" "KAPSIS_MOUNT_FAILURE[probe_mount_readiness]:" \
+        "Overlay-mode probe must NOT emit the false-positive sentinel"
 }
 
 test_probe_mount_readiness_overlay_still_detects_missing_workspace() {


### PR DESCRIPTION
## Summary

Two follow-ups from the [ensemble review](https://github.com/aviadshiber/kapsis/pull/342#pullrequestreview-4293466349) of #342. **Targets `fix/probe-mount-readiness-overlay-mode-341` so it merges into #342 before it lands on main.** No functional change to `probe_mount_readiness` itself.

### S2 — Function-header docblock clarification

`scripts/entrypoint.sh:1685-1697` previously asserted: *"A write probe is required (not just stat) because the failure mode in #276 is that bash's `>` redirect open fails even when stat succeeds on the parent dir."*

After #341 that statement is only true in worktree mode — overlay mode skips the write probe by design. Extended the header to say so explicitly, so the next reader doesn't re-introduce an unconditional write.

### S3 — Lock in the user-facing #341 fix in the overlay test

`test_probe_mount_readiness_overlay_skips_write_probe` was asserting `rc=0` but discarding stderr (`2>/dev/null`). The original #341 bug was the spurious `KAPSIS_MOUNT_FAILURE[probe_mount_readiness]:` sentinel appearing on every overlay-mode launch — a future regression that re-emits the sentinel while still returning 0 would slip past.

Captured stderr (using the same `2>&1 >/dev/null` pattern as the sibling `_readonly` test) and added `assert_not_contains` for the sentinel substring.

### S1 (separate — for the PR author)

The body of #342 cites `scripts/launch-agent.sh:1828` as an overlay short-circuit. That line is actually the credential `inject_to_file` branch; the real overlay short-circuit is at **lines 1941-1945** (gist re-homing for #328). Just a stale ref in the PR description — no code change needed.

### NITs deferred to follow-up

- No test for `KAPSIS_SANDBOX_MODE` set to an unrecognised value.
- Stat-probe-fail in overlay mode only covers nonexistent path (could also cover "path exists but is not a directory").

## Test plan

- [x] `./tests/test-workspace-mount-validation.sh` — **26/26 green** (root, with overlay/readonly tests skipped by the `id -u` gate as designed)
- [x] `./tests/test-workspace-mount-validation.sh` — **26/26 green** under non-root (overlay tests actually exercised; new `assert_not_contains` passed)
- [ ] CI shellcheck + quick suite on push
- [ ] Container tests on CI

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNUicKGGyMDqei6YYXaE1u)_