### PR TITLE
fix(mount): skip write probe in overlay mode — read-only by design (#341)

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1684,9 +1684,11 @@ validate_workspace_mount() {
 # the agent command. On macOS virtio-fs can degrade during that window too.
 #
 # This probe runs immediately before exec and uses `timeout` so a hung virtio-
-# fs transport cannot freeze the container. A write probe is required (not
-# just stat) because the failure mode in #276 is that bash's `>` redirect open
-# fails even when stat succeeds on the parent dir.
+# fs transport cannot freeze the container. In worktree mode a write probe is
+# required (not just stat) because the failure mode in #276 is that bash's `>`
+# redirect open fails even when stat succeeds on the parent dir. In overlay
+# mode the workspace is read-only by design (Issue #341) so only the stat
+# probe runs — see the overlay short-circuit in the function body below.
 #
 # On failure, emits the same KAPSIS_MOUNT_FAILURE: sentinel to stderr that the
 # liveness monitor uses (scripts/lib/liveness-monitor.sh:613), so the existing

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1743,9 +1743,27 @@ probe_mount_readiness() {
         return 1
     fi
 
-    # Write probe: the real failure mode is that bash cannot open files for
-    # output redirect. Verify that the agent will be able to create files
-    # under the workspace before we exec into it.
+    # Issue #341: in overlay mode the workspace is read-only by design — the
+    # agent's writes go to the host-side upperdir (via :O,upperdir=,workdir=),
+    # to $HOME for staged-config CoW overlays (.claude, .ssh, …), and to
+    # /kapsis-status for task progress. The agent never writes to /workspace
+    # directly. A write probe here would always fail with EROFS regardless of
+    # mount health, masking the stat probe above and producing false-positive
+    # mount failures (exit 4) for every overlay-mode launch on macOS where
+    # podman 5.x mounts ":O,upperdir=,workdir=" as ro under --userns=keep-id.
+    # The mid-run liveness-monitor follows the same mode-aware pattern — see
+    # scripts/lib/liveness-monitor.sh::_mount_check_probe (uses stat + ls -A
+    # for both modes, only adds a git sentinel check in worktree mode).
+    # Mirrors the existing overlay short-circuit in
+    # scripts/lib/inject-status-hooks.sh:325.
+    if [[ "${KAPSIS_SANDBOX_MODE:-}" == "overlay" ]]; then
+        log_debug "Pre-agent mount readiness probe: stat passed; skipping write probe in overlay mode (read-only by design)"
+        return 0
+    fi
+
+    # Write probe (worktree mode): the real failure mode is that bash cannot
+    # open files for output redirect. Verify that the agent will be able to
+    # create files under the workspace before we exec into it.
     # Use mktemp for an unpredictable filename; fall back to PID-suffix on
     # systems where mktemp is unavailable inside the container (extremely rare).
     local probe_file

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1686,9 +1686,13 @@ validate_workspace_mount() {
 # This probe runs immediately before exec and uses `timeout` so a hung virtio-
 # fs transport cannot freeze the container. In worktree mode a write probe is
 # required (not just stat) because the failure mode in #276 is that bash's `>`
-# redirect open fails even when stat succeeds on the parent dir. In overlay
-# mode the workspace is read-only by design (Issue #341) so only the stat
-# probe runs — see the overlay short-circuit in the function body below.
+# redirect open fails even when stat succeeds on the parent dir; /workspace is
+# read-write so the probe has signal. In overlay mode the workspace is
+# intentionally read-only (Issue #341): agent writes target $HOME and
+# /kapsis-status instead, so a write probe on /workspace always returns EROFS
+# regardless of mount health — only the stat probe runs. If KAPSIS_SANDBOX_MODE
+# is unset or empty the write probe runs (worktree behavior), which is the safe
+# default for callers that do not export the variable.
 #
 # On failure, emits the same KAPSIS_MOUNT_FAILURE: sentinel to stderr that the
 # liveness monitor uses (scripts/lib/liveness-monitor.sh:613), so the existing
@@ -1757,8 +1761,16 @@ probe_mount_readiness() {
     # scripts/lib/liveness-monitor.sh::_mount_check_probe (uses stat + ls -A
     # for both modes, only adds a git sentinel check in worktree mode).
     # Mirrors the existing overlay short-circuit in
-    # scripts/lib/inject-status-hooks.sh:325.
-    if [[ "${KAPSIS_SANDBOX_MODE:-}" == "overlay" ]]; then
+    # scripts/lib/inject-status-hooks.sh::inject_gist_instructions.
+    #
+    # Normalise the mode string: lowercase and strip whitespace so "Overlay",
+    # " overlay", and future overlay-family names match. Unset/empty is treated
+    # as worktree (write probe runs) — safe default for callers that do not
+    # export KAPSIS_SANDBOX_MODE.
+    local _probe_mode="${KAPSIS_SANDBOX_MODE:-}"
+    _probe_mode="${_probe_mode,,}"                    # bash lowercase
+    _probe_mode="${_probe_mode//[[:space:]]/}"        # strip whitespace
+    if [[ "$_probe_mode" == "overlay" ]]; then
         log_debug "Pre-agent mount readiness probe: stat passed; skipping write probe in overlay mode (read-only by design)"
         return 0
     fi

--- a/tests/test-workspace-mount-validation.sh
+++ b/tests/test-workspace-mount-validation.sh
@@ -60,6 +60,23 @@ cleanup_test_dirs() {
     _TEST_DIRS=()
 }
 
+# _with_sandbox_mode <mode> <cmd...>: run <cmd> with KAPSIS_SANDBOX_MODE=<mode>,
+# restoring the original value on return. Eliminates repetitive save/export/restore
+# boilerplate in probe_mount_readiness tests.
+_with_sandbox_mode() {
+    local _mode="$1"; shift
+    local _prior="${KAPSIS_SANDBOX_MODE:-}"
+    export KAPSIS_SANDBOX_MODE="$_mode"
+    local _rc=0
+    "$@" || _rc=$?
+    if [[ -n "$_prior" ]]; then
+        export KAPSIS_SANDBOX_MODE="$_prior"
+    else
+        unset KAPSIS_SANDBOX_MODE
+    fi
+    return "$_rc"
+}
+
 #===============================================================================
 # TEST: Workspace does not exist
 #===============================================================================
@@ -368,21 +385,21 @@ EOF
 #===============================================================================
 
 test_probe_mount_readiness_healthy() {
-    log_test "probe_mount_readiness returns 0 when workspace is writable"
+    log_test "probe_mount_readiness returns 0 when workspace is writable (worktree mode)"
     local test_dir
     test_dir=$(make_test_dir)
     mkdir -p "$test_dir/workspace"
 
     local exit_code=0
-    probe_mount_readiness "$test_dir/workspace" 2>/dev/null || exit_code=$?
+    _with_sandbox_mode "worktree" probe_mount_readiness "$test_dir/workspace" 2>/dev/null || exit_code=$?
     assert_equals "0" "$exit_code" "Writable workspace should pass probe"
 }
 
 test_probe_mount_readiness_missing() {
-    log_test "probe_mount_readiness returns 1 + sentinel when workspace missing"
+    log_test "probe_mount_readiness returns 1 + sentinel when workspace missing (worktree mode)"
     local stderr_output
     local exit_code=0
-    stderr_output=$(probe_mount_readiness "/nonexistent/workspace-$$" 2>&1 >/dev/null) || exit_code=$?
+    stderr_output=$(_with_sandbox_mode "worktree" probe_mount_readiness "/nonexistent/workspace-$$" 2>&1 >/dev/null) || exit_code=$?
     assert_equals "1" "$exit_code" "Missing workspace should fail probe"
     # Sentinel must use the tagged form introduced after the PR #280 review.
     assert_contains "$stderr_output" "KAPSIS_MOUNT_FAILURE[probe_mount_readiness]:" \
@@ -403,22 +420,10 @@ test_probe_mount_readiness_readonly() {
     mkdir -p "$test_dir/workspace"
     chmod 0555 "$test_dir/workspace"
 
-    # Issue #341: write probe is worktree-mode behavior; make the test's
-    # assumption explicit so it doesn't silently change semantics if the
-    # default mode flips.
-    local saved_mode="${KAPSIS_SANDBOX_MODE:-}"
-    export KAPSIS_SANDBOX_MODE="worktree"
-
-    local stderr_output
-    local exit_code=0
-    stderr_output=$(probe_mount_readiness "$test_dir/workspace" 2>&1 >/dev/null) || exit_code=$?
+    local stderr_output exit_code=0
+    stderr_output=$(_with_sandbox_mode "worktree" probe_mount_readiness "$test_dir/workspace" 2>&1 >/dev/null) || exit_code=$?
     # Restore write so cleanup can rm -rf.
     chmod 0755 "$test_dir/workspace"
-    if [[ -n "$saved_mode" ]]; then
-        export KAPSIS_SANDBOX_MODE="$saved_mode"
-    else
-        unset KAPSIS_SANDBOX_MODE
-    fi
     assert_equals "1" "$exit_code" "Read-only workspace should fail probe in worktree mode"
     assert_contains "$stderr_output" "KAPSIS_MOUNT_FAILURE[probe_mount_readiness]:" \
         "Should emit tagged KAPSIS_MOUNT_FAILURE sentinel when write probe fails"
@@ -443,20 +448,9 @@ test_probe_mount_readiness_overlay_skips_write_probe() {
     mkdir -p "$test_dir/workspace"
     chmod 0555 "$test_dir/workspace"
 
-    local saved_mode="${KAPSIS_SANDBOX_MODE:-}"
-    export KAPSIS_SANDBOX_MODE="overlay"
-
-    local stderr_output
-    local exit_code=0
-    stderr_output=$(probe_mount_readiness "$test_dir/workspace" 2>&1 >/dev/null) || exit_code=$?
-
+    local stderr_output exit_code=0
+    stderr_output=$(_with_sandbox_mode "overlay" probe_mount_readiness "$test_dir/workspace" 2>&1 >/dev/null) || exit_code=$?
     chmod 0755 "$test_dir/workspace"
-    if [[ -n "$saved_mode" ]]; then
-        export KAPSIS_SANDBOX_MODE="$saved_mode"
-    else
-        unset KAPSIS_SANDBOX_MODE
-    fi
-
     assert_equals "0" "$exit_code" \
         "Overlay-mode read-only workspace should pass probe (stat OK, write probe skipped)"
     # Issue #341 user-facing fix: the original bug was the spurious sentinel
@@ -469,19 +463,8 @@ test_probe_mount_readiness_overlay_skips_write_probe() {
 
 test_probe_mount_readiness_overlay_still_detects_missing_workspace() {
     log_test "probe_mount_readiness in overlay mode still fails when workspace is missing (Issue #341)"
-    local saved_mode="${KAPSIS_SANDBOX_MODE:-}"
-    export KAPSIS_SANDBOX_MODE="overlay"
-
-    local stderr_output
-    local exit_code=0
-    stderr_output=$(probe_mount_readiness "/nonexistent/workspace-overlay-$$" 2>&1 >/dev/null) || exit_code=$?
-
-    if [[ -n "$saved_mode" ]]; then
-        export KAPSIS_SANDBOX_MODE="$saved_mode"
-    else
-        unset KAPSIS_SANDBOX_MODE
-    fi
-
+    local stderr_output exit_code=0
+    stderr_output=$(_with_sandbox_mode "overlay" probe_mount_readiness "/nonexistent/workspace-overlay-$$" 2>&1 >/dev/null) || exit_code=$?
     assert_equals "1" "$exit_code" \
         "Overlay-mode missing workspace should fail (stat probe still fires)"
     assert_contains "$stderr_output" "KAPSIS_MOUNT_FAILURE[probe_mount_readiness]:" \

--- a/tests/test-workspace-mount-validation.sh
+++ b/tests/test-workspace-mount-validation.sh
@@ -446,8 +446,9 @@ test_probe_mount_readiness_overlay_skips_write_probe() {
     local saved_mode="${KAPSIS_SANDBOX_MODE:-}"
     export KAPSIS_SANDBOX_MODE="overlay"
 
+    local stderr_output
     local exit_code=0
-    probe_mount_readiness "$test_dir/workspace" 2>/dev/null || exit_code=$?
+    stderr_output=$(probe_mount_readiness "$test_dir/workspace" 2>&1 >/dev/null) || exit_code=$?
 
     chmod 0755 "$test_dir/workspace"
     if [[ -n "$saved_mode" ]]; then
@@ -458,6 +459,12 @@ test_probe_mount_readiness_overlay_skips_write_probe() {
 
     assert_equals "0" "$exit_code" \
         "Overlay-mode read-only workspace should pass probe (stat OK, write probe skipped)"
+    # Issue #341 user-facing fix: the original bug was the spurious sentinel
+    # appearing on every overlay-mode launch. Lock that in — a future change
+    # that re-emits the sentinel while still returning 0 would re-introduce
+    # the false-positive mount_failure on the host side.
+    assert_not_contains "$stderr_output" "KAPSIS_MOUNT_FAILURE[probe_mount_readiness]:" \
+        "Overlay-mode probe must NOT emit the false-positive sentinel"
 }
 
 test_probe_mount_readiness_overlay_still_detects_missing_workspace() {

--- a/tests/test-workspace-mount-validation.sh
+++ b/tests/test-workspace-mount-validation.sh
@@ -392,7 +392,7 @@ test_probe_mount_readiness_missing() {
 }
 
 test_probe_mount_readiness_readonly() {
-    log_test "probe_mount_readiness returns 1 + sentinel when workspace is read-only"
+    log_test "probe_mount_readiness returns 1 + sentinel when workspace is read-only (worktree mode)"
     # Skip the write-probe case when running as root — root bypasses mode bits.
     if [[ $(id -u) -eq 0 ]]; then
         log_skip "Skipping read-only probe test — running as root, mode bits bypassed"
@@ -403,14 +403,84 @@ test_probe_mount_readiness_readonly() {
     mkdir -p "$test_dir/workspace"
     chmod 0555 "$test_dir/workspace"
 
+    # Issue #341: write probe is worktree-mode behavior; make the test's
+    # assumption explicit so it doesn't silently change semantics if the
+    # default mode flips.
+    local saved_mode="${KAPSIS_SANDBOX_MODE:-}"
+    export KAPSIS_SANDBOX_MODE="worktree"
+
     local stderr_output
     local exit_code=0
     stderr_output=$(probe_mount_readiness "$test_dir/workspace" 2>&1 >/dev/null) || exit_code=$?
     # Restore write so cleanup can rm -rf.
     chmod 0755 "$test_dir/workspace"
-    assert_equals "1" "$exit_code" "Read-only workspace should fail probe"
+    if [[ -n "$saved_mode" ]]; then
+        export KAPSIS_SANDBOX_MODE="$saved_mode"
+    else
+        unset KAPSIS_SANDBOX_MODE
+    fi
+    assert_equals "1" "$exit_code" "Read-only workspace should fail probe in worktree mode"
     assert_contains "$stderr_output" "KAPSIS_MOUNT_FAILURE[probe_mount_readiness]:" \
         "Should emit tagged KAPSIS_MOUNT_FAILURE sentinel when write probe fails"
+}
+
+#===============================================================================
+# Issue #341: overlay-mode workspace is read-only by design — the write probe
+# would always fail with EROFS, masking the stat probe's signal. Verify the
+# mode-aware short-circuit short-circuits ONLY the write probe, not the stat
+# probe.
+#===============================================================================
+
+test_probe_mount_readiness_overlay_skips_write_probe() {
+    log_test "probe_mount_readiness skips write probe in overlay mode (Issue #341)"
+    # Skip when running as root — root bypasses mode bits so chmod 0555 is a no-op.
+    if [[ $(id -u) -eq 0 ]]; then
+        log_skip "Skipping overlay write-probe test — running as root, mode bits bypassed"
+        return 0
+    fi
+    local test_dir
+    test_dir=$(make_test_dir)
+    mkdir -p "$test_dir/workspace"
+    chmod 0555 "$test_dir/workspace"
+
+    local saved_mode="${KAPSIS_SANDBOX_MODE:-}"
+    export KAPSIS_SANDBOX_MODE="overlay"
+
+    local exit_code=0
+    probe_mount_readiness "$test_dir/workspace" 2>/dev/null || exit_code=$?
+
+    chmod 0755 "$test_dir/workspace"
+    if [[ -n "$saved_mode" ]]; then
+        export KAPSIS_SANDBOX_MODE="$saved_mode"
+    else
+        unset KAPSIS_SANDBOX_MODE
+    fi
+
+    assert_equals "0" "$exit_code" \
+        "Overlay-mode read-only workspace should pass probe (stat OK, write probe skipped)"
+}
+
+test_probe_mount_readiness_overlay_still_detects_missing_workspace() {
+    log_test "probe_mount_readiness in overlay mode still fails when workspace is missing (Issue #341)"
+    local saved_mode="${KAPSIS_SANDBOX_MODE:-}"
+    export KAPSIS_SANDBOX_MODE="overlay"
+
+    local stderr_output
+    local exit_code=0
+    stderr_output=$(probe_mount_readiness "/nonexistent/workspace-overlay-$$" 2>&1 >/dev/null) || exit_code=$?
+
+    if [[ -n "$saved_mode" ]]; then
+        export KAPSIS_SANDBOX_MODE="$saved_mode"
+    else
+        unset KAPSIS_SANDBOX_MODE
+    fi
+
+    assert_equals "1" "$exit_code" \
+        "Overlay-mode missing workspace should fail (stat probe still fires)"
+    assert_contains "$stderr_output" "KAPSIS_MOUNT_FAILURE[probe_mount_readiness]:" \
+        "Should emit tagged KAPSIS_MOUNT_FAILURE sentinel when stat probe fails"
+    assert_contains "$stderr_output" "inaccessible at startup" \
+        "Sentinel should indicate stat-probe failure (not write-probe failure)"
 }
 
 test_probe_mount_readiness_skips_probe_container() {
@@ -640,6 +710,10 @@ main() {
     run_test test_probe_mount_readiness_readonly
     run_test test_probe_mount_readiness_skips_probe_container
     run_test test_probe_mount_readiness_sentinel_host_compatible
+
+    log_info "=== Overlay-Mode Write-Probe Skip (Issue #341) ==="
+    run_test test_probe_mount_readiness_overlay_skips_write_probe
+    run_test test_probe_mount_readiness_overlay_still_detects_missing_workspace
     run_test test_sentinel_rejects_arbitrary_log_line
     run_test test_sentinel_rejects_spoofed_early_line
     run_test test_sentinel_not_honored_on_exit_1


### PR DESCRIPTION
## Summary

- Skip the write probe in `probe_mount_readiness` when `KAPSIS_SANDBOX_MODE=overlay` — workspace is intentionally read-only by design, so the probe always failed with EROFS producing false-positive exit-4 mount failures on every overlay-mode launch on macOS (fixes #341)
- Update `probe_mount_readiness` header comment to clarify the write probe is worktree-mode only after #341
- Add two new tests: overlay mode skips write probe (rc=0, no spurious sentinel), overlay mode still detects missing workspace via stat probe (rc=1 + sentinel)
- Tighten existing `test_probe_mount_readiness_readonly` to set `KAPSIS_SANDBOX_MODE=worktree` explicitly

## Note

The changes on this branch are equivalent to those already merged into `main` via #342. File diffs vs `main` are empty — this PR exists for CI tracking purposes and can be closed/merged as a no-op.

## Test plan

- [ ] `./tests/run-all-tests.sh --quick` — no regressions
- [ ] `tests/test-workspace-mount-validation.sh` — 26/26 green (24 existing + 2 new)

https://claude.ai/code/session_01AtipW18AHZ9VkvxLHSegDH

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtipW18AHZ9VkvxLHSegDH)_