### PR TITLE
test(dashboard): fix flaky status-deletion test on macOS

### DIFF
--- a/dashboard/server/tests/status-additional.test.ts
+++ b/dashboard/server/tests/status-additional.test.ts
@@ -51,8 +51,14 @@ describe("StatusStore — gap coverage", () => {
     store.onChange((s, file) => { if (s === null) drops.push(file); });
 
     await unlink(path);
-    // Wait past the debounce + drop grace.
-    await Bun.sleep(400);
+    // Poll until the drop fires or 1500 ms elapse.  fs.watch on macOS can
+    // take "a few hundred ms" to deliver events (per status.test.ts comment),
+    // so a fixed 400 ms budget races on slow CI runners.
+    // Budget: up to 300 ms fs.watch + 50 ms debounce + 200 ms drop-grace = 550 ms;
+    // 30 × 50 ms = 1500 ms gives plenty of headroom on any platform.
+    for (let i = 0; i < 30 && !drops.includes("kapsis-demo-drop1.json"); i++) {
+      await Bun.sleep(50);
+    }
     expect(drops).toContain("kapsis-demo-drop1.json");
     expect(store.get("drop1")).toBeUndefined();
   });


### PR DESCRIPTION
## Root cause

`status-additional.test.ts` has a file-deletion test that waits for the `StatusStore` drop-notification via a fixed `Bun.sleep(400)`. The expected latency chain is:

| Step | Time |
|------|------|
| `fs.watch` event delivery | ~0 ms (Linux inotify) / **up to ~300 ms (macOS FSEvents)** |
| `DEBOUNCE_MS` | 50 ms |
| `DROP_GRACE_MS` | 200 ms |
| **Total** | **250 ms (Linux) / up to 550 ms (macOS)** |

On `ubuntu-latest` (inotify) the 400 ms budget is fine. On `macos-latest`, `fs.watch` event delivery can take "a few hundred ms" (already documented in a comment in `status.test.ts`), pushing the total past 400 ms and causing a race.

## Fix

Replace the fixed sleep with the same polling loop used in `status.test.ts`:

```ts
// Before
await Bun.sleep(400);

// After
for (let i = 0; i < 30 && !drops.includes("kapsis-demo-drop1.json"); i++) {
  await Bun.sleep(50);
}
```

30 × 50 ms = 1500 ms max, stops as soon as the event arrives — fast on Linux, reliable on macOS.

## Evidence

- `test (ubuntu-latest)`: ✅ passes consistently  
- `test (macos-latest)`: ❌ fails in runs 26016827720, 26016994416 (same test, same timing race)

https://claude.ai/code/session_01NuMmWJwEzjPDw5yiY8eNyj

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuMmWJwEzjPDw5yiY8eNyj)_