### PR TITLE
fix(image): pre-create /home/developer/.claude as developer-owned (#340)

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -491,10 +491,20 @@ RUN userdel -r ubuntu 2>/dev/null || true && \
     groupadd -g ${GROUP_ID} ${USERNAME} && \
     useradd -m -u ${USER_ID} -g ${GROUP_ID} -s /bin/bash ${USERNAME}
 
-# Create directories with correct ownership
+# Create directories with correct ownership.
+#
+# Issue #340: pre-create /home/${USERNAME}/.claude as developer-owned so the
+# conversations bind-mount (added in #322 at /home/developer/.claude/conversations)
+# doesn't cause podman to auto-create the parent .claude dir as root mode 1755
+# on macOS hosts with --userns=keep-id. The auto-created root-owned .claude
+# subsequently breaks atomic_copy_dir's rm-rf-and-mv replacement step in
+# setup_staged_config_overlays. Pre-creating the dir means podman finds it
+# already there and processes the conversations sub-mount without altering
+# parent ownership/mode.
 RUN mkdir -p /home/${USERNAME}/.m2/repository \
              /home/${USERNAME}/.gradle \
              /home/${USERNAME}/.m2/.gradle-enterprise \
+             /home/${USERNAME}/.claude \
              /home/${USERNAME}/go \
              /workspace && \
     chown -R ${USERNAME}:${USERNAME} /home/${USERNAME} /workspace

--- a/tests/test-containerfile.sh
+++ b/tests/test-containerfile.sh
@@ -363,6 +363,138 @@ test_container_lib_transitive_deps_present() {
 }
 
 #===============================================================================
+# TEST CASES: /home/developer/.claude pre-creation (Issue #340)
+#
+# The conversations bind-mount from #322 (host
+# $HOME/.kapsis/conversations/<id> → container /home/developer/.claude/
+# conversations) causes podman to auto-mkdir /home/developer/.claude as root
+# mode 1755 on macOS hosts with --userns=keep-id when the parent dir does not
+# already exist in the image. The root-owned .claude then breaks
+# atomic_copy_dir's rm-rf-and-mv replacement step in
+# setup_staged_config_overlays. Fix: pre-create /home/developer/.claude in
+# the Containerfile as developer-owned so podman finds it already present.
+#===============================================================================
+
+test_home_claude_dir_pre_created() {
+    log_test "Containerfile pre-creates /home/developer/.claude (Issue #340)"
+
+    assert_file_exists "$CONTAINERFILE" "Containerfile should exist"
+
+    local content
+    content=$(cat "$CONTAINERFILE")
+
+    # The Issue #340 fix lives in the same RUN that pre-creates .m2 / .gradle /
+    # go / /workspace. Look for the .claude path being mkdir'd somewhere in
+    # the file; relying on a specific RUN block would be brittle.
+    # shellcheck disable=SC2016  # single quotes intentional — match literal ${USERNAME} in Containerfile
+    assert_contains "$content" '/home/${USERNAME}/.claude' \
+        "Containerfile should pre-create /home/\${USERNAME}/.claude (Issue #340)"
+}
+
+test_home_claude_dir_chowned_to_developer() {
+    log_test "Containerfile chowns /home/developer (including .claude) to developer (Issue #340)"
+
+    local content
+    content=$(cat "$CONTAINERFILE")
+
+    # The chown -R /home/${USERNAME} after the mkdir covers all subdirs.
+    # Match the chown line that's recursive over /home/${USERNAME} so the
+    # pre-created .claude dir picks up developer ownership.
+    if ! echo "$content" | grep -Eq 'chown -R[[:space:]]+\$\{USERNAME\}:\$\{USERNAME\}[[:space:]]+/home/\$\{USERNAME\}'; then
+        log_fail "Containerfile should run 'chown -R \${USERNAME}:\${USERNAME} /home/\${USERNAME}' after pre-creating .claude"
+        return 1
+    fi
+
+    log_info "chown -R covers /home/\${USERNAME} (including pre-created .claude)"
+}
+
+# Container integration: verify the actual image behavior matches the static
+# assertion above. This is the regression test that would have caught #340 if
+# it had existed when #322 landed.
+test_home_claude_dir_developer_owned_in_built_image() {
+    log_test "/home/developer/.claude is developer-owned in built image (Issue #340)"
+
+    local image="${KAPSIS_TEST_IMAGE:-localhost/kapsis-sandbox:latest}"
+
+    if ! podman image exists "$image" 2>/dev/null; then
+        log_skip "$image not built — skipping in-container ownership check"
+        return 0
+    fi
+
+    local owner mode
+    owner=$(podman run --rm --entrypoint /bin/bash "$image" -c \
+        'stat -c "%U:%G" /home/developer/.claude' 2>/dev/null) || {
+        log_fail "Could not stat /home/developer/.claude in $image"
+        return 1
+    }
+    mode=$(podman run --rm --entrypoint /bin/bash "$image" -c \
+        'stat -c "%a" /home/developer/.claude' 2>/dev/null) || {
+        log_fail "Could not get mode of /home/developer/.claude in $image"
+        return 1
+    }
+
+    assert_equals "developer:developer" "$owner" \
+        "/home/developer/.claude should be developer-owned (got '$owner')"
+
+    # Anything in 7XX (0700, 0755, 0775, 0777) is acceptable as long as the
+    # developer user can read+write+execute. Reject 1755 (sticky bit, the
+    # podman-auto-create signature) and modes lacking developer write.
+    case "$mode" in
+        7*)
+            log_info "/home/developer/.claude mode=$mode owner=$owner (Issue #340 fix verified in image)"
+            ;;
+        *)
+            log_fail "/home/developer/.claude mode=$mode (expected 7XX — developer must have rwx). Mode 1755 indicates podman auto-created the dir, meaning the #340 fix is missing or didn't take effect."
+            return 1
+            ;;
+    esac
+}
+
+# End-to-end probe: with a synthetic conversations bind-mount overlaying the
+# pre-created .claude, the parent directory must remain developer-owned and
+# writable. This is the closest pure-bash equivalent of the real bug.
+test_conversations_mount_does_not_clobber_claude_ownership() {
+    log_test "conversations bind-mount preserves /home/developer/.claude ownership (Issue #340)"
+
+    local image="${KAPSIS_TEST_IMAGE:-localhost/kapsis-sandbox:latest}"
+
+    if ! podman image exists "$image" 2>/dev/null; then
+        log_skip "$image not built — skipping bind-mount regression check"
+        return 0
+    fi
+
+    local conv_host
+    conv_host=$(mktemp -d)
+    # shellcheck disable=SC2064
+    trap "rm -rf '$conv_host'" RETURN
+
+    local result
+    result=$(podman run --rm \
+        --userns=keep-id \
+        -v "${conv_host}:/home/developer/.claude/conversations" \
+        --entrypoint /bin/bash "$image" -c '
+owner=$(stat -c "%U:%G" /home/developer/.claude 2>/dev/null)
+mode=$(stat -c "%a" /home/developer/.claude 2>/dev/null)
+writable=$([[ -w /home/developer/.claude ]] && echo yes || echo no)
+echo "owner=$owner mode=$mode writable=$writable"
+' 2>&1) || {
+        log_fail "Failed to run probe container: $result"
+        return 1
+    }
+
+    # The whole point of #340: post-mount, .claude must still be developer-
+    # owned, NOT root mode 1755, AND writable by the developer user.
+    if echo "$result" | grep -q "owner=developer:developer" \
+       && echo "$result" | grep -q "writable=yes" \
+       && ! echo "$result" | grep -q "mode=1755"; then
+        log_info "Conversations bind-mount preserves .claude ownership ($result)"
+    else
+        log_fail "conversations bind-mount altered .claude ownership/mode — Issue #340 regressed: $result"
+        return 1
+    fi
+}
+
+#===============================================================================
 # MAIN
 #===============================================================================
 
