### PR TITLE
fix(release): ship kapsis-dashboard binary in release + Homebrew (#372)

### DIFF
--- a/.github/workflows/dashboard-build.yml
+++ b/.github/workflows/dashboard-build.yml
@@ -41,53 +41,9 @@ jobs:
         working-directory: dashboard/server
         run: bun test
 
+  # Delegates the actual matrix to .github/workflows/dashboard-compile.yml
+  # so this CI workflow and release.yml share the same build steps. Drift
+  # between them was the root cause of #372.
   compile:
     needs: test
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: bun-darwin-arm64
-            runner: macos-latest
-            runnerArch: ARM64
-          - target: bun-darwin-x64
-            runner: macos-13
-            runnerArch: X64
-          - target: bun-linux-arm64
-            runner: ubuntu-latest
-            runnerArch: X64
-          - target: bun-linux-x64
-            runner: ubuntu-latest
-            runnerArch: X64
-    defaults:
-      run:
-        working-directory: dashboard
-    env:
-      TARGET: ${{ matrix.target }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2.2.0
-        with:
-          bun-version: "1.3.11"
-      - run: bun install --frozen-lockfile
-      - name: Build UI
-        run: bun run build:ui
-      - name: Compile binary
-        run: |
-          mkdir -p bin
-          bun build --compile --minify --target="$TARGET" \
-            server/src/main.ts \
-            --outfile "bin/kapsis-dashboard-$TARGET"
-      # Only smoke-test the binary when the host architecture matches the
-      # target's architecture (cross-compiled binaries cannot execute on the
-      # build host — e.g. linux-arm64 on an x64 ubuntu runner).
-      - name: Verify binary runs
-        if: ${{ (contains(matrix.target, 'x64') && matrix.runnerArch == 'X64') || (contains(matrix.target, 'arm64') && matrix.runnerArch == 'ARM64') }}
-        run: ./bin/kapsis-dashboard-"$TARGET" --version
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-        with:
-          name: kapsis-dashboard-${{ matrix.target }}
-          path: dashboard/bin/kapsis-dashboard-${{ matrix.target }}
-          if-no-files-found: error
-          retention-days: 7
+    uses: ./.github/workflows/dashboard-compile.yml

--- a/.github/workflows/dashboard-compile.yml
+++ b/.github/workflows/dashboard-compile.yml
@@ -1,0 +1,102 @@
+name: dashboard-compile (reusable)
+
+# Reusable workflow: cross-compile the kapsis-dashboard binary for all four
+# supported platforms. Called from both:
+#   - dashboard-build.yml (CI on every dashboard/** change)
+#   - release.yml's compile-dashboard job (on every release tag)
+#
+# Keeping the matrix + build steps in one place prevents the two callers
+# from drifting (#372 was caused by exactly that drift — dashboard-build.yml's
+# binaries were never attached to releases, and the release-path compile was
+# missing embed:ui + --sourcemap).
+
+on:
+  workflow_call:
+    inputs:
+      retention-days:
+        description: "Artifact retention in days (1-90)"
+        type: number
+        default: 7
+      artifact-prefix:
+        description: "Artifact name prefix. Final name is `<prefix>-<target>` (e.g. kapsis-dashboard-darwin-arm64)"
+        type: string
+        default: "kapsis-dashboard"
+
+permissions:
+  contents: read
+
+jobs:
+  compile:
+    name: ${{ inputs.artifact-prefix }}-${{ matrix.target }}
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: darwin-arm64
+            bunTarget: bun-darwin-arm64
+            runner: macos-latest
+            # runnerArch matches the host CPU (NOT the build target) — only
+            # used by the smoke-test if-guard to skip when the host can't
+            # execute the cross-compiled binary.
+            runnerArch: ARM64
+          - target: darwin-x64
+            bunTarget: bun-darwin-x64
+            runner: macos-13
+            runnerArch: X64
+          - target: linux-arm64
+            bunTarget: bun-linux-arm64
+            # No GitHub-hosted Linux ARM64 runner is allocated for this
+            # matrix slot, so the smoke-test if-guard below is structurally
+            # unreachable for linux-arm64. The cross-compiled binary still
+            # ships, just unverified on host. Tracked as a follow-up.
+            runner: ubuntu-latest
+            runnerArch: X64
+          - target: linux-x64
+            bunTarget: bun-linux-x64
+            runner: ubuntu-latest
+            runnerArch: X64
+    defaults:
+      run:
+        working-directory: dashboard
+    env:
+      BUN_TARGET: ${{ matrix.bunTarget }}
+      OUT_NAME: ${{ inputs.artifact-prefix }}-${{ matrix.target }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2.2.0
+        with:
+          bun-version: "1.3.11"
+      - name: Cache Bun install
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf  # v4.2.4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-${{ runner.arch }}-bun-${{ hashFiles('dashboard/bun.lockb') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-bun-
+      - run: bun install --frozen-lockfile --ignore-scripts
+      - name: Build (UI + embed + server)
+        run: bun run build
+      - name: Compile binary
+        run: |
+          mkdir -p bin
+          bun build --compile --minify --sourcemap --target="$BUN_TARGET" \
+            server/src/main.ts \
+            --outfile "bin/${OUT_NAME}"
+      - name: Verify binary runs
+        if: ${{ (contains(matrix.target, 'x64') && matrix.runnerArch == 'X64') || (contains(matrix.target, 'arm64') && matrix.runnerArch == 'ARM64') }}
+        run: |
+          set -euo pipefail
+          OUTPUT=$(./bin/"$OUT_NAME" --version)
+          if ! echo "$OUTPUT" | grep -Eq '[0-9]+\.[0-9]+\.[0-9]+'; then
+            echo "::error::Binary --version did not print a semver string: $OUTPUT"
+            exit 1
+          fi
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: ${{ env.OUT_NAME }}
+          path: dashboard/bin/${{ env.OUT_NAME }}
+          if-no-files-found: error
+          retention-days: ${{ inputs.retention-days }}

--- a/.github/workflows/dashboard-compile.yml
+++ b/.github/workflows/dashboard-compile.yml
@@ -48,8 +48,17 @@ jobs:
             runnerArch: ARM64
           - target: darwin-x64
             bunTarget: bun-darwin-x64
-            runner: macos-13
-            runnerArch: X64
+            # Cross-compile from ARM64 macOS instead of running on macos-13
+            # (Intel). GitHub's Intel macOS runner pool has shrunk since
+            # Apple's ARM transition and routinely queues for tens of
+            # minutes, blocking every dashboard PR. Bun supports
+            # cross-compilation via --target so we don't need a native x64
+            # host — the trade-off is the smoke-test gets skipped here
+            # (host arch is ARM64, binary is X64; the host can't exec it
+            # without Rosetta, which CI doesn't have). Same posture as
+            # linux-arm64 below.
+            runner: macos-latest
+            runnerArch: ARM64
           - target: linux-arm64
             bunTarget: bun-linux-arm64
             # No GitHub-hosted Linux ARM64 runner is allocated for this

--- a/.github/workflows/dashboard-compile.yml
+++ b/.github/workflows/dashboard-compile.yml
@@ -9,6 +9,10 @@ name: dashboard-compile (reusable)
 # from drifting (#372 was caused by exactly that drift — dashboard-build.yml's
 # binaries were never attached to releases, and the release-path compile was
 # missing embed:ui + --sourcemap).
+#
+# Also wired to workflow_dispatch so the matrix can be exercised in
+# isolation (e.g. regenerate artifacts after a packaging-only change)
+# without triggering the whole release or CI pipeline.
 
 on:
   workflow_call:
@@ -17,20 +21,20 @@ on:
         description: "Artifact retention in days (1-90)"
         type: number
         default: 7
-      artifact-prefix:
-        description: "Artifact name prefix. Final name is `<prefix>-<target>` (e.g. kapsis-dashboard-darwin-arm64)"
-        type: string
-        default: "kapsis-dashboard"
+  workflow_dispatch:
+    inputs:
+      retention-days:
+        description: "Artifact retention in days (1-90)"
+        type: number
+        default: 7
 
 permissions:
   contents: read
 
 jobs:
   compile:
-    name: ${{ inputs.artifact-prefix }}-${{ matrix.target }}
+    name: ${{ matrix.target }}
     runs-on: ${{ matrix.runner }}
-    permissions:
-      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -63,25 +67,44 @@ jobs:
         working-directory: dashboard
     env:
       BUN_TARGET: ${{ matrix.bunTarget }}
-      OUT_NAME: ${{ inputs.artifact-prefix }}-${{ matrix.target }}
+      OUT_NAME: kapsis-dashboard-${{ matrix.target }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2.2.0
         with:
           bun-version: "1.3.11"
+      # Cache the Bun module store. Keyed on the workspace package.json
+      # files because dashboard/bun.lockb is gitignored (so hashFiles on
+      # the lockfile would silently collapse the key to a constant and
+      # never invalidate). Hashing package.json sets gives partial
+      # invalidation when any workspace's deps change.
       - name: Cache Bun install
-        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf  # v4.2.4
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809  # v4.2.4
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-${{ runner.arch }}-bun-${{ hashFiles('dashboard/bun.lockb') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-bun-${{ hashFiles('dashboard/package.json', 'dashboard/server/package.json', 'dashboard/ui/package.json', 'dashboard/shared/package.json') }}
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-bun-
+      # --ignore-scripts is defense-in-depth, NOT the primary
+      # supply-chain control: Bun already blocks dependency lifecycle
+      # scripts by default (only packages in `trustedDependencies` run
+      # them). This flag adds a second layer by also blocking the
+      # project's OWN pre/postinstall — currently a no-op since the
+      # dashboard package.json defines none, but future-proofs against
+      # an accidental script addition.
       - run: bun install --frozen-lockfile --ignore-scripts
+      # Use `bun run build` (= build:ui + embed:ui + build:server) and a
+      # SEPARATE `bun build --compile` step, instead of `bun run
+      # compile:$TARGET`. The compile:* scripts in package.json
+      # internally call `bun run build` themselves, so invoking them
+      # here would double-build the UI + embed steps. Keep the split.
       - name: Build (UI + embed + server)
         run: bun run build
       - name: Compile binary
         run: |
           mkdir -p bin
+          # --sourcemap matches every `compile:*` script in package.json so
+          # production crash traces remain debuggable post-minify.
           bun build --compile --minify --sourcemap --target="$BUN_TARGET" \
             server/src/main.ts \
             --outfile "bin/${OUT_NAME}"

--- a/.github/workflows/dashboard-compile.yml
+++ b/.github/workflows/dashboard-compile.yml
@@ -117,7 +117,38 @@ jobs:
           bun build --compile --minify --sourcemap --target="$BUN_TARGET" \
             server/src/main.ts \
             --outfile "bin/${OUT_NAME}"
-      - name: Verify binary runs
+      # Structural arch verification — runs on EVERY matrix slot regardless
+      # of host arch. Catches the failure mode where Bun's --target flag is
+      # silently ignored or misspelt and we ship a host-arch binary under
+      # an x64/arm64 filename. Compare the `file(1)` output to what we asked
+      # for via $MATRIX_TARGET; mismatched arch fails the job loudly.
+      - name: Verify binary architecture matches target
+        env:
+          MATRIX_TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          out=$(file "bin/${OUT_NAME}")
+          echo "$out"
+          case "$MATRIX_TARGET" in
+            darwin-arm64) expect='Mach-O.*arm64' ;;
+            darwin-x64)   expect='Mach-O.*x86_64' ;;
+            linux-arm64)  expect='ELF.*aarch64' ;;
+            linux-x64)    expect='ELF.*x86-64' ;;
+            *) echo "::error::unknown matrix target: $MATRIX_TARGET"; exit 1 ;;
+          esac
+          if ! echo "$out" | grep -Eq "$expect"; then
+            echo "::error::binary arch mismatch: expected pattern '$expect' for target '$MATRIX_TARGET', got: $out"
+            exit 1
+          fi
+      # `hostArch` here is the CPU of the runner — used only to decide
+      # whether this host can natively execute the cross-compiled binary.
+      # When host and target diverge (e.g. darwin-x64 built on macos-latest
+      # ARM64, or linux-arm64 built on ubuntu-latest x64) we skip the
+      # smoke-test because the runner can't exec the binary without
+      # emulation, which GitHub-hosted runners don't provide. The arch
+      # verification above already proves the binary IS the right shape;
+      # the smoke-test is the additional "and it actually starts" check.
+      - name: Verify binary runs (host-native only)
         if: ${{ (contains(matrix.target, 'x64') && matrix.runnerArch == 'X64') || (contains(matrix.target, 'arm64') && matrix.runnerArch == 'ARM64') }}
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -334,16 +334,6 @@ jobs:
     needs: [validate, release, compile-dashboard]
     if: needs.release.result == 'success'
     steps:
-      - name: Download dashboard binaries (for local SHA256 computation)
-        # Sourcing the SHA from the local artifact closes the TOCTOU /
-        # asset-swap window that re-downloading from the public release URL
-        # would leave open, and removes a network dependency.
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6.0.0
-        with:
-          pattern: kapsis-dashboard-*
-          path: dashboard-artifacts
-          merge-multiple: true
-
       - name: Check if GitHub App is configured
         id: check-app
         env:
@@ -357,6 +347,26 @@ jobs:
           else
             echo "configured=true" >> $GITHUB_OUTPUT
           fi
+
+      - name: Download dashboard binaries (for local SHA256 computation)
+        # Sourcing the SHA from the local artifact closes the TOCTOU /
+        # asset-swap window that re-downloading from the public release URL
+        # would leave open, and removes a network dependency. Gated on
+        # check-app so we don't pull artifacts when the GitHub App isn't
+        # configured (in which case every consuming step would skip anyway).
+        if: steps.check-app.outputs.configured == 'true'
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6.0.0
+        with:
+          pattern: kapsis-dashboard-*
+          path: dashboard-artifacts
+          merge-multiple: true
+
+      - name: List downloaded dashboard binaries
+        # Self-diagnostic upfront so any artifact-availability issue is
+        # immediately visible without needing to re-run with debug logging.
+        if: steps.check-app.outputs.configured == 'true'
+        run: |
+          ls -la dashboard-artifacts/ || echo "::warning::dashboard-artifacts/ not present"
 
       - name: Generate GitHub App token
         id: app-token

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,6 +138,11 @@ jobs:
     name: Compile Dashboard Binary (${{ matrix.target }})
     needs: validate
     runs-on: ${{ matrix.runner }}
+    # Least-privilege: this job only reads the source and uploads artifacts.
+    # Overrides the workflow-level contents: write so a compromised npm
+    # post-install or third-party action can't publish a malicious release.
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -145,6 +150,9 @@ jobs:
           - target: darwin-arm64
             bunTarget: bun-darwin-arm64
             runner: macos-latest
+            # runnerArch matches the host CPU, NOT the build target — it's
+            # only used by the "Verify binary runs" if-guard to skip the
+            # smoke-test when the host can't execute a cross-compiled binary.
             runnerArch: ARM64
           - target: darwin-x64
             bunTarget: bun-darwin-x64
@@ -152,6 +160,10 @@ jobs:
             runnerArch: X64
           - target: linux-arm64
             bunTarget: bun-linux-arm64
+            # No GitHub-hosted Linux ARM64 runner is allocated for this
+            # matrix slot, so the smoke-test if-guard below is structurally
+            # unreachable for linux-arm64. Tracked in a follow-up issue;
+            # the cross-compiled binary still ships, just unverified on host.
             runner: ubuntu-latest
             runnerArch: X64
           - target: linux-x64
@@ -169,26 +181,53 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2.2.0
         with:
           bun-version: "1.3.11"
-      - run: bun install --frozen-lockfile
-      - name: Build UI
-        run: bun run build:ui
+      # Cache the Bun module store keyed on the lockfile so the cold install
+      # only runs when dependencies actually change. Mirrors the pattern in
+      # dashboard-build.yml.
+      - name: Cache Bun install
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf  # v4.2.4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-${{ runner.arch }}-bun-${{ hashFiles('dashboard/bun.lockb') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-bun-
+      # --ignore-scripts neutralizes npm lifecycle hooks (defense-in-depth
+      # against a compromised transitive package); the dashboard build does
+      # not rely on any post-install scripts.
+      - run: bun install --frozen-lockfile --ignore-scripts
+      # Run the full `build` script (build:ui + embed:ui + build:server)
+      # exactly as the `compile:*` scripts in dashboard/package.json do.
+      # Skipping `embed:ui` ships a binary without the UI bundle embedded.
+      - name: Build (UI + embed + server)
+        run: bun run build
       - name: Compile binary
         run: |
           mkdir -p bin
-          bun build --compile --minify --target="$BUN_TARGET" \
+          # --sourcemap matches every `compile:*` script in package.json so
+          # production crash traces remain debuggable post-minify.
+          bun build --compile --minify --sourcemap --target="$BUN_TARGET" \
             server/src/main.ts \
             --outfile "bin/${OUT_NAME}"
       # Smoke-test only when host arch matches target arch (cross-compiled
       # binaries can't run on a foreign host).
       - name: Verify binary runs
         if: ${{ (contains(matrix.target, 'x64') && matrix.runnerArch == 'X64') || (contains(matrix.target, 'arm64') && matrix.runnerArch == 'ARM64') }}
-        run: ./bin/"$OUT_NAME" --version
+        run: |
+          set -euo pipefail
+          OUTPUT=$(./bin/"$OUT_NAME" --version)
+          if ! echo "$OUTPUT" | grep -Eq '[0-9]+\.[0-9]+\.[0-9]+'; then
+            echo "::error::Binary --version did not print a semver string: $OUTPUT"
+            exit 1
+          fi
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: ${{ env.OUT_NAME }}
           path: dashboard/bin/${{ env.OUT_NAME }}
           if-no-files-found: error
-          retention-days: 1
+          # 7 days mirrors dashboard-build.yml so a failed `release` job can
+          # be re-run without re-triggering the entire (expensive, multi-runner)
+          # compile matrix.
+          retention-days: 7
 
   release:
     name: Create GitHub Release
@@ -225,6 +264,16 @@ jobs:
           mv dashboard-artifacts/kapsis-dashboard-* .
           chmod 0755 kapsis-dashboard-*
           ls -la kapsis-dashboard-*
+          # Guard against future regressions: a name collision in
+          # merge-multiple would silently overwrite one binary with another,
+          # or a missing artifact would slip through `if-no-files-found:
+          # error` (which only fails the producer, not the consumer).
+          COUNT=$(ls kapsis-dashboard-* 2>/dev/null | wc -l | tr -d ' ')
+          if [ "$COUNT" -ne 4 ]; then
+            echo "::error::Expected exactly 4 dashboard binaries, found $COUNT"
+            ls -la kapsis-dashboard-* 2>&1 || true
+            exit 1
+          fi
 
       - name: Generate checksums
         env:
@@ -368,9 +417,19 @@ jobs:
   update-packages:
     name: Update Package Definitions
     runs-on: ubuntu-latest
-    needs: [validate, release]
+    needs: [validate, release, compile-dashboard]
     if: needs.release.result == 'success'
     steps:
+      - name: Download dashboard binaries (for local SHA256 computation)
+        # Sourcing the SHA from the local artifact closes the TOCTOU /
+        # asset-swap window that re-downloading from the public release URL
+        # would leave open, and removes a network dependency.
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6.0.0
+        with:
+          pattern: kapsis-dashboard-*
+          path: dashboard-artifacts
+          merge-multiple: true
+
       - name: Check if GitHub App is configured
         id: check-app
         env:
@@ -692,33 +751,32 @@ jobs:
           echo "✓ Updated Homebrew formula to v${VERSION}"
 
           # Compute SHA256 for each per-platform kapsis-dashboard binary
-          # attached to the release and patch the corresponding marker block.
+          # FROM THE LOCAL ARTIFACT (downloaded earlier in this job from the
+          # compile-dashboard job's artifacts — not from the published release
+          # URL) and patch the corresponding marker block. Sourcing locally
+          # closes the TOCTOU window: if the release asset were ever swapped
+          # between checksum-computation and Homebrew user download, the
+          # formula's recorded hash would still match the binary CI built.
           # Each block looks like:
           #   # DASHBOARD_<TARGET>_MARKER_START
           #   url "https://.../kapsis-dashboard-<target>"
           #   sha256 "..."
           #   # DASHBOARD_<TARGET>_MARKER_END
           for TARGET in darwin-arm64 darwin-x64 linux-arm64 linux-x64; do
+            LOCAL_BIN="dashboard-artifacts/kapsis-dashboard-${TARGET}"
             BIN_URL="https://github.com/${REPO}/releases/download/v${VERSION}/kapsis-dashboard-${TARGET}"
-            echo "Fetching SHA256 for kapsis-dashboard-${TARGET}..."
 
-            BIN_RETRY=0
-            BIN_SHA256=""
-            while [[ $BIN_RETRY -lt $MAX_RETRIES ]]; do
-              if BIN_SHA256=$(curl -fsSL --retry 3 "$BIN_URL" | sha256sum | cut -d' ' -f1); then
-                if [[ "$BIN_SHA256" =~ ^[a-f0-9]{64}$ ]]; then
-                  echo "  ${TARGET}: ${BIN_SHA256}"
-                  break
-                fi
-              fi
-              BIN_RETRY=$((BIN_RETRY + 1))
-              if [[ $BIN_RETRY -lt $MAX_RETRIES ]]; then
-                sleep 10
-              else
-                echo "::error::Failed to compute SHA256 for kapsis-dashboard-${TARGET}"
-                exit 1
-              fi
-            done
+            if [[ ! -f "$LOCAL_BIN" ]]; then
+              echo "::error::Local artifact missing: $LOCAL_BIN (compile-dashboard job did not produce it, or retention expired)"
+              exit 1
+            fi
+
+            BIN_SHA256=$(sha256sum "$LOCAL_BIN" | cut -d' ' -f1)
+            if [[ ! "$BIN_SHA256" =~ ^[a-f0-9]{64}$ ]]; then
+              echo "::error::Invalid SHA256 computed for ${TARGET}: $BIN_SHA256"
+              exit 1
+            fi
+            echo "  ${TARGET}: ${BIN_SHA256}"
 
             # Uppercase target marker (DARWIN_ARM64, etc.) for sed
             MARKER=$(echo "$TARGET" | tr '[:lower:]-' '[:upper:]_')
@@ -729,11 +787,27 @@ jobs:
               }" "$FORMULA_FILE"
             rm -f "${FORMULA_FILE}.bak"
 
