### PR TITLE
fix(launch): serialize sandbox setup to work around macOS AVF virtio-fs cache race

### DIFF
--- a/scripts/launch-agent.sh
+++ b/scripts/launch-agent.sh
@@ -128,6 +128,12 @@ source "$SCRIPT_DIR/lib/vfkit-watchdog.sh"
 # Source host-side status volume sync (Issue #276) — no-op when KAPSIS_STATUS_VOLUME unset
 source "$SCRIPT_DIR/lib/status-sync.sh"
 
+# Source launch-phase serialization mutex (macOS AVF virtio-fs cache-coherency
+# bug workaround). Default-on for Darwin, no-op elsewhere; see launch-lock.sh
+# for design rationale and env-var knobs (KAPSIS_LAUNCH_LOCK_ENABLED,
+# KAPSIS_LAUNCH_LOCK_TIMEOUT, KAPSIS_LAUNCH_LOCK_POST_COOLDOWN).
+source "$SCRIPT_DIR/lib/launch-lock.sh"
+
 # Network isolation mode: none (isolated), filtered (DNS allowlist - default), open (unrestricted)
 NETWORK_MODE="${KAPSIS_NETWORK_MODE:-$KAPSIS_DEFAULT_NETWORK_MODE}"
 CLI_NETWORK_MODE=""  # Track if CLI explicitly set network mode