@@ -384,17 +516,25 @@ main() {
     run_test test_entrypoint_libs_copied_to_container
     run_test test_container_lib_transitive_deps_present
 
+    # /home/developer/.claude pre-creation (Issue #340)
+    run_test test_home_claude_dir_pre_created
+    run_test test_home_claude_dir_chowned_to_developer
+
     # Container integration tests (requires Podman)
     if skip_if_no_container 2>/dev/null; then
         run_test test_sdkman_config_in_built_image
         run_test test_sdkman_no_network_warning
         run_test test_java_available_in_image
         run_test test_maven_available_in_image
+        run_test test_home_claude_dir_developer_owned_in_built_image
+        run_test test_conversations_mount_does_not_clobber_claude_ownership
     else
         skip_test test_sdkman_config_in_built_image "No container runtime"
         skip_test test_sdkman_no_network_warning "No container runtime"
         skip_test test_java_available_in_image "No container runtime"
         skip_test test_maven_available_in_image "No container runtime"
+        skip_test test_home_claude_dir_developer_owned_in_built_image "No container runtime"
+        skip_test test_conversations_mount_does_not_clobber_claude_ownership "No container runtime"
     fi
 
     # Summary


### PR DESCRIPTION
## Summary

The conversations bind-mount added in #322 (`$HOME/.kapsis/conversations/<id> → /home/developer/.claude/conversations`) causes podman to auto-`mkdir` `/home/developer/.claude` as **root mode 1755** (sticky bit) on macOS hosts using `--userns=keep-id` when the parent directory does not already exist in the image. The root-owned `.claude` subsequently breaks `atomic_copy_dir`'s `rm -rf "$dst"; mv "$tmp_dir" "$dst"` replacement step in `setup_staged_config_overlays` (both `rm` and `mv` get EACCES), so staged-config copy fails silently and `inject-lsp-config.sh` later fails with `Permission denied` writing `settings.local.json`. Every overlay-mode launch on macOS dies during entrypoint.

Fixes #340.

## Reproduction (macOS, podman 5.x, kapsis 2.28.6 unpatched)

Probe (no kapsis CLI needed — the bug is in the image, not the launcher):

```bash
mkdir -p /tmp/test-conv-host
podman run --rm --userns=keep-id \
    -v "/tmp/test-conv-host:/home/developer/.claude/conversations" \
    --entrypoint /bin/bash localhost/kapsis-sandbox:latest -c '
echo "owner=$(stat -c %U:%G /home/developer/.claude) mode=$(stat -c %a /home/developer/.claude)"
echo "developer writable: $([[ -w /home/developer/.claude ]] && echo YES || echo NO)"
'
```

Output (unpatched):
```
owner=root:root mode=1755
developer writable: NO
```

Real agent trace on kapsis 2.28.5 (just verified during /upgrade-kapsis):
```
rm: cannot remove '/home/developer/.claude/conversations': Permission denied
mv: cannot move '/home/developer/.atomic-copy-dir-EJyjju' to '/home/developer/.claude/.atomic-copy-dir-EJyjju': Permission denied
/opt/kapsis/lib/inject-lsp-config.sh: line 82: /home/developer/.claude/settings.local.json: Permission denied
```

## Why this is macOS-specific

Linux hosts where the kapsis CLI runs as the same UID as `developer` don't hit this — podman auto-creates the intermediate mount parent owned by the host UID (which == container UID on Linux without keep-id remapping), so `.claude` ends up developer-owned by accident. On macOS where kapsis runs with `--userns=keep-id` (host UID 501 → container UID 1000 / developer), the auto-created parent ends up owned by `root:root` in the container's user namespace, with mode 1755 from podman's default. This is also why Linux CI didn't catch #340 when #322 landed.

## The change

Pre-create `/home/${USERNAME}/.claude` in the Containerfile so podman finds it already present when processing the conversations sub-mount. One line added to an existing `mkdir -p` block; the existing `chown -R ${USERNAME}:${USERNAME} /home/${USERNAME}` immediately below already covers the new subdir.

```diff
+# Issue #340: pre-create /home/${USERNAME}/.claude as developer-owned so the
+# conversations bind-mount (added in #322 at /home/developer/.claude/conversations)
+# doesn't cause podman to auto-create the parent .claude dir as root mode 1755
+# on macOS hosts with --userns=keep-id.
 RUN mkdir -p /home/${USERNAME}/.m2/repository \
              /home/${USERNAME}/.gradle \
              /home/${USERNAME}/.m2/.gradle-enterprise \
+             /home/${USERNAME}/.claude \
              /home/${USERNAME}/go \
              /workspace && \
     chown -R ${USERNAME}:${USERNAME} /home/${USERNAME} /workspace
```

## Why this is the right fix (not a launch-agent.sh workaround)

| Option | Pro | Con |
|---|---|---|
| **Pre-create in Containerfile (this PR)** | Smallest patch (3 lines). podman never sees a missing parent → never auto-creates. Future bind-mounts under `.claude` benefit automatically. | Image rebuild required to pick up the fix. |
| Mount conversations to a non-conflicting path (`/home/developer/.kapsis-conversations/`), then symlink into `.claude/conversations` at entrypoint time | Avoids the path collision entirely. | Changes user-visible behavior (the JSONL files live under a new name); more moving parts; the entrypoint symlink step itself can race with staging. |
| `mkdir -p .claude` in entrypoint.sh BEFORE `setup_staged_config_overlays` | Host-side launcher unchanged. | The conversations mount is processed by podman BEFORE the entrypoint runs, so this can't fix the underlying auto-create — it would only paper over the rm-rf-and-mv step. |
| `launch-agent.sh` patch to drop the conversations mount on macOS | Trivial workaround. | Loses the entire #322 feature on macOS, where it's actually most useful (where the bot runs in prod). |

Option 1 ships the fewest changes and the strongest guarantee.

## Tests (`tests/test-containerfile.sh`)

Two static + two integration:

- `test_home_claude_dir_pre_created` (static): Containerfile mkdir line includes `/home/${USERNAME}/.claude`.
- `test_home_claude_dir_chowned_to_developer` (static): `chown -R ${USERNAME}:${USERNAME} /home/${USERNAME}` line covers the pre-created subtree.
- `test_home_claude_dir_developer_owned_in_built_image` (integration, requires podman + built image): `stat /home/developer/.claude` in a fresh container returns `developer:developer` with mode `7XX` (rejects `1755` — the podman-auto-create signature).
- `test_conversations_mount_does_not_clobber_claude_ownership` (integration): launches a probe container with `--userns=keep-id` and `-v ...:/home/developer/.claude/conversations`, verifies `/home/developer/.claude` is still `developer:developer`, mode != 1755, and writable. **This is the closest pure-bash equivalent of the production failure** — it would have caught #340 if it had existed when #322 landed, and it acts as a regression guard going forward.

Integration tests `skip_if_no_container`; the static tests run on any host.

Local run on this PR: static tests pass; integration tests pending image rebuild (the kapsis-sandbox:latest cached locally was built before this fix).

## Risk

- **Existing kapsis launches:** none — the new mkdir adds an empty dir; staged-config copy of `.claude` writes into it normally (`atomic_copy_dir` already accepts a pre-existing dst, with the chmod hardening from #335). The dir mode after `chown -R ${USERNAME}` is the default 0755, which matches the inject-lsp-config.sh write expectation.
- **Empty-staged-config users:** if a user runs without `.claude` in `filesystem.include`, the pre-created dir is empty — harmless, ~0 bytes.
- **Backwards compat:** none affected. The pre-created dir is mode 0755 owned by developer; this is the same shape `atomic_copy_dir` would produce anyway.

## Consumer status

This is the last upstream blocker in the slack-bot overlay-mode chain on macOS 2.28.x. With #339 (`:U` pre-filter), #342 (probe_mount_readiness overlay skip), and this PR all landed, the slack-bot's `elif _default_repo:` worktree-mode workaround in `claude_handler.py` can finally be removed and overlay-mode Q&A tasks should run clean end-to-end.

Closes #340