+            # Validate BOTH url AND sha256 were patched. A silent url-sed
+            # failure (e.g., regex drift from a URL format change) would
+            # otherwise leave the formula with a correct hash but stale URL,
+            # making Homebrew installs fail with a confusing checksum mismatch.
+            if ! grep -q "url \"${BIN_URL}\"" "$FORMULA_FILE"; then
+              echo "::error::Failed to update dashboard ${TARGET} URL in formula"
+              exit 1
+            fi
             if ! grep -q "sha256 \"${BIN_SHA256}\"" "$FORMULA_FILE"; then
               echo "::error::Failed to update dashboard ${TARGET} SHA256 in formula"
               exit 1
             fi
           done
+
+          # Final sanity check: no placeholder all-zero sha256s remain.
+          # Catches the case where sed silently matched the wrong block range.
+          if grep -q 'sha256 "0\{64\}"' "$FORMULA_FILE"; then
+            echo "::error::Formula still contains placeholder all-zero sha256 after patching"
+            grep -n 'sha256 "0\{64\}"' "$FORMULA_FILE"
+            exit 1
+          fi
 
           echo "✓ Updated all 4 dashboard binary SHA256s in formula"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,100 +134,14 @@ jobs:
             echo "Pushed ${REGISTRY}/${IMAGE}:${VERSION}"
           done
 
