### PR TITLE
fix(ci): move secrets check out of job-level if so workflow parses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,27 +316,45 @@ jobs:
     # main and scheduled runs execute with the real secret.
     # Failing e2e does NOT block the ci-success gate (optional check).
     needs: [unit-tests, integration-tests]
-    if: >-
-      github.event_name != 'pull_request' &&
-      success() &&
-      secrets.CLAUDE_CODE_OAUTH_TOKEN != ''
+    # NOTE: the `secrets` context is NOT allowed in job-level `if:` — referencing
+    # it there causes GitHub to reject the workflow file at parse time (no jobs
+    # run, `gh api .../jobs` returns `{"jobs": []}`). The token-present check
+    # has to live in a dedicated step (env CAN reference secrets), and every
+    # other step in this job gates on its output.
+    if: github.event_name != 'pull_request' && success()
     steps:
+      - name: Check OAuth token availability
+        id: oauth
+        env:
+          HAS_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
+        run: |
+          if [[ "$HAS_TOKEN" == "true" ]]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::CLAUDE_CODE_OAUTH_TOKEN not configured — E2E tests skipped"
+          fi
+
       - name: Checkout code
+        if: steps.oauth.outputs.available == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Install dependencies
+        if: steps.oauth.outputs.available == 'true'
         run: |
           sudo apt-get update -q
           sudo apt-get install -y -q jq
           npm install -g @anthropic-ai/claude-code@latest
 
       - name: Configure git (required by Claude Code)
+        if: steps.oauth.outputs.available == 'true'
         run: |
           git config --global user.email "ci@kapsis.test"
           git config --global user.name "Kapsis CI"
           git config --global commit.gpgsign false
 
       - name: Run E2E tests against live API
+        if: steps.oauth.outputs.available == 'true'
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           CI: "true"


### PR DESCRIPTION
## Summary

Restore CI on `main`. The `e2e-tests` job introduced in #352 referenced `secrets.CLAUDE_CODE_OAUTH_TOKEN` from inside its **job-level** `if:`, but the `secrets` context isn't allowed there — only inside `env:`, `with:`, and step-level expressions. GitHub rejects the workflow file at parse time:

```
$ gh api repos/aviadshiber/kapsis/actions/runs/<id>/jobs
{"total_count": 0, "jobs": []}
```

Every `main` push after #352 (`585d181`) has been a parse-fail since:

| commit | result |
|---|---|
| `585d181` fix(hooks)… #351/#352 | CI failure (0 jobs) |
| `08a475b` fix(autoheal)… #348/#349 | CI failure (0 jobs) |
| `86bf4ea` test(zombie-recovery)… #298/#337 | CI failure (0 jobs) |

`auto-release` is triggered by `workflow_run` on CI **completed → success**, so it hasn't fired for any of those — Homebrew is still serving `v2.28.7` and the fixes for #348, #351, #298 are stranded on `main`.

## What this PR changes

Keeps the same security properties (no `pull_request` access to the secret, silent skip when the secret isn't set), but moves the token-present check into a dedicated first step that uses `env:` (where the `secrets` context IS allowed) and writes the result to `$GITHUB_OUTPUT`. Every subsequent step in `e2e-tests` gates on that output.

```yaml
if: github.event_name != 'pull_request' && success()
steps:
  - id: oauth
    env:
      HAS_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
    run: |
      if [[ "$HAS_TOKEN" == "true" ]]; then
        echo "available=true" >> "$GITHUB_OUTPUT"
      else
        echo "available=false" >> "$GITHUB_OUTPUT"
        echo "::notice::CLAUDE_CODE_OAUTH_TOKEN not configured — E2E tests skipped"
      fi

  - if: steps.oauth.outputs.available == 'true'
    uses: actions/checkout@…
  # …
```

## Behavioural equivalence to #352

| Trigger | Before #352 (broken) | After this PR |
|---|---|---|
| `pull_request` | Workflow rejected → 0 jobs | Job skipped at job-level `if:` |
| `push` / `schedule`, secret **unset** | Workflow rejected → 0 jobs | Job runs, emits `::notice`, all real steps skipped, **succeeds** |
| `push` / `schedule`, secret **set** | Workflow rejected → 0 jobs | Job runs E2E exactly as #352 intended |

The "silent skip on missing secret" is preserved — it just costs one tiny runner step instead of being a parser-level conditional.

## Why the original conditional failed

GitHub's documented contexts table:

| Context | workflow-level | job `if:` | step `if:` | `env:` | `with:` | `run:` |
|---|---|---|---|---|---|---|
| `github`, `vars`, `inputs`, `needs` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| **`secrets`** | ❌ | **❌** | ✅ | ✅ | ✅ | ✅ |
| `steps`, `runner`, `env`, `job` | ❌ | partial | ✅ | ✅ | ✅ | ✅ |

(See: https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability)

## Verification

- `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/ci.yml"))'` → YAML OK
- The only other `secrets.*` reference in the file (line 341) is already inside a step-level `env:` and stays untouched.
- Once this is merged, the next push to `main` should produce real jobs/check-runs again, and `auto-release` will cut the long-overdue patch tag covering #348, #351, and #298.

## Out of scope

- The 3 stranded fixes (#348/#349, #351/#352, #298/#337) are functionally fine — they're just waiting on this CI parse fix to unblock the release pipeline.
- No behaviour changes outside the `e2e-tests` job.