@@ -2616,6 +2622,11 @@ main() {
             stop_status_sync "${AGENT_ID:-}" "$KAPSIS_STATUS_VOLUME" \
                 "${KAPSIS_STATUS_DIR:-$HOME/.kapsis/status}" 2>/dev/null || true
         fi
+        # Release the launch-phase lock if we still hold it on abnormal exit
+        # (the normal release happens right after setup_sandbox in main flow,
+        # but a crash between acquire and that release would leak the lock
+        # to the next agent's acquire-timeout). Idempotent.
+        launch_lock_release 2>/dev/null || true
         # Delegate backend-specific cleanup (secrets env file, inline spec, dns pin, etc.)
         backend_cleanup 2>/dev/null || true
         # Ensure status transitions to 'complete' on abnormal exit (Fix #168)
@@ -2708,14 +2719,25 @@ main() {
         status_phase "initializing" 15 "Pre-flight check passed" || true
     fi
 
-    # Setup sandbox (worktree/overlay) — only for backends that support it
+    # Setup sandbox (worktree/overlay) — only for backends that support it.
+    #
+    # Wrapped with the host-scoped launch lock (macOS-only by default) so two
+    # agents don't enter the heavy metadata-I/O window simultaneously and
+    # trip the AVF virtio-fs cache-coherency bug — see launch-lock.sh. The
+    # post-cooldown happens inside launch_lock_release so the VM-side overlay
+    # mount of THIS agent's container settles before the next launch starts.
     if backend_supports "worktree" || backend_supports "overlay"; then
         log_timer_start "sandbox_setup"
+        if ! launch_lock_acquire; then
+            log_warn "Launch lock unavailable — proceeding without serialization (next agent may race)"
+        fi
         if ! setup_sandbox; then
+            launch_lock_release  # release before failing exit
             status_complete 1 "Sandbox setup failed (mode: ${SANDBOX_MODE:-unknown})"
             _STATUS_COMPLETE_SHOWN=true
             exit 1
         fi
+        launch_lock_release
         log_timer_end "sandbox_setup"
     else
         log_info "Backend '$BACKEND' handles sandbox setup in-cluster"

--- a/scripts/lib/launch-lock.sh
+++ b/scripts/lib/launch-lock.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# scripts/lib/launch-lock.sh
+#
+# Launch-phase serialization mutex.
+#
+# Why this exists
+# ---------------
+# On macOS Podman applehv hosts, the Apple Virtualization framework's
+# virtio-fs server has a documented cache-coherency bug (Apple Feedback
+# FB16008360, podman/podman#23061, podman/podman#24725) that produces:
+#
+#   overlayfs: failed to create directory .../<id>/work/work (errno: 13);
+#               mounting read-only
+#   overlayfs: failed to get metacopy (-2)
+#
+# inside the VM and surfaces as Kapsis exit code 4 / error_type=mount_failure.
+# When two agent launches overlap their heavy host-side metadata I/O window
+# (git worktree add on a multi-GB repo, sanitized-git prep, overlay upper/work
+# dir creation), the shared AVF virtio-fs cache wedges and ALL in-flight
+# containers see lookup failures in the same instant — producing "same-second
+# failure cluster" exit-code-4s across unrelated agents.
+#
+# This helper provides a host-scoped advisory lock that callers wrap around
+# their launch I/O burst. While one agent holds the lock, other launches
+# block until it is released (plus an optional post-release cooldown so the
+# VM-side mount has time to stabilize before the next launch's `podman run`
+# starts a fresh overlay).
+#
+# The lock is INTENTIONALLY scoped per host (not per project / not per repo)
+# because the AVF virtio-fs server is a single shared resource. Two agents
+# launching against different repos can wedge the same cache.
+#
+# Design choices
+# --------------
+# - Uses `mkdir` (atomic on POSIX) for the lock — `flock` is not portable to
+#   macOS without an extra Homebrew install, and we already use the mkdir
+#   pattern in kapsis (see _gc_lock_acquire in launch-agent.sh).
+# - Stale-lock recovery: if the PID file inside the lock dir names a dead
+#   process, the lock is force-released and re-acquired. Protects against
+#   crashed launches deadlocking the next agent.
+# - Default-on for Darwin only. On Linux hosts virtio-fs runs natively in
+#   the kernel; the AVF cache race does not apply, so the lock would add
+#   pointless contention. Users can override with KAPSIS_LAUNCH_LOCK_ENABLED.
+# - Acquire-timeout default 600 s — bounded so a wedged holder eventually
+#   fails the new launch loudly rather than hanging forever.
+# - Post-cooldown default 5 s on macOS — measured empirically as enough for
+#   the VM's overlay mount to settle after `podman run`. Tunable via
+#   KAPSIS_LAUNCH_LOCK_POST_COOLDOWN.
+
+# shellcheck disable=SC2034  # used by sourcing scripts
+KAPSIS_LAUNCH_LOCK_DIR="${KAPSIS_LAUNCH_LOCK_DIR:-$HOME/.kapsis/locks/launch.lock.d}"
+KAPSIS_LAUNCH_LOCK_TIMEOUT="${KAPSIS_LAUNCH_LOCK_TIMEOUT:-600}"
+
+# Default-on for Darwin, default-off elsewhere.
+if [[ -z "${KAPSIS_LAUNCH_LOCK_ENABLED:-}" ]]; then
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        KAPSIS_LAUNCH_LOCK_ENABLED=true
+    else
+        KAPSIS_LAUNCH_LOCK_ENABLED=false
+    fi
+fi
+
+# 5 s post-cooldown on macOS, 0 elsewhere.
+if [[ -z "${KAPSIS_LAUNCH_LOCK_POST_COOLDOWN:-}" ]]; then
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        KAPSIS_LAUNCH_LOCK_POST_COOLDOWN=5
+    else
+        KAPSIS_LAUNCH_LOCK_POST_COOLDOWN=0
+    fi
+fi
+
+# Internal state — non-empty when this process holds the lock.
+_LAUNCH_LOCK_HELD=""
+
+# launch_lock_acquire — block until the host-scoped launch lock is held.
+#
+# Returns 0 on success, 1 on timeout or if disabled. Idempotent: a process
+# that already holds the lock just returns 0 immediately.
+#
+# Callers should pair this with launch_lock_release in an EXIT trap so the
+# lock is released even on abnormal termination.
+launch_lock_acquire() {
+    if [[ "$KAPSIS_LAUNCH_LOCK_ENABLED" != "true" ]]; then
+        return 0
+    fi
+    if [[ -n "$_LAUNCH_LOCK_HELD" ]]; then
+        return 0  # already held
+    fi
+
+    local lock_dir="$KAPSIS_LAUNCH_LOCK_DIR"
+    local timeout_s="$KAPSIS_LAUNCH_LOCK_TIMEOUT"
+    local pid_file="$lock_dir/pid"
+
+    mkdir -p "$(dirname "$lock_dir")" 2>/dev/null || {
+        log_warn "launch_lock_acquire: cannot create $(dirname "$lock_dir") — proceeding without lock"
+        return 0
+    }
+
+    local waited=0
+    local logged_wait=false
+    while ! mkdir "$lock_dir" 2>/dev/null; do
+        # Stale-lock recovery: if PID file names a dead process, reclaim.
+        if [[ -f "$pid_file" ]]; then
+            local holder_pid
+            holder_pid=$(cat "$pid_file" 2>/dev/null || echo "")
+            if [[ -n "$holder_pid" ]] && ! kill -0 "$holder_pid" 2>/dev/null; then
+                log_warn "launch_lock_acquire: reclaiming stale lock from dead PID $holder_pid"
+                rm -rf "$lock_dir"
+                continue
+            fi
+            if [[ "$logged_wait" != "true" ]] && (( waited == 0 )); then
+                log_info "launch_lock_acquire: waiting for launch held by PID ${holder_pid:-unknown} (max ${timeout_s}s)"
+                logged_wait=true
+            fi
+        fi
+
+        if (( waited >= timeout_s )); then
+            log_warn "launch_lock_acquire: timeout after ${timeout_s}s — proceeding without lock (risk of virtio-fs cluster failure)"
+            return 1
+        fi
+        sleep 1
+        waited=$((waited + 1))
+    done
+
+    echo "$$" > "$pid_file"
+    _LAUNCH_LOCK_HELD="$lock_dir"
+    if (( waited > 0 )); then
+        log_info "launch_lock_acquire: acquired after ${waited}s wait"
+    else
+        log_debug "launch_lock_acquire: acquired immediately"
+    fi
+    return 0
+}
+
+# launch_lock_release — release the host-scoped launch lock (with cooldown).
+#
+# Sleeps for KAPSIS_LAUNCH_LOCK_POST_COOLDOWN seconds BEFORE removing the lock
+# dir, giving the VM-side overlay mount time to stabilize so the next agent's
+# `podman run` doesn't race the current one.
+#
+# Safe to call when no lock is held (no-op).
+launch_lock_release() {
+    if [[ -z "$_LAUNCH_LOCK_HELD" ]]; then
+        return 0
+    fi
+
+    local cooldown="$KAPSIS_LAUNCH_LOCK_POST_COOLDOWN"
+    if (( cooldown > 0 )); then
+        log_debug "launch_lock_release: cooldown ${cooldown}s before release"
+        sleep "$cooldown"
+    fi
+
+    rm -rf "$_LAUNCH_LOCK_HELD" 2>/dev/null || true
+    log_debug "launch_lock_release: released $_LAUNCH_LOCK_HELD"
+    _LAUNCH_LOCK_HELD=""
+}


### PR DESCRIPTION
## Root cause (debug-debate diagnosis, 2026-05-18)

On macOS Podman applehv hosts, the Apple Virtualization framework's virtio-fs server has a documented cache-coherency bug:

- Apple Feedback **FB16008360**
- podman/podman#23061 (macOS vm virtiofs concurrency issue)
- podman/podman#24725 (mkdirat returns EACCES on virtio-fs)
- docker/for-mac#6690 (Docker already shipped a cache-invalidation-on-hardlink workaround that Podman 5.8.2 lacks)

When two agent launches overlap their heavy host-side metadata I/O window (`git worktree add` on a multi-GB repo, sanitized-git prep, overlay upper/work dir creation), the shared AVF virtio-fs cache wedges and ALL in-flight containers see lookup failures **in the same instant** — producing same-second exit-code-4 `mount_failure` clusters across unrelated agents.

### Smoking gun

Inside the macOS Podman VM, `sudo dmesg | grep overlayfs` shows EACCES (errno 13) lines for every dead agent ID in the corpus:

```
overlayfs: failed to create directory /Users/aviad.s/.ai-sandboxes/products-c4b778/work/work (errno: 13); mounting read-only
overlayfs: failed to create directory /Users/aviad.s/.ai-sandboxes/products-b55e6d/work/work (errno: 13); mounting read-only
overlayfs: failed to create directory /Users/aviad.s/.ai-sandboxes/products-d29782/work/work (errno: 13); mounting read-only
overlayfs: failed to create directory /Users/aviad.s/.ai-sandboxes/helm-charts-6cd095/work/work (errno: 13); mounting read-only
overlayfs: failed to create directory /Users/aviad.s/.ai-sandboxes/products-5eb6fc/work/work (errno: 13); mounting read-only
overlayfs: failed to get metacopy (-2)
```

8 failures observed in a ~3 h window on one developer's host. Two same-second clusters confirmed:
- `b55e6d` (07:32:56Z) + `e7a561` (07:33:27Z) both fail at exactly **07:39:55Z**
- `36f288` (07:55:21Z) + `7095ff` (07:55:18Z) both fail at exactly **08:03:14Z**

Each pair is a launch within 30 s of its partner — both members inside the ~109 s metadata-I/O window simultaneously when the cache wedged.

## Fix

New `scripts/lib/launch-lock.sh` provides a host-scoped advisory mutex around the launch I/O burst. Implementation choices:

- **`mkdir`-based lock** (atomic on POSIX, portable to macOS without extra deps; follows the existing `_gc_lock_acquire` pattern in `launch-agent.sh`).
- **Wraps `setup_sandbox`** so two agents can't enter the heavy worktree + sanitized-git phase simultaneously.
- **Configurable post-cooldown** (default 5 s on Darwin, 0 elsewhere) inside `launch_lock_release` lets the VM-side overlay mount of the current agent's container settle before the next launch's `podman run` starts a fresh overlay against the same cache.
- **Default-on for Darwin only**: on Linux hosts virtio-fs runs natively in the kernel and the AVF cache race does not apply, so the lock would add pointless contention.
- **Stale-lock recovery**: if the PID file in the lock dir names a dead process, the lock is force-released and re-acquired — so a crashed launch doesn't deadlock the next agent.
- **Bounded acquire-timeout** (default 600 s): a wedged holder eventually fails loudly rather than hanging forever.
- **EXIT-trap release**: safety net for the case where the script dies between `launch_lock_acquire` and the normal release point.

### Env-var knobs

| Variable | Default | Notes |
|---|---|---|
| `KAPSIS_LAUNCH_LOCK_ENABLED` | `true` on Darwin, `false` elsewhere | Opt-out for users without the bug |
| `KAPSIS_LAUNCH_LOCK_TIMEOUT` | `600` (s) | Max wait before giving up |
| `KAPSIS_LAUNCH_LOCK_POST_COOLDOWN` | `5` on Darwin, `0` elsewhere | Tuning for VM-side mount stabilization |
| `KAPSIS_LAUNCH_LOCK_DIR` | `$HOME/.kapsis/locks/launch.lock.d` | Custom lock path |

## Tested

- `bash -n` on both files (no syntax errors)
- Acquire / release happy path
- Stale-lock recovery (dead PID file in lock dir → reclaimed cleanly)
- Contention (parent waits for child to release, then acquires)
- Disabled mode (`KAPSIS_LAUNCH_LOCK_ENABLED=false` is a clean no-op)

Smoke-test script in commit message.

## Structural follow-up (separate PR)

This PR mitigates the **trigger** (concurrent launch overlap). The **bug class** (overlay metadata on virtio-fs is inherently racy) is a separate, larger fix: move overlay `upper`/`work` dirs off the virtio-fs share onto VM-native ext4 (Podman named volume). The `/workspace` bind can stay virtio-fs; only the overlay-internal metadata needs to move.

Tracking the bug-class fix as a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)