### PR TITLE
fix(release): move dashboard-artifact download AFTER Checkout to survive its clean

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -348,26 +348,6 @@ jobs:
             echo "configured=true" >> $GITHUB_OUTPUT
           fi
 
-      - name: Download dashboard binaries (for local SHA256 computation)
-        # Sourcing the SHA from the local artifact closes the TOCTOU /
-        # asset-swap window that re-downloading from the public release URL
-        # would leave open, and removes a network dependency. Gated on
-        # check-app so we don't pull artifacts when the GitHub App isn't
-        # configured (in which case every consuming step would skip anyway).
-        if: steps.check-app.outputs.configured == 'true'
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6.0.0
-        with:
-          pattern: kapsis-dashboard-*
-          path: dashboard-artifacts
-          merge-multiple: true
-
-      - name: List downloaded dashboard binaries
-        # Self-diagnostic upfront so any artifact-availability issue is
-        # immediately visible without needing to re-run with debug logging.
-        if: steps.check-app.outputs.configured == 'true'
-        run: |
-          ls -la dashboard-artifacts/ || echo "::warning::dashboard-artifacts/ not present"
-
       - name: Generate GitHub App token
         id: app-token
         if: steps.check-app.outputs.configured == 'true'
@@ -385,6 +365,29 @@ jobs:
           # The app is configured as a bypass actor in the repository ruleset
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
+
+      - name: Download dashboard binaries (for local SHA256 computation)
+        # MUST run AFTER `Checkout code`: actions/checkout@v6 defaults to
+        # `clean: true` which runs `git clean -ffdx` and wipes untracked
+        # files like dashboard-artifacts/. Sourcing the SHA from the local
+        # artifact closes the TOCTOU / asset-swap window that re-downloading
+        # from the public release URL would leave open, and removes a network
+        # dependency. Gated on check-app so we don't pull artifacts when the
+        # GitHub App isn't configured (in which case every consuming step
+        # would skip anyway).
+        if: steps.check-app.outputs.configured == 'true'
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6.0.0
+        with:
+          pattern: kapsis-dashboard-*
+          path: dashboard-artifacts
+          merge-multiple: true
+
+      - name: List downloaded dashboard binaries
+        # Self-diagnostic upfront so any artifact-availability issue is
+        # immediately visible without needing to re-run with debug logging.
+        if: steps.check-app.outputs.configured == 'true'
+        run: |
+          ls -la dashboard-artifacts/ || echo "::warning::dashboard-artifacts/ not present"
 
       - name: Validate inputs
         if: steps.check-app.outputs.configured == 'true'


### PR DESCRIPTION
## Symptom

\`Release\` workflow's \`Update Package Definitions\` job has been failing on every release since PR #373 merged:

- v2.31.0 (run 26029756600) — failed
- v2.31.1 (run 26031144305) — failed

with:

\`\`\`
##[error]Local artifact missing: dashboard-artifacts/kapsis-dashboard-darwin-arm64
##[error]Process completed with exit code 1.
\`\`\`

## Root cause

The job's step order was:

1. Check app configured ✓
2. **Download dashboard binaries** → puts 4 files in \`dashboard-artifacts/\` (logged \`-rw-r--r-- … kapsis-dashboard-darwin-arm64\`)
3. List binaries → confirms all 4 present
4. Generate App token
5. **Checkout code** with \`actions/checkout@v6\` — defaults to \`clean: true\` which runs \`git clean -ffdx\`, **wiping untracked files including \`dashboard-artifacts/\`**
6. SHA-injection loop → ALL 4 \`if [[ ! -f \"$LOCAL_BIN\" ]]\` checks now fire → fails with the error above

Confirmed via the v2.31.1 run log: download succeeded, files listed, then post-Checkout the loop reports them missing.

## Fix

One-block reorder: Download + List-binaries now run AFTER Checkout. Added a MUST-run-after-checkout comment so this trap can't be silently re-introduced by a future reorder.

\`diff
+ Generate GitHub App token
+ Checkout code (clean: true wipes dashboard-artifacts/)
+ Download dashboard binaries  ← moved here
+ List downloaded dashboard binaries
- Download dashboard binaries  ← was here, got wiped
- List downloaded dashboard binaries
- Generate GitHub App token
- Checkout code
\`

## How this slipped past PR #373's CI

PR #373's branch-level CI runs the \`CI\` and \`Security Scanning\` workflows, NOT \`Release\` (which only runs on tags). The first actual release after merge was v2.31.0 — that's when the trap fired. PR #373's round-2 ensemble review correctly noted that \`update-packages\` should gate the download on \`check-app == true\`, but didn't catch that the download also needed to land after \`Checkout\` to survive its clean. Fixing that in this follow-up.

## Verification plan

This PR can't be tested in branch CI either (same reason — Release only runs on tags). Two options:
1. Merge to main and verify the next auto-release succeeds end-to-end (cheapest, slight risk).
2. Manually trigger \`workflow_dispatch\` of release.yml on this branch with \`prerelease: true\` (zero risk to mainline, gives full E2E proof).

Recommend option 2 if practical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)