### PR TITLE
fix(release): use awk splice instead of brittle sed pair for CHANGELOG carryover

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -407,12 +407,21 @@ jobs:
           done <<< "$COMMITS"
 
           # Create a temporary file for the new changelog
+          # Build the new version section in a temp file so awk can splice
+          # it into the existing CHANGELOG in a single pass. The previous
+          # implementation used `head -7` (brittle — assumed the header was
+          # exactly 7 lines) plus a pair of sed pipelines that were supposed
+          # to carry the post-Unreleased history forward. The sed range
+          # `/^## \[Unreleased\]/,/^## \[/{d}` deleted the closing version
+          # header along with the Unreleased block, then the follow-up
+          # `/^## \[/,$p | tail -n +2` re-anchored to the SECOND next
+          # version header and skipped its first line — corrupting one
+          # version's header on every release run. Repeated over months,
+          # the file drifted into a state where ~20 historical release
+          # blocks lost their version headers and got concatenated under
+          # whatever single header survived (see CHANGELOG.md state on
+          # 2026-05-17: lines 16-812 mis-labelled as "[2.1.1]").
           {
-            # Keep header lines (title and format description)
-            head -7 "$CHANGELOG_FILE"
-            echo ""
-
-            # Add new version section
             echo "## [${VERSION}] - ${DATE}"
             echo ""
 
@@ -469,15 +478,31 @@ jobs:
               echo ""
             fi
 
-            # Add empty [Unreleased] section and rest of changelog (skip old unreleased content)
-            echo "## [Unreleased]"
-            echo ""
+          } > /tmp/cl_new_section.md
 
-            # Get everything after [Unreleased] section's content (starting from next version)
-            sed -n '/^## \[Unreleased\]/,/^## \[/{ /^## \[Unreleased\]/d; /^## \[/p; }' "$CHANGELOG_FILE"
-            sed -n '/^## \[Unreleased\]/,/^## \[/{d}; /^## \[/,$p' "$CHANGELOG_FILE" | tail -n +2
-
-          } > "${CHANGELOG_FILE}.new"
+          # Splice the new section in front of the existing Unreleased block,
+          # preserving everything else verbatim. State machine:
+          #   header        — print as-is, until we hit ## [Unreleased]
+          #   in_unreleased — drop the stale Unreleased body (it gets rolled
+          #                   into the new version section just emitted)
+          #   passthrough   — first ## [ after Unreleased onwards: print as-is
+          awk -v new_file="/tmp/cl_new_section.md" '
+            BEGIN { state = "header" }
+            state == "header" && /^## \[Unreleased\]/ {
+              while ((getline line < new_file) > 0) print line
+              print "## [Unreleased]"
+              print ""
+              state = "in_unreleased"
+              next
+            }
+            state == "in_unreleased" && /^## \[/ {
+              state = "passthrough"
+              print
+              next
+            }
+            state == "in_unreleased" { next }
+            { print }
+          ' "$CHANGELOG_FILE" > "${CHANGELOG_FILE}.new"
 
           # Update comparison links at the bottom
           # Add new version link and update Unreleased link


### PR DESCRIPTION
## Summary

Restore the CHANGELOG carryover step in the release workflow. The current logic has been silently corrupting `CHANGELOG.md` on every release run; over time enough history was lost that lines 16-812 of `main`'s CHANGELOG are now all stacked under a single `## [2.1.1] - 2026-02-02` header that bears no relation to their actual release origins.

## Root cause

`.github/workflows/release.yml` had two compounding bugs in the `Update CHANGELOG.md` step:

**Bug 1 — fragile header copy:**
```bash
head -7 "$CHANGELOG_FILE"
```
Assumes the file's preamble is always exactly seven lines. If anything (a blank line, a docs migration) shifts that, the first line of the previous version's content leaks into the header section of the regenerated file.

**Bug 2 — broken sed pair for carrying old history forward:**
```bash
sed -n '/^## \[Unreleased\]/,/^## \[/{ /^## \[Unreleased\]/d; /^## \[/p; }' "$CHANGELOG_FILE"
sed -n '/^## \[Unreleased\]/,/^## \[/{d}; /^## \[/,$p' "$CHANGELOG_FILE" | tail -n +2
```

The intent is "print just the next version header, then print everything from that header onward verbatim." The actual behaviour:
- First pipeline prints the closing version header (one line). ✓
- Second pipeline's `/^## \[Unreleased\]/,/^## \[/{d}` range **deletes the closing `## [` line** along with the Unreleased body, so the follow-up `/^## \[/,$p` re-anchors to the SECOND `## [` it finds (one version too far), and `| tail -n +2` then chops the first line off that too.

Net effect on every release: one historical version block loses its header. Repeated 20+ times since CHANGELOG generation was first wired up, the file drifted into the observed state where dozens of release entries have been concatenated under whichever single header survived the most recent run.

## Fix

Replace `head -7` + the sed pair with a single awk pass driven by an explicit three-state machine:

```
header        — print as-is, until ## [Unreleased]
in_unreleased — drop the stale body (rolled into the new version section)
passthrough   — first ## [ after Unreleased onwards: print byte-for-byte
```

The new version section is built into `/tmp/cl_new_section.md` first (so the splice is a single read), then awk emits it in front of a fresh `## [Unreleased]`. Historical entries are forwarded verbatim — no line-counting or sed range arithmetic.

## Verification

Synthetic test fixture with pre-existing Unreleased content + two historical version blocks:

```
INPUT
  # Changelog ...
  ## [Unreleased]
    placeholder body  <-- should be dropped
  ## [1.2.3] - 2026-04-01
    ### Fixed
    - Old fix A
  ## [1.2.2] - 2026-03-01
    ### Added
    - Old feature B

OUTPUT (after splicing in new ## [1.2.4])
  # Changelog ...
  ## [1.2.4] - 2026-05-17
    ### Fixed
    - New fix C (#42)
  ## [Unreleased]
  ## [1.2.3] - 2026-04-01
    ### Fixed
    - Old fix A
  ## [1.2.2] - 2026-03-01
    ### Added
    - Old feature B
```

All historical headers preserved in the correct order; stale Unreleased body stripped; new version inserted at the right spot.

## Scope / out of scope

✅ Fixes future runs of the workflow — every subsequent release will preserve full history.

❌ Does **not** heal the existing damage on `main`'s `CHANGELOG.md`. The file's mislabelled-`[2.1.1]` block (lines 16–812) needs a separate manual reconstruction — best approach is probably a one-shot script that walks `git tag -l 'v*'` and rebuilds each release section from the actual commit ranges. Filed as future cleanup; out of scope for this PR.

## Risk

The change only touches the CHANGELOG generation step. The retry/push logic, the GitHub release creation, and the Homebrew tap sync are all untouched. Worst case if the awk has a regression: the generated CHANGELOG is wrong (same class of bug as today) and the user notices on the next release.