+  # The actual matrix lives in .github/workflows/dashboard-compile.yml —
+  # shared with dashboard-build.yml so the two callers can't drift (#372
+  # was caused by exactly that drift).
   compile-dashboard:
-    name: Compile Dashboard Binary (${{ matrix.target }})
     needs: validate
-    runs-on: ${{ matrix.runner }}
-    # Least-privilege: this job only reads the source and uploads artifacts.
-    # Overrides the workflow-level contents: write so a compromised npm
-    # post-install or third-party action can't publish a malicious release.
-    permissions:
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: darwin-arm64
-            bunTarget: bun-darwin-arm64
-            runner: macos-latest
-            # runnerArch matches the host CPU, NOT the build target — it's
-            # only used by the "Verify binary runs" if-guard to skip the
-            # smoke-test when the host can't execute a cross-compiled binary.
-            runnerArch: ARM64
-          - target: darwin-x64
-            bunTarget: bun-darwin-x64
-            runner: macos-13
-            runnerArch: X64
-          - target: linux-arm64
-            bunTarget: bun-linux-arm64
-            # No GitHub-hosted Linux ARM64 runner is allocated for this
-            # matrix slot, so the smoke-test if-guard below is structurally
-            # unreachable for linux-arm64. Tracked in a follow-up issue;
-            # the cross-compiled binary still ships, just unverified on host.
-            runner: ubuntu-latest
-            runnerArch: X64
-          - target: linux-x64
-            bunTarget: bun-linux-x64
-            runner: ubuntu-latest
-            runnerArch: X64
-    defaults:
-      run:
-        working-directory: dashboard
-    env:
-      BUN_TARGET: ${{ matrix.bunTarget }}
-      OUT_NAME: kapsis-dashboard-${{ matrix.target }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2.2.0
-        with:
-          bun-version: "1.3.11"
-      # Cache the Bun module store keyed on the lockfile so the cold install
-      # only runs when dependencies actually change. Mirrors the pattern in
-      # dashboard-build.yml.
-      - name: Cache Bun install
-        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf  # v4.2.4
-        with:
-          path: ~/.bun/install/cache
-          key: ${{ runner.os }}-${{ runner.arch }}-bun-${{ hashFiles('dashboard/bun.lockb') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-bun-
-      # --ignore-scripts neutralizes npm lifecycle hooks (defense-in-depth
-      # against a compromised transitive package); the dashboard build does
-      # not rely on any post-install scripts.
-      - run: bun install --frozen-lockfile --ignore-scripts
-      # Run the full `build` script (build:ui + embed:ui + build:server)
-      # exactly as the `compile:*` scripts in dashboard/package.json do.
-      # Skipping `embed:ui` ships a binary without the UI bundle embedded.
-      - name: Build (UI + embed + server)
-        run: bun run build
-      - name: Compile binary
-        run: |
-          mkdir -p bin
-          # --sourcemap matches every `compile:*` script in package.json so
-          # production crash traces remain debuggable post-minify.
-          bun build --compile --minify --sourcemap --target="$BUN_TARGET" \
-            server/src/main.ts \
-            --outfile "bin/${OUT_NAME}"
-      # Smoke-test only when host arch matches target arch (cross-compiled
-      # binaries can't run on a foreign host).
-      - name: Verify binary runs
-        if: ${{ (contains(matrix.target, 'x64') && matrix.runnerArch == 'X64') || (contains(matrix.target, 'arm64') && matrix.runnerArch == 'ARM64') }}
-        run: |
-          set -euo pipefail
-          OUTPUT=$(./bin/"$OUT_NAME" --version)
-          if ! echo "$OUTPUT" | grep -Eq '[0-9]+\.[0-9]+\.[0-9]+'; then
-            echo "::error::Binary --version did not print a semver string: $OUTPUT"
-            exit 1
-          fi
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-        with:
-          name: ${{ env.OUT_NAME }}
-          path: dashboard/bin/${{ env.OUT_NAME }}
-          if-no-files-found: error
-          # 7 days mirrors dashboard-build.yml so a failed `release` job can
-          # be re-run without re-triggering the entire (expensive, multi-runner)
-          # compile matrix.
-          retention-days: 7
+    uses: ./.github/workflows/dashboard-compile.yml
+    with:
+      retention-days: 7
 
   release:
     name: Create GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,10 +134,66 @@ jobs:
             echo "Pushed ${REGISTRY}/${IMAGE}:${VERSION}"
           done
 
+  compile-dashboard:
+    name: Compile Dashboard Binary (${{ matrix.target }})
+    needs: validate
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: darwin-arm64
+            bunTarget: bun-darwin-arm64
+            runner: macos-latest
+            runnerArch: ARM64
+          - target: darwin-x64
+            bunTarget: bun-darwin-x64
+            runner: macos-13
+            runnerArch: X64
+          - target: linux-arm64
+            bunTarget: bun-linux-arm64
+            runner: ubuntu-latest
+            runnerArch: X64
+          - target: linux-x64
+            bunTarget: bun-linux-x64
+            runner: ubuntu-latest
+            runnerArch: X64
+    defaults:
+      run:
+        working-directory: dashboard
+    env:
+      BUN_TARGET: ${{ matrix.bunTarget }}
+      OUT_NAME: kapsis-dashboard-${{ matrix.target }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2.2.0
+        with:
+          bun-version: "1.3.11"
+      - run: bun install --frozen-lockfile
+      - name: Build UI
+        run: bun run build:ui
+      - name: Compile binary
+        run: |
+          mkdir -p bin
+          bun build --compile --minify --target="$BUN_TARGET" \
+            server/src/main.ts \
+            --outfile "bin/${OUT_NAME}"
+      # Smoke-test only when host arch matches target arch (cross-compiled
+      # binaries can't run on a foreign host).
+      - name: Verify binary runs
+        if: ${{ (contains(matrix.target, 'x64') && matrix.runnerArch == 'X64') || (contains(matrix.target, 'arm64') && matrix.runnerArch == 'ARM64') }}
+        run: ./bin/"$OUT_NAME" --version
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: ${{ env.OUT_NAME }}
+          path: dashboard/bin/${{ env.OUT_NAME }}
+          if-no-files-found: error
+          retention-days: 1
+
   release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: [validate, test, build-and-push]
+    needs: [validate, test, build-and-push, compile-dashboard]
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
@@ -152,11 +208,29 @@ jobs:
           tar czf "kapsis-${VERSION}.tar.gz" "kapsis-${VERSION}"
           rm -rf "kapsis-${VERSION}"
 
+      - name: Download dashboard binaries
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6.0.0
+        with:
+          pattern: kapsis-dashboard-*
+          path: dashboard-artifacts
+          merge-multiple: true
+
+      - name: Stage dashboard binaries
+        run: |
+          set -euo pipefail
+          ls -la dashboard-artifacts/
+          # download-artifact with merge-multiple flattens all artifact files
+          # into one directory; bring them to repo root so the release files:
+          # block picks them up by name.
+          mv dashboard-artifacts/kapsis-dashboard-* .
+          chmod 0755 kapsis-dashboard-*
+          ls -la kapsis-dashboard-*
+
       - name: Generate checksums
         env:
           VERSION: ${{ needs.validate.outputs.version }}
         run: |
-          sha256sum "kapsis-${VERSION}.tar.gz" > checksums.sha256
+          sha256sum "kapsis-${VERSION}.tar.gz" kapsis-dashboard-* > checksums.sha256
 
           echo "Generated checksums:"
           cat checksums.sha256
@@ -251,6 +325,17 @@ jobs:
             echo '```'
             echo ""
 
+            echo "### 📊 Dashboard Binary"
+            echo ""
+            echo "Per-platform \`kapsis-dashboard\` binaries are attached below."
+            echo "The Homebrew formula installs the right one automatically; download manually with:"
+            echo '```bash'
+            echo "# macOS Apple Silicon"
+            echo "curl -L -o kapsis-dashboard https://github.com/${{ github.repository }}/releases/download/v${VERSION}/kapsis-dashboard-darwin-arm64"
+            echo "chmod +x kapsis-dashboard && ./kapsis-dashboard --version"
+            echo '```'
+            echo ""
+
             # Add compare link
             if [[ -n "$PREV_TAG" ]]; then
               echo "**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREV_TAG}...v${VERSION}"
@@ -273,6 +358,10 @@ jobs:
           files: |
             kapsis-${{ needs.validate.outputs.version }}.tar.gz
             checksums.sha256
+            kapsis-dashboard-darwin-arm64
+            kapsis-dashboard-darwin-x64
+            kapsis-dashboard-linux-arm64
+            kapsis-dashboard-linux-x64
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -601,6 +690,52 @@ jobs:
           fi
 
           echo "✓ Updated Homebrew formula to v${VERSION}"
+
+          # Compute SHA256 for each per-platform kapsis-dashboard binary
+          # attached to the release and patch the corresponding marker block.
+          # Each block looks like:
+          #   # DASHBOARD_<TARGET>_MARKER_START
+          #   url "https://.../kapsis-dashboard-<target>"
+          #   sha256 "..."
+          #   # DASHBOARD_<TARGET>_MARKER_END
+          for TARGET in darwin-arm64 darwin-x64 linux-arm64 linux-x64; do
+            BIN_URL="https://github.com/${REPO}/releases/download/v${VERSION}/kapsis-dashboard-${TARGET}"
+            echo "Fetching SHA256 for kapsis-dashboard-${TARGET}..."
+
+            BIN_RETRY=0
+            BIN_SHA256=""
+            while [[ $BIN_RETRY -lt $MAX_RETRIES ]]; do
+              if BIN_SHA256=$(curl -fsSL --retry 3 "$BIN_URL" | sha256sum | cut -d' ' -f1); then
+                if [[ "$BIN_SHA256" =~ ^[a-f0-9]{64}$ ]]; then
+                  echo "  ${TARGET}: ${BIN_SHA256}"
+                  break
+                fi
+              fi
+              BIN_RETRY=$((BIN_RETRY + 1))
+              if [[ $BIN_RETRY -lt $MAX_RETRIES ]]; then
+                sleep 10
+              else
+                echo "::error::Failed to compute SHA256 for kapsis-dashboard-${TARGET}"
+                exit 1
+              fi
+            done
+
+            # Uppercase target marker (DARWIN_ARM64, etc.) for sed
+            MARKER=$(echo "$TARGET" | tr '[:lower:]-' '[:upper:]_')
+            sed -i.bak \
+              -e "/DASHBOARD_${MARKER}_MARKER_START/,/DASHBOARD_${MARKER}_MARKER_END/{
+                s|url \"https://github.com/.*/kapsis-dashboard-${TARGET}\"|url \"${BIN_URL}\"|
+                s|sha256 \"[a-f0-9]*\"|sha256 \"${BIN_SHA256}\"|
+              }" "$FORMULA_FILE"
+            rm -f "${FORMULA_FILE}.bak"
+
+            if ! grep -q "sha256 \"${BIN_SHA256}\"" "$FORMULA_FILE"; then
+              echo "::error::Failed to update dashboard ${TARGET} SHA256 in formula"
+              exit 1
+            fi
+          done
+
+          echo "✓ Updated all 4 dashboard binary SHA256s in formula"
 
       - name: Update RPM spec
         if: steps.check-app.outputs.configured == 'true'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,15 +20,9 @@
 **Any user-facing feature change (CLI flags, status schema, audit events, error/exit codes, config options, container resources) MUST update `dashboard/` in the same PR** so the dashboard reflects the change. The status schema mirror is `dashboard/server/src/types.ts` (`AgentStatus`); CI enforces sync via `.github/workflows/dashboard-sync.yml`. Details in `CLAUDE.md`.
 
 ## Release Artifact Rule
-**Any new user-facing binary, CLI script, or release artifact MUST update ALL FOUR distribution surfaces in the same PR**, or platforms silently lose the feature (see #372 for a recent example: `kapsis-dashboard` shipped only as source in v2.29.1 because release.yml didn't build it, Homebrew silently skipped the missing binary, and the formula's `test` block didn't assert it existed).
+**Any new user-facing binary, CLI script, or release artifact MUST update ALL FOUR distribution surfaces** (release.yml, Homebrew formula, RPM spec, Debian rules) **in the same PR**, or platforms silently lose the feature (see #372 for a recent example: `kapsis-dashboard` shipped only as source in v2.29.1 because the formula's `test` block didn't assert the binary existed, so the skip went undetected).
 
-The four surfaces:
-1. **`.github/workflows/release.yml`** — build job (if compiled), append to `files:` list of `softprops/action-gh-release`, add to `checksums.sha256`, mention in the release-notes block. If the formula contains version-locked URLs/sha256s, also extend the `update-packages` job to patch them.
-2. **`packaging/homebrew/kapsis.rb`** — wrapper hash entry (shell scripts) OR `on_macos`/`on_linux` + `on_arm`/`on_intel` `resource` block (per-platform binaries). MUST add a `--version` (or equivalent) check to the `test` block — this is what catches the regression.
-3. **`packaging/rpm/kapsis.spec`** — `install -m 755` line, `cat > … << EOF` wrapper, `%files` entry.
-4. **`packaging/debian/debian/rules`** — matching `install -m 755` line and `echo '#!/bin/bash' > …` wrapper block.
-
-For shell scripts under `scripts/`, the source tarball already picks them up via `cp -r scripts …` in release.yml — only wrapper plumbing changes are needed. Details and worked example in `CLAUDE.md`'s "Release Artifact Rule" section.
+For the full rule — including the four-surface checklist, the `test`-block assertion that is the actual regression-catching mechanism, the marker-naming convention for CI-patched sha256s, and the source-tarball auto-pickup behavior for `scripts/*.sh` — see **CLAUDE.md § Release Artifact Rule**. Keep that section as the single source of truth and update it (not this paragraph) when the process changes.
 
 ## Build, Test, and Development Commands
 - `./scripts/build-image.sh` builds the base Podman image used by Kapsis.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,17 @@
 ## Dashboard Sync Rule
 **Any user-facing feature change (CLI flags, status schema, audit events, error/exit codes, config options, container resources) MUST update `dashboard/` in the same PR** so the dashboard reflects the change. The status schema mirror is `dashboard/server/src/types.ts` (`AgentStatus`); CI enforces sync via `.github/workflows/dashboard-sync.yml`. Details in `CLAUDE.md`.
 
+## Release Artifact Rule
+**Any new user-facing binary, CLI script, or release artifact MUST update ALL FOUR distribution surfaces in the same PR**, or platforms silently lose the feature (see #372 for a recent example: `kapsis-dashboard` shipped only as source in v2.29.1 because release.yml didn't build it, Homebrew silently skipped the missing binary, and the formula's `test` block didn't assert it existed).
+
+The four surfaces:
+1. **`.github/workflows/release.yml`** — build job (if compiled), append to `files:` list of `softprops/action-gh-release`, add to `checksums.sha256`, mention in the release-notes block. If the formula contains version-locked URLs/sha256s, also extend the `update-packages` job to patch them.
+2. **`packaging/homebrew/kapsis.rb`** — wrapper hash entry (shell scripts) OR `on_macos`/`on_linux` + `on_arm`/`on_intel` `resource` block (per-platform binaries). MUST add a `--version` (or equivalent) check to the `test` block — this is what catches the regression.
+3. **`packaging/rpm/kapsis.spec`** — `install -m 755` line, `cat > … << EOF` wrapper, `%files` entry.
+4. **`packaging/debian/debian/rules`** — matching `install -m 755` line and `echo '#!/bin/bash' > …` wrapper block.
+
+For shell scripts under `scripts/`, the source tarball already picks them up via `cp -r scripts …` in release.yml — only wrapper plumbing changes are needed. Details and worked example in `CLAUDE.md`'s "Release Artifact Rule" section.
+
 ## Build, Test, and Development Commands
 - `./scripts/build-image.sh` builds the base Podman image used by Kapsis.
 - `./scripts/build-agent-image.sh <profile>` builds an agent-specific image (see `configs/agents/`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@
 ## Release Artifact Rule
 **Any new user-facing binary, CLI script, or release artifact MUST update ALL FOUR distribution surfaces** (release.yml, Homebrew formula, RPM spec, Debian rules) **in the same PR**, or platforms silently lose the feature (see #372 for a recent example: `kapsis-dashboard` shipped only as source in v2.29.1 because the formula's `test` block didn't assert the binary existed, so the skip went undetected).
 
-For the full rule — including the four-surface checklist, the `test`-block assertion that is the actual regression-catching mechanism, the marker-naming convention for CI-patched sha256s, and the source-tarball auto-pickup behavior for `scripts/*.sh` — see **CLAUDE.md § Release Artifact Rule**. Keep that section as the single source of truth and update it (not this paragraph) when the process changes.
+For the full rule — including the four-surface checklist, the `test`-block assertion that is the actual regression-catching mechanism, the marker-naming convention for CI-patched sha256s, and the source-tarball auto-pickup behavior for `scripts/*.sh` — see **CLAUDE.md § Release Artifact Rule**. CLAUDE.md is the single source of truth for this rule — update it there (not this summary) when the process changes.
 
 ## Build, Test, and Development Commands
 - `./scripts/build-image.sh` builds the base Podman image used by Kapsis.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -384,6 +384,21 @@ The PR should either:
 
 The TypeScript mirror of the status schema lives at `dashboard/server/src/types.ts` (`AgentStatus` interface) — keep it in lockstep with `scripts/lib/status.sh`. CI enforces this via `.github/workflows/dashboard-sync.yml`.
 
+## Release Artifact Rule
+
+**Whenever a new user-facing binary, CLI script, or release artifact is added, ALL FOUR distribution surfaces must be updated in the same PR.** Missing one means users on that platform silently lose the feature.
+
+The four surfaces:
+
+1. **`.github/workflows/release.yml`** — if the artifact needs to be built or downloaded for the GitHub Release, add a build job (gated by `validate`) and append the file to the `files:` list of the `softprops/action-gh-release` step. Include it in `checksums.sha256`. Add a section to the release notes block describing how to download/use it.
+2. **`packaging/homebrew/kapsis.rb`** — add either (a) a `bin/<name>` wrapper to the wrapper-script hash in `install` (for shell scripts shipped in the source tarball), or (b) an `on_macos`/`on_linux` + `on_arm`/`on_intel` `resource` block (for per-platform binaries downloaded from release assets). Add an `assert_predicate` to the `test` block that runs `<name> --version` (or another no-side-effect smoke check) — this is what catches the regression upfront.
+3. **`packaging/rpm/kapsis.spec`** — add an `install -m 755 …` line under "Install executable scripts" (for shell scripts) or copy the binary from the staged location, add the corresponding `cat > %{buildroot}%{_bindir}/<name> << 'EOF' … EOF` wrapper, and list `%{_bindir}/<name>` in the `%files` section.
+4. **`packaging/debian/debian/rules`** — add the matching `install -m 755 …` line under "Install main executable scripts" plus the `echo '#!/bin/bash' > … kapsis/usr/bin/<name>` wrapper block. For per-platform binaries staged from CI, also update `debian/install` if needed.
+
+Also update any CI workflow that builds the artifact (e.g., `.github/workflows/dashboard-build.yml`-style helper jobs) AND `.github/workflows/release.yml`'s `update-packages` job if the formula/spec contains version-locked URLs or sha256s that need to be patched after the release is cut (look for `RELEASE_VERSION_MARKER_START` / `DASHBOARD_*_MARKER_START` markers as the pattern to follow).
+
+For shell scripts, prefer adding them to `scripts/` so the existing `cp -r scripts ...` step in release.yml automatically picks them up for the source tarball — no release.yml change needed beyond the wrapper plumbing.
+
 ## Things to Avoid
 
 1. **Hardcoding paths** — use `$KAPSIS_HOME`, `$SCRIPT_DIR`, constants from `scripts/lib/constants.sh`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -397,7 +397,7 @@ The four surfaces:
 
 Also update any CI workflow that builds the artifact (e.g., `.github/workflows/dashboard-build.yml`-style helper jobs) AND `.github/workflows/release.yml`'s `update-packages` job if the formula/spec contains version-locked URLs or sha256s that need to be patched after the release is cut (look for `RELEASE_VERSION_MARKER_START` / `DASHBOARD_*_MARKER_START` markers as the pattern to follow).
 
-Marker naming convention: lowercase-hyphenated target → uppercase-underscored marker. Example: `darwin-arm64` becomes `DASHBOARD_DARWIN_ARM64_MARKER_START` / `DASHBOARD_DARWIN_ARM64_MARKER_END`. The transformation is `tr '[:lower:]-' '[:upper:]_'`.
+Marker naming convention: `<ARTIFACT>_<TARGET>_MARKER_START` / `_END`, where the prefix is **artifact-specific** (not universal) and the target transformation is lowercase-hyphenated → uppercase-underscored via `tr '[:lower:]-' '[:upper:]_'`. Examples: for the `kapsis-dashboard` artifact, `darwin-arm64` becomes `DASHBOARD_DARWIN_ARM64_MARKER_START` / `_END`. For a hypothetical future `my-new-tool` artifact, the same target would become `MY_NEW_TOOL_DARWIN_ARM64_MARKER_START` / `_END`. Only the target portion is mechanically transformed; the prefix is yours to choose per artifact.
 
 For shell scripts, prefer adding them to `scripts/` so the existing `cp -r scripts ...` step in release.yml automatically picks them up for the source tarball — no release.yml change needed beyond the wrapper plumbing.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -397,6 +397,8 @@ The four surfaces:
 
 Also update any CI workflow that builds the artifact (e.g., `.github/workflows/dashboard-build.yml`-style helper jobs) AND `.github/workflows/release.yml`'s `update-packages` job if the formula/spec contains version-locked URLs or sha256s that need to be patched after the release is cut (look for `RELEASE_VERSION_MARKER_START` / `DASHBOARD_*_MARKER_START` markers as the pattern to follow).
 
+Marker naming convention: lowercase-hyphenated target → uppercase-underscored marker. Example: `darwin-arm64` becomes `DASHBOARD_DARWIN_ARM64_MARKER_START` / `DASHBOARD_DARWIN_ARM64_MARKER_END`. The transformation is `tr '[:lower:]-' '[:upper:]_'`.
+
 For shell scripts, prefer adding them to `scripts/` so the existing `cp -r scripts ...` step in release.yml automatically picks them up for the source tarball — no release.yml change needed beyond the wrapper plumbing.
 
 ## Things to Avoid

--- a/dashboard/server/tests/status-additional.test.ts
+++ b/dashboard/server/tests/status-additional.test.ts
@@ -52,15 +52,21 @@ describe("StatusStore — gap coverage", () => {
 
     await unlink(path);
     // fs.watch latency varies a lot on macOS CI runners — FSEvents
-    // coalescing has been observed past 1s. Poll up to 5s for the drop
-    // to land. Underlying budget is ~300ms (fs.watch) + 50ms (debounce)
-    // + 200ms (drop-grace) = ~550ms in the typical case.
-    for (let i = 0; i < 100 && !drops.includes("kapsis-demo-drop1.json"); i++) {
-      await Bun.sleep(50);
+    // coalescing has been observed past 1s, and on loaded runners
+    // (parallel matrix jobs, virtualized hosts) the delete event has
+    // missed the previous 5s window. Underlying happy-path budget is
+    // ~300ms (fs.watch) + 50ms (debounce) + 200ms (drop-grace) = ~550ms.
+    // Poll for up to 25s so a slow runner doesn't trip the test, and
+    // raise the per-test timeout to 30s (the third arg to `it()`) so
+    // the poll budget can actually run to completion instead of being
+    // truncated at Bun's default 5s test timeout.
+    const deadlineMs = Date.now() + 25_000;
+    while (!drops.includes("kapsis-demo-drop1.json") && Date.now() < deadlineMs) {
+      await Bun.sleep(100);
     }
     expect(drops).toContain("kapsis-demo-drop1.json");
     expect(store.get("drop1")).toBeUndefined();
-  });
+  }, 30_000);
 
   it("get(agentId) is O(1) via the secondary index (sanity check it returns)", async () => {
     for (let i = 0; i < 100; i++) {

--- a/dashboard/ui/vite.config.ts
+++ b/dashboard/ui/vite.config.ts
@@ -3,12 +3,18 @@ import react from "@vitejs/plugin-react";
 
 const SERVER = "http://127.0.0.1:7777";
 
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   plugins: [react()],
   build: {
     outDir: "dist",
     emptyOutDir: true,
-    sourcemap: true,
+    // Production builds skip sourcemaps because the resulting .js.map
+    // files get embedded into the compiled kapsis-dashboard binary (via
+    // generate-ui-bundle.ts) and bloat it by ~2-5x the minified JS size
+    // with no runtime payoff — Bun's server-side error reporter can't
+    // apply browser source maps. The server-side bundle still gets
+    // source maps via `bun build --compile --sourcemap` in CI.
+    sourcemap: mode !== "production",
   },
   server: {
     port: 5173,
@@ -18,4 +24,4 @@ export default defineConfig({
       "/sse": { target: SERVER, changeOrigin: true, ws: false },
     },
   },
-});
+}));

--- a/packaging/debian/debian/rules
+++ b/packaging/debian/debian/rules
@@ -18,6 +18,7 @@ override_dh_auto_install:
 	install -m 755 scripts/build-agent-image.sh $(CURDIR)/debian/kapsis/usr/lib/kapsis/scripts/
 	install -m 755 scripts/kapsis-cleanup.sh $(CURDIR)/debian/kapsis/usr/lib/kapsis/scripts/
 	install -m 755 scripts/kapsis-status.sh $(CURDIR)/debian/kapsis/usr/lib/kapsis/scripts/
+	install -m 755 scripts/kapsis-recovery-action.sh $(CURDIR)/debian/kapsis/usr/lib/kapsis/scripts/
 	install -m 755 scripts/entrypoint.sh $(CURDIR)/debian/kapsis/usr/lib/kapsis/scripts/
 	install -m 755 scripts/worktree-manager.sh $(CURDIR)/debian/kapsis/usr/lib/kapsis/scripts/
 	install -m 755 scripts/post-container-git.sh $(CURDIR)/debian/kapsis/usr/lib/kapsis/scripts/
@@ -69,6 +70,12 @@ override_dh_auto_install:
 	echo 'export KAPSIS_CMD_NAME="kapsis-status"' >> $(CURDIR)/debian/kapsis/usr/bin/kapsis-status
 	echo 'exec /usr/lib/kapsis/scripts/kapsis-status.sh "$$@"' >> $(CURDIR)/debian/kapsis/usr/bin/kapsis-status
 	chmod 755 $(CURDIR)/debian/kapsis/usr/bin/kapsis-status
+
+	echo '#!/bin/bash' > $(CURDIR)/debian/kapsis/usr/bin/kapsis-recovery-action
+	echo 'export KAPSIS_HOME="/usr/share/kapsis"' >> $(CURDIR)/debian/kapsis/usr/bin/kapsis-recovery-action
+	echo 'export KAPSIS_CMD_NAME="kapsis-recovery-action"' >> $(CURDIR)/debian/kapsis/usr/bin/kapsis-recovery-action
+	echo 'exec /usr/lib/kapsis/scripts/kapsis-recovery-action.sh "$$@"' >> $(CURDIR)/debian/kapsis/usr/bin/kapsis-recovery-action
+	chmod 755 $(CURDIR)/debian/kapsis/usr/bin/kapsis-recovery-action
 
 	echo '#!/bin/bash' > $(CURDIR)/debian/kapsis/usr/bin/kapsis-setup
 	echo 'export KAPSIS_HOME="/usr/share/kapsis"' >> $(CURDIR)/debian/kapsis/usr/bin/kapsis-setup

--- a/packaging/homebrew/kapsis.rb
+++ b/packaging/homebrew/kapsis.rb
@@ -31,6 +31,51 @@ class Kapsis < Formula
   # Podman is the container runtime - required but not a Homebrew dependency
   # Users must install it separately (brew install podman on macOS)
 
+  # Per-platform kapsis-dashboard binaries.
+  #
+  # These resources reference release assets produced by the
+  # `compile-dashboard` job in .github/workflows/release.yml. The CI
+  # `Update Homebrew formula` step patches each block's url + sha256
+  # after the release is created (it computes the SHA256 by downloading
+  # the freshly-attached asset). The marker comments are load-bearing
+  # — do not remove or change their wording.
+  on_macos do
+    on_arm do
+      # DASHBOARD_DARWIN_ARM64_MARKER_START
+      resource "kapsis-dashboard" do
+        url "https://github.com/aviadshiber/kapsis/releases/download/v2.29.1/kapsis-dashboard-darwin-arm64"
+        sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+      end
+      # DASHBOARD_DARWIN_ARM64_MARKER_END
+    end
+    on_intel do
+      # DASHBOARD_DARWIN_X64_MARKER_START
+      resource "kapsis-dashboard" do
+        url "https://github.com/aviadshiber/kapsis/releases/download/v2.29.1/kapsis-dashboard-darwin-x64"
+        sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+      end
+      # DASHBOARD_DARWIN_X64_MARKER_END
+    end
+  end
+  on_linux do
+    on_arm do
+      # DASHBOARD_LINUX_ARM64_MARKER_START
+      resource "kapsis-dashboard" do
+        url "https://github.com/aviadshiber/kapsis/releases/download/v2.29.1/kapsis-dashboard-linux-arm64"
+        sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+      end
+      # DASHBOARD_LINUX_ARM64_MARKER_END
+    end
+    on_intel do
+      # DASHBOARD_LINUX_X64_MARKER_START
+      resource "kapsis-dashboard" do
+        url "https://github.com/aviadshiber/kapsis/releases/download/v2.29.1/kapsis-dashboard-linux-x64"
+        sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+      end
+      # DASHBOARD_LINUX_X64_MARKER_END
+    end
+  end
+
   def install
     # Install everything to libexec, then create wrappers
     libexec.install Dir["*"]
@@ -72,15 +117,21 @@ class Kapsis < Formula
       EOS
     end
 
-    # Install the dashboard binary if one was prebuilt and shipped in the release.
-    # Release artifacts come from .github/workflows/dashboard-build.yml as
-    # kapsis-dashboard-bun-{darwin,linux}-{arm64,x64}; the release packager
-    # renames the per-platform binary to dashboard/bin/kapsis-dashboard.
-    dashboard_bin = libexec/"dashboard/bin/kapsis-dashboard"
-    if dashboard_bin.exist?
-      chmod 0755, dashboard_bin
-      bin.install_symlink dashboard_bin => "kapsis-dashboard"
+    # Install the kapsis-dashboard binary from the per-platform release
+    # asset selected by the on_macos/on_linux + on_arm/on_intel resource
+    # blocks above. The asset is downloaded by Homebrew (sha256-verified
+    # against the formula) at install time.
+    resource("kapsis-dashboard").stage do
+      bin_dir = libexec/"dashboard/bin"
+      bin_dir.mkpath
+      # The staged file has the per-target suffix (e.g. kapsis-dashboard-darwin-arm64);
+      # rename to the generic name the bin symlink expects.
+      staged = Dir["kapsis-dashboard-*"].first
+      odie "kapsis-dashboard resource downloaded but no binary found" unless staged
+      cp staged, bin_dir/"kapsis-dashboard"
+      chmod 0755, bin_dir/"kapsis-dashboard"
     end
+    bin.install_symlink libexec/"dashboard/bin/kapsis-dashboard"
   end
 
   def caveats
@@ -125,5 +176,14 @@ class Kapsis < Formula
       assert_predicate libexec/script, :executable?,
         "#{script} should be executable"
     end
+
+    # Verify kapsis-dashboard binary was installed and is runnable.
+    assert_predicate bin/"kapsis-dashboard", :exist?,
+      "kapsis-dashboard binary should be installed"
+    assert_predicate bin/"kapsis-dashboard", :executable?,
+      "kapsis-dashboard binary should be executable"
+    # --version is the only flag that exits 0 without binding a port.
+    assert_match(/\d+\.\d+\.\d+/,
+      shell_output("#{bin}/kapsis-dashboard --version"))
   end
 end

--- a/packaging/homebrew/kapsis.rb
+++ b/packaging/homebrew/kapsis.rb
@@ -103,6 +103,7 @@ class Kapsis < Formula
       "kapsis-build" => "scripts/build-image.sh",
       "kapsis-cleanup" => "scripts/kapsis-cleanup.sh",
       "kapsis-status" => "scripts/kapsis-status.sh",
+      "kapsis-recovery-action" => "scripts/kapsis-recovery-action.sh",
       "kapsis-setup" => "setup.sh",
       "kapsis-quick" => "quick-start.sh",
     }.each do |cmd, script|

--- a/packaging/homebrew/kapsis.rb
+++ b/packaging/homebrew/kapsis.rb
@@ -36,9 +36,15 @@ class Kapsis < Formula
   # These resources reference release assets produced by the
   # `compile-dashboard` job in .github/workflows/release.yml. The CI
   # `Update Homebrew formula` step patches each block's url + sha256
-  # after the release is created (it computes the SHA256 by downloading
-  # the freshly-attached asset). The marker comments are load-bearing
-  # — do not remove or change their wording.
+  # after the release is created (it sha256sums the local artifact
+  # uploaded by compile-dashboard, NOT the published release URL, to
+  # close the TOCTOU window). The marker comments are load-bearing —
+  # do not remove or change their wording.
+  #
+  # Placeholder sha256 = 64 zeros. `brew audit` will reject this until
+  # CI patches it; that is intentional — `brew install` against an
+  # un-patched formula must fail loudly rather than silently install
+  # nothing.
   on_macos do
     on_arm do
       # DASHBOARD_DARWIN_ARM64_MARKER_START
@@ -89,6 +95,7 @@ class Kapsis < Formula
       scripts/worktree-manager.sh
       scripts/kapsis-cleanup.sh
       scripts/kapsis-status.sh
+      scripts/kapsis-recovery-action.sh
       scripts/lib/logging.sh
       scripts/lib/status.sh
       scripts/lib/constants.sh
@@ -184,7 +191,17 @@ class Kapsis < Formula
     assert_predicate bin/"kapsis-dashboard", :executable?,
       "kapsis-dashboard binary should be executable"
     # --version is the only flag that exits 0 without binding a port.
+    # Pass explicit exit code 0 so any non-zero exit produces a clear
+    # failure instead of an opaque pattern-match miss.
     assert_match(/\d+\.\d+\.\d+/,
-      shell_output("#{bin}/kapsis-dashboard --version"))
+      shell_output("#{bin}/kapsis-dashboard --version", 0))
+
+    # Verify kapsis-recovery-action wrapper is installed and its --help
+    # smoke check works. Catches the same packaging-skip class of bug
+    # the dashboard test above is designed to catch (see #372).
+    assert_predicate bin/"kapsis-recovery-action", :exist?,
+      "kapsis-recovery-action wrapper should be installed"
+    assert_match "Usage:",
+      shell_output("#{bin}/kapsis-recovery-action --help 2>&1", 0)
   end
 end

--- a/packaging/rpm/kapsis.spec
+++ b/packaging/rpm/kapsis.spec
@@ -49,6 +49,7 @@ install -m 755 scripts/build-image.sh %{buildroot}%{_libexecdir}/%{name}/scripts
 install -m 755 scripts/build-agent-image.sh %{buildroot}%{_libexecdir}/%{name}/scripts/
 install -m 755 scripts/kapsis-cleanup.sh %{buildroot}%{_libexecdir}/%{name}/scripts/
 install -m 755 scripts/kapsis-status.sh %{buildroot}%{_libexecdir}/%{name}/scripts/
+install -m 755 scripts/kapsis-recovery-action.sh %{buildroot}%{_libexecdir}/%{name}/scripts/
 install -m 755 scripts/entrypoint.sh %{buildroot}%{_libexecdir}/%{name}/scripts/
 install -m 755 scripts/worktree-manager.sh %{buildroot}%{_libexecdir}/%{name}/scripts/
 install -m 755 scripts/post-container-git.sh %{buildroot}%{_libexecdir}/%{name}/scripts/
@@ -110,6 +111,14 @@ exec %{_libexecdir}/kapsis/scripts/kapsis-status.sh "$@"
 EOF
 chmod 755 %{buildroot}%{_bindir}/kapsis-status
 
+cat > %{buildroot}%{_bindir}/kapsis-recovery-action << 'EOF'
+#!/bin/bash
+export KAPSIS_HOME="%{_datadir}/kapsis"
+export KAPSIS_CMD_NAME="kapsis-recovery-action"
+exec %{_libexecdir}/kapsis/scripts/kapsis-recovery-action.sh "$@"
+EOF
+chmod 755 %{buildroot}%{_bindir}/kapsis-recovery-action
+
 cat > %{buildroot}%{_bindir}/kapsis-setup << 'EOF'
 #!/bin/bash
 export KAPSIS_HOME="%{_datadir}/kapsis"
@@ -139,6 +148,7 @@ install -m 755 dashboard/bin/kapsis-dashboard %{buildroot}%{_bindir}/kapsis-dash
 %{_bindir}/kapsis-build
 %{_bindir}/kapsis-cleanup
 %{_bindir}/kapsis-status
+%{_bindir}/kapsis-recovery-action
 %{_bindir}/kapsis-setup
 %{_bindir}/kapsis-quick
 %{_bindir}/kapsis-dashboard


### PR DESCRIPTION
Closes #372.

## What changed

### 1. `.github/workflows/release.yml`

- **New `compile-dashboard` job** mirroring the matrix from `dashboard-build.yml` (4 targets: darwin/linux × arm64/x64). Gated by `validate` so it runs in parallel with `test` and `build-and-push`. Each platform binary is uploaded as an artifact (1-day retention since the release job consumes it immediately).
- **`release` job now needs `compile-dashboard`**, downloads the artifacts via `actions/download-artifact` with `merge-multiple`, flattens them to repo root, includes them in `checksums.sha256`, attaches them to the GitHub release alongside `kapsis-{version}.tar.gz`, and adds a "📊 Dashboard Binary" section to release notes.
- **`Update Homebrew formula` step in `update-packages`** now also fetches each of the 4 attached dashboard binaries, computes their SHA256, and patches them between new `# DASHBOARD_<TARGET>_MARKER_START/END` blocks in the formula. The version-bump commit therefore arrives with valid checksums for the per-arch resources.

### 2. `packaging/homebrew/kapsis.rb`

- **Replaced the silent `if dashboard_bin.exist?` no-op** with explicit per-platform `resource "kapsis-dashboard"` blocks (`on_macos`/`on_linux` × `on_arm`/`on_intel`). Each block points at the release-asset URL for the matching binary, sha256-verified by Homebrew at install time.
- **`install` method** now `stage`s the right resource, copies it to `libexec/dashboard/bin/kapsis-dashboard`, and symlinks into `bin/`. `odie` fires if the resource somehow downloads nothing — no more silent skip.
- **`test` block** now asserts `kapsis-dashboard --version` actually runs, so we catch this regression class upfront (`brew test kapsis` would have caught the v2.29.1 break).

## End-to-end effect

After this lands and a release cuts:

```bash
brew upgrade aviadshiber/kapsis/kapsis
kapsis-dashboard --version       # ✓ works, no Bun toolchain needed
```

## Notes for reviewer

- Marker blocks (`DASHBOARD_DARWIN_ARM64_MARKER_*`, etc.) are load-bearing — CI parses them by exact string match. Comment in the formula calls this out.
- I picked `merge-multiple: true` on `download-artifact` (each artifact has a unique name like `kapsis-dashboard-darwin-arm64` so there are no collisions) — simpler than 4 separate `download-artifact` steps.
- The placeholder sha256 of all zeros in the formula will be overwritten on the very next release run; if anyone runs `brew install` against this branch before then, Homebrew will refuse with a checksum mismatch (which is the correct behavior — fail loud, not silent like before).
- `compile-dashboard` matrix is intentionally identical to the one in `dashboard-build.yml` so the two stay parity. If we want to DRY them up later, a composite action would be the right move.

## Test plan

- [ ] Smoke-test the workflow on a prerelease (`workflow_dispatch` with `prerelease: true`) — confirm all 4 binaries attach, formula bump commit lands with real sha256s, `brew install --HEAD` then `brew test kapsis` passes on macOS.
- [ ] Confirm `dashboard-artifacts/` isn't accidentally committed (it's a runner-only path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)