### PR TITLE
feat(watchdog): host-side podman exec channel watchdog (#382)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Host-side `podman exec` channel watchdog catches the silent-wedge mode where vfkit is alive but the in-VM podman daemon's exec channel hangs (#382). New `scripts/lib/exec-channel-watchdog.sh` probes the container every 30s with `timeout 5 podman exec <ctr> true`; after 3 consecutive failures (~90s blind window) it writes `exit_code: 4` + `error_type: exec_channel_hang` to status.json, touches a host-only sentinel under `$TMPDIR`, and SIGTERMs the agent's `podman run`. Mirrors the vfkit watchdog trust model — host sentinel is the authoritative fire signal; the override block in `launch-agent.sh` yields to the vfkit watchdog when both fire so the more specific `mount_failure` error_type wins. Knobs: `KAPSIS_EXEC_WATCHDOG_{ENABLED,INTERVAL,TIMEOUT,THRESHOLD}`. macOS-only; no-op on Linux.
+
 ## [2.1.1] - 2026-02-02
 
 ### Fixed

--- a/dashboard/server/src/store/health.ts
+++ b/dashboard/server/src/store/health.ts
@@ -48,6 +48,9 @@ export function terminalRule(s: AgentStatus): HealthRule | null {
   if (s.error_type === "mount_failure") {
     return { name: "terminal", state: "failed", detail: s.error ?? "mount failure" };
   }
+  if (s.error_type === "exec_channel_hang") {
+    return { name: "terminal", state: "failed", detail: s.error ?? "exec channel hang" };
+  }
   return { name: "terminal", state: "failed", detail: s.error ?? `exit ${s.exit_code ?? "?"}` };
 }
 

--- a/dashboard/server/src/store/status.ts
+++ b/dashboard/server/src/store/status.ts
@@ -10,8 +10,26 @@ const DEBOUNCE_MS = 50;
 // appears. Wait this long before treating a "file vanished" event as a real
 // delete; otherwise the UI flickers every time status.sh writes.
 const DROP_GRACE_MS = 200;
+// Backstop reconcile cadence. fs.watch on macOS FSEvents can drop events
+// under load (parallel matrix CI runners, virtualized hosts), leaving a
+// finished agent's status file deleted on disk but still present in the
+// cache. A periodic directory rescan catches the gap. 30s is cheap (one
+// readdir per tick) and bounds the worst-case dashboard staleness.
+const DEFAULT_RECONCILE_INTERVAL_MS = 30_000;
 
 export type StatusListener = (status: AgentStatus | null, file: string) => void;
+
+export interface StatusStoreOptions {
+  /**
+   * How often to rescan the status directory as a safety net against dropped
+   * fs.watch events. Defaults to 30s. Tests use a much shorter value so the
+   * reconcile loop closes the gap within the test timeout.
+   *
+   * Set to 0 to disable reconciliation entirely (useful for tests that want
+   * to assert pure fs.watch behavior).
+   */
+  reconcileIntervalMs?: number;
+}
 
 export class StatusStore {
   private cache = new Map<string, AgentStatus>();
@@ -20,17 +38,26 @@ export class StatusStore {
   private watcher: AbortController | null = null;
   private debounce = new Map<string, ReturnType<typeof setTimeout>>();
   private dropTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private reconcileTimer: ReturnType<typeof setInterval> | null = null;
+  private reconcileIntervalMs: number;
 
-  constructor(private statusDir: string) {}
+  constructor(private statusDir: string, opts: StatusStoreOptions = {}) {
+    this.reconcileIntervalMs = opts.reconcileIntervalMs ?? DEFAULT_RECONCILE_INTERVAL_MS;
+  }
 
   async init(): Promise<void> {
     await this.refreshAll();
     this.startWatch();
+    this.startReconcile();
   }
 
   close(): void {
     this.watcher?.abort();
     this.watcher = null;
+    if (this.reconcileTimer) {
+      clearInterval(this.reconcileTimer);
+      this.reconcileTimer = null;
+    }
     this.listeners.clear();
     for (const t of this.debounce.values()) clearTimeout(t);
     this.debounce.clear();
@@ -139,6 +166,61 @@ export class StatusStore {
         }
       }
     })();
+  }
+
+  private startReconcile(): void {
+    if (this.reconcileIntervalMs <= 0) return;
+    this.reconcileTimer = setInterval(() => {
+      void this.reconcile().catch((e: unknown) => {
+        log.warn("status reconcile failed", { err: String(e) });
+      });
+    }, this.reconcileIntervalMs);
+    // Don't keep the event loop alive for the timer alone — when the server
+    // shuts down (e.g. via SIGTERM), Bun should be free to exit even if
+    // close() wasn't explicitly called.
+    if (typeof (this.reconcileTimer as { unref?: () => void }).unref === "function") {
+      (this.reconcileTimer as unknown as { unref: () => void }).unref();
+    }
+  }
+
+  /**
+   * Compare on-disk directory contents to cache and reconcile gaps.
+   *
+   * - Files present in cache but missing on disk → dropOneSoon (notifies
+   *   listeners with null after the same grace period an fs.watch-driven
+   *   delete uses).
+   * - Files present on disk but missing from cache → refreshOne (notifies
+   *   listeners with the loaded status).
+   *
+   * Exposed via the periodic interval started in `startReconcile()` as a
+   * safety net against dropped fs.watch events (macOS FSEvents under load).
+   * Also useful in tests that want to force a synchronous reconciliation.
+   */
+  async reconcile(): Promise<void> {
+    let files: string[];
+    try {
+      files = await readdir(this.statusDir);
+    } catch {
+      return; // Directory transiently missing; refreshAll handles full failures.
+    }
+    const onDisk = new Set(
+      files.filter((f) => !f.startsWith(".") && f.endsWith(".json")),
+    );
+    // Deletes missed by fs.watch — schedule drop with the same grace period
+    // an atomic-rename write would use, so a concurrent write that just
+    // happened to land between readdir and the reconcile tick doesn't
+    // produce a spurious null notification.
+    for (const file of this.cache.keys()) {
+      if (!onDisk.has(file)) this.dropOneSoon(file);
+    }
+    // Creates missed by fs.watch — refresh into cache. Skips files already
+    // present (refreshOne's `if (!prev || ... updated_at differs ...)` keeps
+    // listeners from firing on no-op rescans of unchanged files).
+    for (const file of onDisk) {
+      if (!this.cache.has(file)) {
+        await this.refreshOne(join(this.statusDir, file));
+      }
+    }
   }
 }
 

--- a/dashboard/server/src/types.ts
+++ b/dashboard/server/src/types.ts
@@ -1,4 +1,8 @@
 // Re-export the single source of truth in @kapsis/dashboard-shared. Server
 // code keeps importing from "./types" for backward compatibility; new code
 // should import directly from "@kapsis/dashboard-shared".
+//
+// AgentStatus.error_type union mirrors the set documented in
+// scripts/lib/status.sh::status_set_error_type. Last sync added
+// "exec_channel_hang" for Issue #382 (host-side podman exec watchdog).
 export * from "@kapsis/dashboard-shared";

--- a/dashboard/server/tests/status-additional.test.ts
+++ b/dashboard/server/tests/status-additional.test.ts
@@ -44,29 +44,27 @@ describe("StatusStore — gap coverage", () => {
   it("notifies listeners with null when a file is deleted (after grace period)", async () => {
     const path = join(dir, "kapsis-demo-drop1.json");
     await writeFile(path, fixture({ agent_id: "drop1" }));
-    store = new StatusStore(dir);
+    // Short reconcile interval so the periodic safety net catches a dropped
+    // fs.watch event within the test budget. macOS FSEvents can drop the
+    // unlink event entirely under CI load (previous 25s poll on fs.watch
+    // alone wasn't reliable). The reconcile loop closes the gap deterministically.
+    store = new StatusStore(dir, { reconcileIntervalMs: 250 });
     await store.init();
 
     const drops: string[] = [];
     store.onChange((s, file) => { if (s === null) drops.push(file); });
 
     await unlink(path);
-    // fs.watch latency varies a lot on macOS CI runners — FSEvents
-    // coalescing has been observed past 1s, and on loaded runners
-    // (parallel matrix jobs, virtualized hosts) the delete event has
-    // missed the previous 5s window. Underlying happy-path budget is
-    // ~300ms (fs.watch) + 50ms (debounce) + 200ms (drop-grace) = ~550ms.
-    // Poll for up to 25s so a slow runner doesn't trip the test, and
-    // raise the per-test timeout to 30s (the third arg to `it()`) so
-    // the poll budget can actually run to completion instead of being
-    // truncated at Bun's default 5s test timeout.
-    const deadlineMs = Date.now() + 25_000;
+    // Wait up to 5s. Budget: fs.watch path (~300ms + 50ms debounce + 200ms
+    // grace = ~550ms) or reconcile fallback (≤250ms tick + 200ms grace ≈
+    // 450ms). 5s is generous for both paths even on loaded macOS runners.
+    const deadlineMs = Date.now() + 5_000;
     while (!drops.includes("kapsis-demo-drop1.json") && Date.now() < deadlineMs) {
-      await Bun.sleep(100);
+      await Bun.sleep(50);
     }
     expect(drops).toContain("kapsis-demo-drop1.json");
     expect(store.get("drop1")).toBeUndefined();
-  }, 30_000);
+  }, 10_000);
 
   it("get(agentId) is O(1) via the secondary index (sanity check it returns)", async () => {
     for (let i = 0; i < 100; i++) {
@@ -76,5 +74,48 @@ describe("StatusStore — gap coverage", () => {
     await store.init();
     expect(store.get("id42")?.agent_id).toBe("id42");
     expect(store.get("nope")).toBeUndefined();
+  });
+
+  it("reconcile() catches deletes even with fs.watch disabled (safety net path)", async () => {
+    // Direct exercise of the reconcile path, independent of any fs.watch
+    // event firing. Regression anchor for the periodic safety net we added
+    // to handle FSEvents drops on macOS CI runners under load.
+    const path = join(dir, "kapsis-demo-orphan.json");
+    await writeFile(path, fixture({ agent_id: "orphan" }));
+    // reconcileIntervalMs=0 disables the periodic timer so we drive
+    // reconcile() manually and prove the contract without depending on
+    // wall-clock timing.
+    store = new StatusStore(dir, { reconcileIntervalMs: 0 });
+    await store.init();
+    expect(store.get("orphan")?.agent_id).toBe("orphan");
+
+    const drops: string[] = [];
+    store.onChange((s, file) => { if (s === null) drops.push(file); });
+
+    await unlink(path);
+    await store.reconcile();
+    // dropOneSoon uses a 200ms grace; wait it out deterministically.
+    await Bun.sleep(300);
+
+    expect(drops).toContain("kapsis-demo-orphan.json");
+    expect(store.get("orphan")).toBeUndefined();
+  });
+
+  it("reconcile() picks up files missed by fs.watch (create path)", async () => {
+    store = new StatusStore(dir, { reconcileIntervalMs: 0 });
+    await store.init();
+    expect(store.get("late")).toBeUndefined();
+
+    const updates: string[] = [];
+    store.onChange((s, file) => { if (s !== null) updates.push(file); });
+
+    // Write the file AFTER fs.watch has been started, then run reconcile.
+    // On a real CI runner where the fs.watch event was dropped, reconcile
+    // is what brings the new file into cache.
+    await writeFile(join(dir, "kapsis-demo-late.json"), fixture({ agent_id: "late" }));
+    await store.reconcile();
+
+    expect(store.get("late")?.agent_id).toBe("late");
+    expect(updates).toContain("kapsis-demo-late.json");
   });
 });

--- a/dashboard/shared/src/index.ts
+++ b/dashboard/shared/src/index.ts
@@ -49,6 +49,7 @@ export interface AgentStatus {
     | "commit_failure"
     | "push_failure"
     | "mount_failure"
+    | "exec_channel_hang"
     | "killed"
     | "zombie"
     | null;

--- a/scripts/launch-agent.sh
+++ b/scripts/launch-agent.sh
@@ -125,6 +125,11 @@ source "$SCRIPT_DIR/lib/podman-health.sh"
 # shellcheck source=lib/vfkit-watchdog.sh
 source "$SCRIPT_DIR/lib/vfkit-watchdog.sh"
 
+# shellcheck source=lib/exec-channel-watchdog.sh
+# Catches the silent-wedge mode that vfkit-watchdog cannot (Issue #382): vfkit
+# alive, container Up, but `podman exec` channel hung.
+source "$SCRIPT_DIR/lib/exec-channel-watchdog.sh"
+
 # Source host-side status volume sync (Issue #276) — no-op when KAPSIS_STATUS_VOLUME unset
 source "$SCRIPT_DIR/lib/status-sync.sh"
 
@@ -2586,6 +2591,16 @@ main() {
     # inside the container cannot forge a mount_failure exit.
     _VFKIT_FIRED_SENTINEL=""
 
+    # PID of exec-channel watchdog subshell (Issue #382). macOS-only; empty
+    # when disabled. Cleaned up in _cleanup_with_completion.
+    _EXEC_CHANNEL_WATCHDOG_PID=""
+
+    # Host-only sentinel path written by the exec-channel watchdog when
+    # `podman exec <container> true` hangs N consecutive times. Same trust
+    # model as _VFKIT_FIRED_SENTINEL: under $TMPDIR, host-private, NOT
+    # bind-mounted into the container.
+    _EXEC_HANG_FIRED_SENTINEL=""
+
     # Cleanup function that ensures completion message is shown
     # shellcheck disable=SC2329  # Function is invoked via trap on line 1565
     _cleanup_with_completion() {
@@ -2614,6 +2629,19 @@ main() {
         # run with the same AGENT_ID (resume mode).
         if [[ -n "${_VFKIT_FIRED_SENTINEL:-}" ]]; then
             rm -f "$_VFKIT_FIRED_SENTINEL" 2>/dev/null || true
+        fi
+        # Same shape as the vfkit watchdog teardown above. Killed before
+        # backend_cleanup so a stale watchdog cannot fire on a future agent
+        # after the container has already exited normally. `wait` drains the
+        # subshell so any in-flight `_status_write` finishes before this trap
+        # runs `status_complete` again.
+        if [[ -n "${_EXEC_CHANNEL_WATCHDOG_PID:-}" ]]; then
+            kill "$_EXEC_CHANNEL_WATCHDOG_PID" 2>/dev/null || true
+            wait "$_EXEC_CHANNEL_WATCHDOG_PID" 2>/dev/null || true
+            _EXEC_CHANNEL_WATCHDOG_PID=""
+        fi
+        if [[ -n "${_EXEC_HANG_FIRED_SENTINEL:-}" ]]; then
+            rm -f "$_EXEC_HANG_FIRED_SENTINEL" 2>/dev/null || true
         fi
         # Stop host-side status volume sync and flush one final snapshot to
         # the host status dir so post-exit consumers see the definitive state
@@ -2895,6 +2923,15 @@ main() {
         rm -f "$_VFKIT_FIRED_SENTINEL" 2>/dev/null || true
         start_vfkit_watchdog "$AGENT_ID" "" "" "$_VFKIT_FIRED_SENTINEL" \
             || log_warn "vfkit watchdog failed to start — mount failure detection disabled for this session"
+
+        # exec-channel watchdog (Issue #382): catches the silent-wedge mode
+        # where vfkit is alive but `podman exec` hangs (the v2.24.0 vfkit
+        # watchdog cannot detect this). Same trust model as the vfkit
+        # sentinel — host-only path under $TMPDIR, never bind-mounted.
+        _EXEC_HANG_FIRED_SENTINEL="${TMPDIR:-/tmp}/kapsis-${AGENT_ID}.exec-hang-fired"
+        rm -f "$_EXEC_HANG_FIRED_SENTINEL" 2>/dev/null || true
+        start_exec_channel_watchdog "$AGENT_ID" "" "" "" "" "$_EXEC_HANG_FIRED_SENTINEL" \
+            || log_warn "exec-channel watchdog failed to start — silent-wedge detection disabled for this session"
     fi
 
     # Display progress header (shows sandbox ready status with timer)
@@ -3090,6 +3127,37 @@ main() {
         fi
     fi
 
+    # Check for exec-channel watchdog hang (Issue #382). Same trust model
+    # as the vfkit override above: host-only sentinel is the authoritative
+    # signal; status.json's `error_type: exec_channel_hang` is defense in
+    # depth. Skipped if the vfkit watchdog already escalated EXIT_CODE=4 —
+    # both watchdogs share the exit code, and `exec_channel_hang` would
+    # otherwise overwrite the more specific `mount_failure` error_type
+    # when both fire in close succession (e.g. vfkit dies while exec is
+    # already hung). Order matches the spawn order.
+    if [[ "$EXIT_CODE" -ne 0 ]] \
+       && [[ -n "${_EXEC_HANG_FIRED_SENTINEL:-}" && -f "$_EXEC_HANG_FIRED_SENTINEL" ]] \
+       && [[ ! -f "${_VFKIT_FIRED_SENTINEL:-/dev/null}" ]]; then
+        local _status_file_exec
+        _status_file_exec="${KAPSIS_STATUS_DIR:-$HOME/.kapsis/status}/kapsis-$(basename "$PROJECT_PATH")-${AGENT_ID}.json"
+        local status_exit_exec status_err_exec
+        status_exit_exec=$(status_get_exit_code 2>/dev/null || echo "")
+        status_err_exec=""
+        if [[ -f "$_status_file_exec" ]] \
+           && grep -Eq '"error_type":[[:space:]]*"exec_channel_hang"' "$_status_file_exec" 2>/dev/null; then
+            status_err_exec="exec_channel_hang"
+        fi
+        if [[ "$status_exit_exec" == "4" && "$status_err_exec" == "exec_channel_hang" ]]; then
+            log_warn "Exec-channel hang confirmed by host-side watchdog (sentinel + status.json exec_channel_hang) — overriding exit code from $EXIT_CODE to 4"
+            EXIT_CODE=4
+            _KAPSIS_EXEC_HANG_DETECTED=true
+        else
+            log_warn "Exec-channel hang detected via host sentinel (status.json mismatch — disk full?) — overriding exit code from $EXIT_CODE to 4"
+            EXIT_CODE=4
+            _KAPSIS_EXEC_HANG_DETECTED=true
+        fi
+    fi
+
     rm -f "$container_output"
     # Update status to post_processing (Fix #3: don't report "completed" until commit verified)
     status_phase "post_processing" 85 "Processing agent output (exit code: $EXIT_CODE)" || true
@@ -3158,11 +3226,20 @@ main() {
         _DISPLAY_COMPLETE_SHOWN=true
         rm -f "$_kill_marker" 2>/dev/null || true
     elif [[ "$EXIT_CODE" -eq 4 ]]; then
-        # Mount failure detected via sentinel (Issue #248)
+        # Mount-class failure detected via sentinel (Issue #248 / #382).
+        # _KAPSIS_EXEC_HANG_DETECTED distinguishes the silent-wedge mode
+        # from a true virtio-fs drop so the user message and error_type
+        # reflect the actual diagnosis.
         FINAL_EXIT_CODE=4
         log_finalize 4
-        status_set_error_type "mount_failure"
-        local mount_error="Workspace mount lost (virtio-fs drop). Recovery: podman machine stop && podman machine start, then re-run."
+        local mount_error
+        if [[ "${_KAPSIS_EXEC_HANG_DETECTED:-false}" == "true" ]]; then
+            status_set_error_type "exec_channel_hang"
+            mount_error="Container exec channel wedged (podman daemon hang while vfkit alive). Recovery: podman machine stop && podman machine start, then re-run."
+        else
+            status_set_error_type "mount_failure"
+            mount_error="Workspace mount lost (virtio-fs drop). Recovery: podman machine stop && podman machine start, then re-run."
+        fi
         status_complete 4 "$mount_error"
         _STATUS_COMPLETE_SHOWN=true
         display_complete 4 "" "$mount_error"

--- a/scripts/launch-agent.sh
+++ b/scripts/launch-agent.sh
@@ -3115,26 +3115,32 @@ main() {
         if [[ "$status_exit_vfkit" == "4" && "$status_err_vfkit" == "mount_failure" ]]; then
             log_warn "Mount failure confirmed by vfkit watchdog (host sentinel + status.json mount_failure) — overriding exit code from $EXIT_CODE to 4"
             EXIT_CODE=4
+            _KAPSIS_VFKIT_HANG_DETECTED=true
         else
             # Sentinel present but status.json doesn't agree — possible
             # status_complete failure inside the watchdog subshell. Still
             # safe to override because the sentinel is host-trusted.
             log_warn "Mount failure detected via vfkit watchdog host sentinel (status.json mismatch — disk full?) — overriding exit code from $EXIT_CODE to 4"
             EXIT_CODE=4
+            _KAPSIS_VFKIT_HANG_DETECTED=true
         fi
     fi
 
     # Check for exec-channel watchdog hang (Issue #382). Same trust model
     # as the vfkit override above: host-only sentinel is the authoritative
     # signal; status.json's `error_type: exec_channel_hang` is defense in
-    # depth. Skipped if the vfkit watchdog already escalated EXIT_CODE=4 —
-    # both watchdogs share the exit code, and `exec_channel_hang` would
-    # otherwise overwrite the more specific `mount_failure` error_type
-    # when both fire in close succession (e.g. vfkit dies while exec is
-    # already hung). Order matches the spawn order.
+    # depth. Skipped if the vfkit watchdog already fired — both watchdogs
+    # share exit code 4, and `exec_channel_hang` would otherwise overwrite
+    # the more specific `mount_failure` error_type when both fire in close
+    # succession (e.g. vfkit dies while exec is already hung). We gate on
+    # the `_KAPSIS_VFKIT_HANG_DETECTED` boolean rather than the sentinel
+    # file because `_cleanup_with_completion` may delete the sentinel
+    # before this block runs (e.g. via an ERR/EXIT trap during a fatal
+    # error earlier in main), and a missing sentinel would otherwise let
+    # this block silently overwrite the vfkit watchdog's diagnosis.
     if [[ "$EXIT_CODE" -ne 0 ]] \
        && [[ -n "${_EXEC_HANG_FIRED_SENTINEL:-}" && -f "$_EXEC_HANG_FIRED_SENTINEL" ]] \
-       && [[ ! -f "${_VFKIT_FIRED_SENTINEL:-/dev/null}" ]]; then
+       && [[ "${_KAPSIS_VFKIT_HANG_DETECTED:-false}" != "true" ]]; then
         local _status_file_exec
         _status_file_exec="${KAPSIS_STATUS_DIR:-$HOME/.kapsis/status}/kapsis-$(basename "$PROJECT_PATH")-${AGENT_ID}.json"
         local status_exit_exec status_err_exec

--- a/scripts/launch-agent.sh
+++ b/scripts/launch-agent.sh
@@ -124,10 +124,7 @@ source "$SCRIPT_DIR/lib/dns-pin.sh"
 source "$SCRIPT_DIR/lib/podman-health.sh"
 # shellcheck source=lib/vfkit-watchdog.sh
 source "$SCRIPT_DIR/lib/vfkit-watchdog.sh"
-
 # shellcheck source=lib/exec-channel-watchdog.sh
-# Catches the silent-wedge mode that vfkit-watchdog cannot (Issue #382): vfkit
-# alive, container Up, but `podman exec` channel hung.
 source "$SCRIPT_DIR/lib/exec-channel-watchdog.sh"
 
 # Source host-side status volume sync (Issue #276) — no-op when KAPSIS_STATUS_VOLUME unset

--- a/scripts/lib/exec-channel-watchdog.sh
+++ b/scripts/lib/exec-channel-watchdog.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+#===============================================================================
+# exec-channel-watchdog.sh — Host-side podman exec channel watchdog (Issue #382)
+#
+# Detects a silent-wedge mode that the v2.24.0 vfkit watchdog cannot catch:
+# vfkit is still alive, the container is `Up`, the agent process is in
+# `podman top`, but `podman exec <container> ...` hangs forever. status-sync
+# stalls in lockstep (the same daemon channel is wedged), so the host sees
+# `phase: running` and no exit code until a human runs `podman machine stop`.
+#
+# Symptom evidence (issue #382): a 37-minute "Up" container where
+# `timeout 10 podman exec ... echo hello` returns rc=124. The vfkit watchdog
+# does not fire (vfkit alive). The in-VM liveness probe does not fire
+# (its sentinel write into /kapsis-status is what's blocked).
+#
+# Mechanism: every $interval seconds, run `timeout $exec_timeout podman exec
+# <ctr> true`. If $threshold consecutive ticks return non-zero, treat the
+# channel as dead — write the host-only sentinel, mark status.json
+# `exit_code: 4` + `error_type: exec_channel_hang`, and SIGTERM the agent's
+# `podman run` foreground process (analogous to vfkit-watchdog.sh).
+#
+# Trust model mirrors the vfkit watchdog (Issue #303 ensemble review #2):
+# the override block in launch-agent.sh requires the host-only sentinel
+# (under $TMPDIR, NOT bind-mounted) as the authoritative proof. status.json
+# is mirrored from a named volume the container can write, so it confirms
+# the watchdog's own write but is never trusted in isolation.
+#
+# Public API:
+#   start_exec_channel_watchdog <agent_id> [container_name] [interval] \
+#                               [exec_timeout] [threshold] [sentinel_path]
+#       Spawns a backgrounded watchdog subshell. Sets
+#       _EXEC_CHANNEL_WATCHDOG_PID (caller-readable). No-op on Linux or when
+#       disabled.
+#
+# Caller is responsible for cleanup (same shape as vfkit-watchdog):
+#   if [[ -n "$_EXEC_CHANNEL_WATCHDOG_PID" ]]; then
+#       kill "$_EXEC_CHANNEL_WATCHDOG_PID" 2>/dev/null || true
+#       wait "$_EXEC_CHANNEL_WATCHDOG_PID" 2>/dev/null || true
+#   fi
+#===============================================================================
+
+[[ -n "${_KAPSIS_EXEC_CHANNEL_WATCHDOG_LOADED:-}" ]] && return 0
+_KAPSIS_EXEC_CHANNEL_WATCHDOG_LOADED=1
+
+# Stubs for isolated test contexts (production has logging.sh + compat.sh sourced first).
+declare -f log_warn  &>/dev/null || log_warn()  { echo "[WARN] $*" >&2; }
+declare -f log_debug &>/dev/null || log_debug() { :; }
+declare -f is_macos  &>/dev/null || is_macos()  { [[ "$(uname -s)" == "Darwin" ]]; }
+
+_KAPSIS_EXEC_WATCHDOG_PODMAN="${KAPSIS_EXEC_WATCHDOG_PODMAN:-podman}"
+
+#-------------------------------------------------------------------------------
+# start_exec_channel_watchdog <agent_id> [container_name] [interval]
+#                             [exec_timeout] [threshold] [sentinel_path]
+#
+# interval       — seconds between probes (default 30; KAPSIS_EXEC_WATCHDOG_INTERVAL)
+# exec_timeout   — seconds per probe (default 5; KAPSIS_EXEC_WATCHDOG_TIMEOUT)
+# threshold      — consecutive failures before firing (default 3;
+#                  KAPSIS_EXEC_WATCHDOG_THRESHOLD). With defaults: ~90s blind
+#                  window from first hang to escalation. Trade-off: lower
+#                  thresholds catch wedges faster but may misfire on
+#                  transient daemon hiccups (network pause, image pull on
+#                  another container). 3 has been chosen as a conservative
+#                  default; can be lowered via env var.
+# sentinel_path  — host-only file path the watchdog touches on fire. MUST
+#                  be host-private (under $TMPDIR or another non-bind-mounted
+#                  dir) or the trust anchor in the override block is void.
+#
+# Exits silently on parent death or external SIGTERM/SIGHUP — a stale
+# watchdog must not fire on a future agent that reuses the same AGENT_ID
+# via --agent-id resume.
+#
+# Sets:
+#   _EXEC_CHANNEL_WATCHDOG_PID — PID of the watchdog subshell, or empty if skipped
+#-------------------------------------------------------------------------------
+start_exec_channel_watchdog() {
+    local agent_id="${1:-}"
+    local container_name="${2:-}"
+    local interval="${3:-${KAPSIS_EXEC_WATCHDOG_INTERVAL:-30}}"
+    local exec_timeout="${4:-${KAPSIS_EXEC_WATCHDOG_TIMEOUT:-5}}"
+    local threshold="${5:-${KAPSIS_EXEC_WATCHDOG_THRESHOLD:-3}}"
+    local sentinel_path="${6:-}"
+
+    _EXEC_CHANNEL_WATCHDOG_PID=""
+
+    if [[ -z "$agent_id" ]]; then
+        log_warn "exec-channel watchdog: missing agent_id — skipping"
+        return 0
+    fi
+    if ! is_macos; then
+        # The wedge family (FB16008360 / podman#23061) is macOS-applehv-specific.
+        # Skip on Linux for the same reason vfkit-watchdog does.
+        return 0
+    fi
+    if [[ "${KAPSIS_EXEC_WATCHDOG_ENABLED:-true}" != "true" ]]; then
+        log_debug "exec-channel watchdog disabled by KAPSIS_EXEC_WATCHDOG_ENABLED"
+        return 0
+    fi
+
+    # Default container name follows launch-agent.sh's `--name kapsis-${AGENT_ID}` convention.
+    [[ -z "$container_name" ]] && container_name="kapsis-${agent_id}"
+
+    # Validate AGENT_ID format (defense in depth — caller already validates).
+    # Same character class as vfkit-watchdog and pkill boundary class below.
+    if ! [[ "$agent_id" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+        log_warn "exec-channel watchdog: invalid agent_id '$agent_id' — skipping"
+        return 0
+    fi
+    # Container name must be safe to pass to podman without quoting hazards.
+    if ! [[ "$container_name" =~ ^[a-zA-Z0-9_.-]+$ ]]; then
+        log_warn "exec-channel watchdog: invalid container_name '$container_name' — skipping"
+        return 0
+    fi
+    # All three timing knobs must be positive integers.
+    if ! [[ "$interval" =~ ^[1-9][0-9]*$ ]]; then
+        log_warn "exec-channel watchdog: invalid interval '$interval' — using default 30s"
+        interval=30
+    fi
+    if ! [[ "$exec_timeout" =~ ^[1-9][0-9]*$ ]]; then
+        log_warn "exec-channel watchdog: invalid exec_timeout '$exec_timeout' — using default 5s"
+        exec_timeout=5
+    fi
+    if ! [[ "$threshold" =~ ^[1-9][0-9]*$ ]]; then
+        log_warn "exec-channel watchdog: invalid threshold '$threshold' — using default 3"
+        threshold=3
+    fi
+
+    # Verify `timeout` is available. macOS doesn't ship GNU coreutils;
+    # Homebrew installs `gtimeout` (used by other kapsis scripts) but for
+    # this watchdog we prefer the `timeout` symlink which `setup.sh`
+    # provisions, falling back to gtimeout.
+    local timeout_bin=""
+    if command -v timeout &>/dev/null; then
+        timeout_bin="timeout"
+    elif command -v gtimeout &>/dev/null; then
+        timeout_bin="gtimeout"
+    else
+        log_warn "exec-channel watchdog: neither timeout nor gtimeout found — skipping"
+        return 0
+    fi
+
+    local parent_pid=$$
+    (
+        set +e
+        # Exit silently when the parent cleanup kills us, so we never
+        # double-fire after a normal agent shutdown.
+        trap 'exit 0' TERM HUP INT
+
+        # POSIX-ERE-portable boundary class (same rationale as vfkit-watchdog.sh):
+        # macOS BSD pkill does NOT support \b. `[^a-zA-Z0-9_-]` matches the
+        # space that always follows `--name kapsis-${AGENT_ID}` in argv.
+        local boundary='[^a-zA-Z0-9_-]'
+
+        local failures=0
+        while true; do
+            # Orphan protection: a stale watchdog (parent SIGKILLed,
+            # terminal hung up) must not fire on a future agent that
+            # reuses the same AGENT_ID via --agent-id resume.
+            if ! kill -0 "$parent_pid" 2>/dev/null; then
+                exit 0
+            fi
+
+            # Active probe. `true` is the lightest possible payload — no
+            # filesystem touch, no command parsing inside the container.
+            # The hang we're catching lives in the podman daemon's exec
+            # attach channel; the inner command doesn't matter.
+            #
+            # `</dev/null` is critical: without it, `podman exec` would
+            # inherit this subshell's stdin which is the parent script's
+            # stdin (often a TTY), giving spurious behavior on probe.
+            if "$timeout_bin" "$exec_timeout" \
+                "$_KAPSIS_EXEC_WATCHDOG_PODMAN" exec "$container_name" true \
+                </dev/null >/dev/null 2>&1; then
+                # Recovery — reset the counter. A wedge that clears on its
+                # own (transient daemon contention) must not accumulate
+                # across long uptimes.
+                failures=0
+            else
+                failures=$((failures + 1))
+                log_debug "exec-channel watchdog: probe failed (${failures}/${threshold}) for ${container_name}"
+                if (( failures >= threshold )); then
+                    break
+                fi
+            fi
+
+            # Backgrounded sleep + wait so SIGTERM from the cleanup trap
+            # interrupts immediately (otherwise normal-shutdown wait would
+            # block up to $interval seconds).
+            sleep "$interval" & wait $! 2>/dev/null
+        done
+
+        # Threshold breached. One last parent check before firing — racing
+        # with normal cleanup is fine; the trap above handles the
+        # cleanup-kills-watchdog ordering.
+        if ! kill -0 "$parent_pid" 2>/dev/null; then
+            exit 0
+        fi
+
+        # Host-only sentinel FIRST — this is the authoritative "watchdog
+        # fired" signal and is checked by the post-container override in
+        # launch-agent.sh. Writing this before status_complete means the
+        # override has a strong signal even if status_complete fails
+        # (disk full, status disabled, etc.).
+        if [[ -n "$sentinel_path" ]]; then
+            : > "$sentinel_path" 2>/dev/null || true
+        fi
+        status_set_error_type "exec_channel_hang" 2>/dev/null || true
+        status_complete 4 "Container exec channel wedged: ${threshold} consecutive 'podman exec ${container_name} true' probes timed out (>${exec_timeout}s each, host-side watchdog). vfkit alive; podman daemon exec channel hung. Recovery: podman machine stop && podman machine start, then re-run." 2>/dev/null || true
+        log_warn "KAPSIS_EXEC_CHANNEL_HANG[exec_channel_watchdog]: ${threshold} consecutive podman exec timeouts on ${container_name} — daemon exec channel wedged"
+        pkill -TERM -f "podman run .*--name kapsis-${agent_id}(${boundary}|\$)" 2>/dev/null || true
+    ) &
+    _EXEC_CHANNEL_WATCHDOG_PID=$!
+
+    log_debug "exec-channel watchdog active (container: $container_name, poll: ${interval}s, timeout: ${exec_timeout}s, threshold: ${threshold}, watchdog PID: $_EXEC_CHANNEL_WATCHDOG_PID)"
+}

--- a/scripts/lib/status.sh
+++ b/scripts/lib/status.sh
@@ -428,7 +428,7 @@ status_get_commit_sha() {
 # Arguments:
 #   $1 - Error type: "agent_failure", "agent_partial", "commit_failure",
 #        "push_failure", "uncommitted_work", "mount_failure",
-#        "hung_after_completion", "killed"
+#        "exec_channel_hang", "hung_after_completion", "killed"
 status_set_error_type() {
     _KAPSIS_ERROR_TYPE="${1:-}"
 }

--- a/tests/test-exec-channel-watchdog.sh
+++ b/tests/test-exec-channel-watchdog.sh
@@ -1,0 +1,467 @@
+#!/usr/bin/env bash
+#===============================================================================
+# Tests for the host-side exec-channel watchdog (Issue #382)
+#
+# The watchdog body lives in scripts/lib/exec-channel-watchdog.sh. These tests
+# source the production library directly (no body duplication), force
+# is_macos=true so the macOS-only path is exercised on Linux CI, and verify:
+#
+# - When `podman exec <ctr> true` hangs N consecutive times, the watchdog
+#   writes exit_code=4 + error_type=exec_channel_hang to status.json, touches
+#   the host-only sentinel, and SIGTERMs the agent's `podman run` via a pkill
+#   pattern anchored to the AGENT_ID with a BSD-portable boundary class.
+# - A transient single failure that recovers before threshold does NOT cause
+#   the watchdog to fire (counter reset semantics).
+# - Killing the watchdog before threshold leaves the sentinel and status.json
+#   untouched (idempotent cleanup).
+# - When the parent shell goes away, the watchdog exits without firing
+#   (orphan protection — must not fire on a future agent that reuses the same
+#   AGENT_ID via resume mode).
+# - Invalid AGENT_ID / container_name / timing knobs cause the watchdog to
+#   skip rather than crash.
+# - The post-container override block upgrades non-zero EXIT_CODE to 4 when
+#   status.json reports exit_code=4 + error_type=exec_channel_hang AND the
+#   host sentinel exists; leaves EXIT_CODE alone for clean exits or when
+#   the sentinel is missing (forgery resistance).
+#
+# Run: ./tests/test-exec-channel-watchdog.sh
+#===============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/test-framework.sh"
+
+LIB_DIR="$KAPSIS_ROOT/scripts/lib"
+
+#-------------------------------------------------------------------------------
+# Per-test isolated env: scoped status dir, fresh status state, force macOS,
+# source the production watchdog lib. Caller must call _teardown_test_env on
+# all paths (including failure) — _setup_test_env registers a trap.
+#-------------------------------------------------------------------------------
+_setup_test_env() {
+    TEST_TMP=$(mktemp -d)
+    export KAPSIS_STATUS_DIR="$TEST_TMP/status"
+    export KAPSIS_STATUS_ENABLED="true"
+    mkdir -p "$KAPSIS_STATUS_DIR"
+
+    # Re-source modules so each test starts with defaults
+    unset _KAPSIS_STATUS_LOADED _KAPSIS_EXEC_CHANNEL_WATCHDOG_LOADED
+    # shellcheck source=/dev/null
+    source "$LIB_DIR/status.sh"
+
+    # Quiet logging stubs (sourced first so exec-channel-watchdog.sh's
+    # `declare -f` guards leave them untouched).
+    log_warn()  { :; }
+    log_debug() { :; }
+    log_info()  { :; }
+    # Force macOS path so the watchdog body runs on Linux CI.
+    is_macos()  { return 0; }
+    is_linux()  { return 1; }
+
+    # shellcheck source=/dev/null
+    source "$LIB_DIR/exec-channel-watchdog.sh"
+
+    status_init "test-project" "${TEST_AGENT_ID:-exec-test-1}" "test-branch" "worktree" "$TEST_TMP/wt"
+}
+
+_teardown_test_env() {
+    if [[ -n "${TEST_CHILD_PIDS:-}" ]]; then
+        local pid
+        for pid in $TEST_CHILD_PIDS; do
+            kill "$pid" 2>/dev/null || true
+            wait "$pid" 2>/dev/null || true
+        done
+        TEST_CHILD_PIDS=""
+    fi
+    [[ -n "${TEST_TMP:-}" ]] && rm -rf "$TEST_TMP"
+    if [[ -n "${SAVED_PATH:-}" ]]; then
+        export PATH="$SAVED_PATH"
+        SAVED_PATH=""
+    fi
+    return 0
+}
+
+#-------------------------------------------------------------------------------
+# Helper: install a fake `podman`, `timeout`, and `pkill` on PATH.
+#
+# - `podman exec ... true` reads $FAKE_PODMAN_EXEC_MODE:
+#     "hang"     — sleep 60 (will be killed by the fake `timeout`)
+#     "ok"       — exit 0
+#     "transient"— a file at $TEST_TMP/podman-fail-once toggles: present
+#                  means this call fails once and removes the file, so the
+#                  next call succeeds. Used to verify counter reset.
+# - `timeout` is a real "kill after N seconds" stub (cheap, no GNU coreutils
+#   dependency on macOS CI).
+# - `pkill` records argv for assertion.
+#-------------------------------------------------------------------------------
+_install_fakes() {
+    local fake_bin="$TEST_TMP/bin"
+    mkdir -p "$fake_bin"
+
+    cat > "$fake_bin/podman" <<EOF
+#!/usr/bin/env bash
+# Only intercept "exec <ctr> true" — anything else is unexpected in tests.
+if [[ "\$1" == "exec" && "\$3" == "true" ]]; then
+    case "\${FAKE_PODMAN_EXEC_MODE:-ok}" in
+        hang)
+            sleep 60
+            ;;
+        ok)
+            exit 0
+            ;;
+        transient)
+            if [[ -f "$TEST_TMP/podman-fail-once" ]]; then
+                rm -f "$TEST_TMP/podman-fail-once"
+                sleep 60
+            else
+                exit 0
+            fi
+            ;;
+        *)
+            exit 0
+            ;;
+    esac
+fi
+exit 0
+EOF
+
+    # Tiny `timeout` shim: spawns child in background and kills it after N seconds.
+    # Returns 124 on timeout (GNU semantics) so the watchdog's counter behavior matches prod.
+    cat > "$fake_bin/timeout" <<'EOF'
+#!/usr/bin/env bash
+duration="$1"; shift
+"$@" &
+child_pid=$!
+( sleep "$duration"; kill -KILL "$child_pid" 2>/dev/null ) &
+killer_pid=$!
+if wait "$child_pid" 2>/dev/null; then
+    rc=$?
+    kill "$killer_pid" 2>/dev/null
+    wait "$killer_pid" 2>/dev/null
+    exit "$rc"
+else
+    rc=$?
+    kill "$killer_pid" 2>/dev/null
+    wait "$killer_pid" 2>/dev/null
+    # 137 (128+9) when killed by SIGKILL -> map to 124 (timeout semantics)
+    if [[ "$rc" == "137" ]]; then exit 124; fi
+    exit "$rc"
+fi
+EOF
+
+    cat > "$fake_bin/pkill" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$@" > "$TEST_TMP/pkill.argv"
+exit 0
+EOF
+
+    chmod +x "$fake_bin/podman" "$fake_bin/timeout" "$fake_bin/pkill"
+    SAVED_PATH="$PATH"
+    export PATH="$fake_bin:$PATH"
+}
+
+#===============================================================================
+# Core: watchdog fires after N consecutive probe timeouts
+#===============================================================================
+
+test_watchdog_fires_after_threshold() {
+    log_test "Watchdog fires (status.json + sentinel + pkill) after N consecutive exec timeouts"
+    TEST_AGENT_ID="exec-fire-1"
+    _setup_test_env
+    FAKE_PODMAN_EXEC_MODE=hang _install_fakes
+
+    local sentinel="$TEST_TMP/exec-hang-fired"
+    # Tight knobs for a fast test: 1s interval, 1s timeout, threshold 2 → ~2-3s to fire.
+    export FAKE_PODMAN_EXEC_MODE=hang
+    start_exec_channel_watchdog "$TEST_AGENT_ID" "" "1" "1" "2" "$sentinel"
+    local watchdog_pid="$_EXEC_CHANNEL_WATCHDOG_PID"
+    [[ -n "$watchdog_pid" ]] || { log_test "FAIL: watchdog did not start"; _teardown_test_env; return 1; }
+
+    # Wait for watchdog to fire and exit on its own. Generous upper bound
+    # (10s) for slow CI; with threshold=2, interval=1, timeout=1, expected
+    # ~2-4s.
+    local waited=0
+    while kill -0 "$watchdog_pid" 2>/dev/null && (( waited < 10 )); do
+        sleep 1
+        waited=$((waited + 1))
+    done
+    wait "$watchdog_pid" 2>/dev/null || true
+
+    local status_file="$KAPSIS_STATUS_DIR/kapsis-test-project-$TEST_AGENT_ID.json"
+    assert_file_exists "$status_file" "status.json must be written by the watchdog"
+    local content
+    content=$(<"$status_file")
+    assert_contains "$content" '"exit_code": 4' "status.json must carry exit_code=4"
+    assert_contains "$content" '"error_type": "exec_channel_hang"' "status.json must carry error_type=exec_channel_hang"
+    assert_contains "$content" "exec channel" "status message must mention exec channel for diagnostic clarity"
+    assert_contains "$content" "host-side watchdog" "status message must identify the watchdog as the source"
+    assert_file_exists "$sentinel" "host-only sentinel must be touched by the watchdog"
+
+    assert_file_exists "$TEST_TMP/pkill.argv" "pkill must be invoked by the watchdog"
+    local argv
+    argv=$(<"$TEST_TMP/pkill.argv")
+    assert_contains "$argv" "-TERM" "pkill must use -TERM (graceful)"
+    assert_contains "$argv" "-f" "pkill must use -f to match full command line"
+    assert_contains "$argv" "kapsis-${TEST_AGENT_ID}" "pkill pattern must contain the agent-scoped container name"
+    assert_contains "$argv" "podman run" "pkill pattern must be anchored to 'podman run'"
+    assert_not_contains "$argv" '\b' "pkill pattern must NOT use \\b (unsupported by macOS BSD pkill)"
+    assert_contains "$argv" '[^a-zA-Z0-9_-]' "pkill pattern must use the portable character-class boundary"
+    _teardown_test_env
+}
+
+#===============================================================================
+# Counter-reset: a recovered probe must not accumulate toward threshold
+#===============================================================================
+
+test_watchdog_does_not_fire_on_transient_failure() {
+    log_test "Single transient failure that recovers does NOT fire the watchdog"
+    TEST_AGENT_ID="exec-transient-2"
+    _setup_test_env
+    _install_fakes
+    # Tell fake podman: first call hangs, then succeeds on every subsequent call.
+    : > "$TEST_TMP/podman-fail-once"
+    export FAKE_PODMAN_EXEC_MODE=transient
+
+    local sentinel="$TEST_TMP/exec-hang-fired"
+    # threshold=3: a single failure should leave failures=1, then a success
+    # resets to 0. After a few more cycles the watchdog must still be alive
+    # with no sentinel.
+    start_exec_channel_watchdog "$TEST_AGENT_ID" "" "1" "1" "3" "$sentinel"
+    local watchdog_pid="$_EXEC_CHANNEL_WATCHDOG_PID"
+    [[ -n "$watchdog_pid" ]] || { log_test "FAIL: watchdog did not start"; _teardown_test_env; return 1; }
+
+    # Give the watchdog ~6s — long enough for ~5 cycles (one fail, several
+    # successes), well past where 3 consecutive failures would have fired.
+    sleep 6
+
+    # Watchdog must still be alive (no firing happened).
+    if ! kill -0 "$watchdog_pid" 2>/dev/null; then
+        kill "$watchdog_pid" 2>/dev/null || true
+        log_test "FAIL: watchdog fired on transient failure (should have recovered)"
+        _teardown_test_env
+        return 1
+    fi
+
+    # Clean shutdown — kill watchdog and confirm no firing artifacts.
+    kill "$watchdog_pid" 2>/dev/null || true
+    wait "$watchdog_pid" 2>/dev/null || true
+
+    [[ ! -f "$sentinel" ]]
+    assert_equals "0" "$?" "sentinel must NOT exist after transient-only failure"
+    [[ ! -f "$TEST_TMP/pkill.argv" ]]
+    assert_equals "0" "$?" "pkill must NOT have been invoked after transient-only failure"
+    _teardown_test_env
+}
+
+#===============================================================================
+# Cleanup: killing the watchdog before threshold leaves state untouched
+#===============================================================================
+
+test_watchdog_killed_early_does_not_fire() {
+    log_test "Watchdog killed before threshold does NOT touch sentinel/status.json/pkill"
+    TEST_AGENT_ID="exec-cleanup-3"
+    _setup_test_env
+    FAKE_PODMAN_EXEC_MODE=hang _install_fakes
+    export FAKE_PODMAN_EXEC_MODE=hang
+
+    local sentinel="$TEST_TMP/exec-hang-fired"
+    # threshold=10 ensures we have time to kill before it fires.
+    start_exec_channel_watchdog "$TEST_AGENT_ID" "" "1" "1" "10" "$sentinel"
+    local watchdog_pid="$_EXEC_CHANNEL_WATCHDOG_PID"
+
+    sleep 1
+    kill "$watchdog_pid" 2>/dev/null || true
+    wait "$watchdog_pid" 2>/dev/null || true
+
+    local status_file="$KAPSIS_STATUS_DIR/kapsis-test-project-$TEST_AGENT_ID.json"
+    assert_file_exists "$status_file" "status.json from status_init must exist"
+    local content
+    content=$(<"$status_file")
+    assert_not_contains "$content" '"exit_code": 4' "status.json must NOT carry exit_code=4 when watchdog was killed early"
+    assert_not_contains "$content" '"error_type": "exec_channel_hang"' "status.json must NOT carry exec_channel_hang when watchdog was killed early"
+    [[ ! -f "$sentinel" ]]
+    assert_equals "0" "$?" "sentinel file must NOT exist when watchdog was killed early"
+    [[ ! -f "$TEST_TMP/pkill.argv" ]]
+    assert_equals "0" "$?" "pkill must NOT have been invoked when watchdog was killed early"
+    _teardown_test_env
+}
+
+#===============================================================================
+# Skip paths: invalid inputs do not crash and do not start a watchdog
+#===============================================================================
+
+test_watchdog_skipped_when_disabled() {
+    log_test "Watchdog skipped when KAPSIS_EXEC_WATCHDOG_ENABLED=false"
+    TEST_AGENT_ID="exec-skip-4"
+    _setup_test_env
+    _install_fakes
+    KAPSIS_EXEC_WATCHDOG_ENABLED=false start_exec_channel_watchdog "$TEST_AGENT_ID"
+    assert_equals "" "${_EXEC_CHANNEL_WATCHDOG_PID:-}" "no watchdog PID must be set when disabled"
+    _teardown_test_env
+}
+
+test_watchdog_skipped_when_agent_id_invalid() {
+    log_test "Watchdog skipped on malformed AGENT_ID"
+    _setup_test_env
+    _install_fakes
+    start_exec_channel_watchdog 'agent;rm -rf /'
+    assert_equals "" "${_EXEC_CHANNEL_WATCHDOG_PID:-}" "watchdog must refuse an AGENT_ID containing shell metacharacters"
+    _teardown_test_env
+}
+
+test_watchdog_skipped_when_container_name_invalid() {
+    log_test "Watchdog skipped on malformed container_name (defense in depth)"
+    TEST_AGENT_ID="exec-skip-5"
+    _setup_test_env
+    _install_fakes
+    start_exec_channel_watchdog "$TEST_AGENT_ID" 'ctr;evil'
+    assert_equals "" "${_EXEC_CHANNEL_WATCHDOG_PID:-}" "watchdog must refuse a container name containing shell metacharacters"
+    _teardown_test_env
+}
+
+test_watchdog_invalid_timing_uses_defaults() {
+    log_test "Watchdog falls back to default timing on malformed interval/timeout/threshold"
+    TEST_AGENT_ID="exec-skip-6"
+    _setup_test_env
+    _install_fakes
+    # Force ok mode so the watchdog stays alive (we'll kill it immediately)
+    export FAKE_PODMAN_EXEC_MODE=ok
+    # Pass garbage for all three timing knobs.
+    start_exec_channel_watchdog "$TEST_AGENT_ID" "" "not-a-number" "also-garbage" "negative-1"
+    local watchdog_pid="$_EXEC_CHANNEL_WATCHDOG_PID"
+    [[ -n "$watchdog_pid" ]] || { log_test "FAIL: watchdog should accept garbage and use defaults"; _teardown_test_env; return 1; }
+    kill "$watchdog_pid" 2>/dev/null || true
+    wait "$watchdog_pid" 2>/dev/null || true
+    _teardown_test_env
+}
+
+#===============================================================================
+# Post-container exit-code override (mirrors launch-agent.sh override block)
+#
+# The override block at scripts/launch-agent.sh requires THREE conditions:
+#   1. EXIT_CODE != 0
+#   2. exec-hang sentinel exists on the HOST (NOT bind-mounted, forgery-proof)
+#   3. _VFKIT_FIRED_SENTINEL is NOT present (vfkit override has priority)
+#===============================================================================
+
+_simulate_override() {
+    local EXIT_CODE="$1"
+    local status_file="$2"
+    local exec_sentinel="${3:-}"
+    local vfkit_sentinel="${4:-}"
+
+    if [[ "$EXIT_CODE" -ne 0 ]] \
+       && [[ -n "$exec_sentinel" && -f "$exec_sentinel" ]] \
+       && [[ ! -f "${vfkit_sentinel:-/dev/null}" ]]; then
+        # Status.json is defense-in-depth; sentinel is the trust anchor.
+        EXIT_CODE=4
+    fi
+    echo "$EXIT_CODE"
+}
+
+test_override_upgrades_signal_exit_to_4() {
+    log_test "Override upgrades signal exit (143) to 4 when exec-hang sentinel + status.json exec_channel_hang"
+    TEST_AGENT_ID="exec-override-7"
+    _setup_test_env
+    status_set_error_type "exec_channel_hang"
+    status_complete 4 "test fixture"
+    local status_file="$KAPSIS_STATUS_DIR/kapsis-test-project-$TEST_AGENT_ID.json"
+    local sentinel="$TEST_TMP/exec-hang-fired"
+    : > "$sentinel"
+    local result
+    result=$(_simulate_override 143 "$status_file" "$sentinel" "")
+    assert_equals "4" "$result" "EXIT_CODE 143 must be upgraded to 4 when exec-hang sentinel + status.json"
+    _teardown_test_env
+}
+
+test_override_preserves_exit_0() {
+    log_test "Override preserves EXIT_CODE 0 (security: legitimate completion before exec channel wedged)"
+    TEST_AGENT_ID="exec-override-8"
+    _setup_test_env
+    status_set_error_type "exec_channel_hang"
+    status_complete 4 "test fixture"
+    local status_file="$KAPSIS_STATUS_DIR/kapsis-test-project-$TEST_AGENT_ID.json"
+    local sentinel="$TEST_TMP/exec-hang-fired"
+    : > "$sentinel"
+    local result
+    result=$(_simulate_override 0 "$status_file" "$sentinel" "")
+    assert_equals "0" "$result" "EXIT_CODE 0 must NOT be silently upgraded to 4"
+    _teardown_test_env
+}
+
+test_override_yields_to_vfkit_when_both_fired() {
+    log_test "Override yields to vfkit when BOTH sentinels exist (vfkit has more specific diagnosis)"
+    TEST_AGENT_ID="exec-override-9"
+    _setup_test_env
+    local status_file="$KAPSIS_STATUS_DIR/kapsis-test-project-$TEST_AGENT_ID.json"
+    local exec_sentinel="$TEST_TMP/exec-hang-fired"
+    local vfkit_sentinel="$TEST_TMP/vfkit-fired"
+    : > "$exec_sentinel"
+    : > "$vfkit_sentinel"
+    # The exec override is the one being tested here — and it must NOT fire
+    # when vfkit also fired (vfkit override would have already upgraded to 4
+    # and set the more specific error_type=mount_failure).
+    local result
+    result=$(_simulate_override 1 "$status_file" "$exec_sentinel" "$vfkit_sentinel")
+    assert_equals "1" "$result" "Exec override must yield to vfkit override when both sentinels fired"
+    _teardown_test_env
+}
+
+test_override_does_not_fire_without_sentinel() {
+    log_test "Override does NOT fire when status.json reports exec_channel_hang but no host sentinel (forgery resistance)"
+    TEST_AGENT_ID="exec-override-10"
+    _setup_test_env
+    status_set_error_type "exec_channel_hang"
+    status_complete 4 "FORGED by container"
+    local status_file="$KAPSIS_STATUS_DIR/kapsis-test-project-$TEST_AGENT_ID.json"
+    # Note: no sentinel file at $TEST_TMP/exec-hang-fired
+    local sentinel="$TEST_TMP/exec-hang-fired-nonexistent"
+    local result
+    result=$(_simulate_override 1 "$status_file" "$sentinel" "")
+    assert_equals "1" "$result" "EXIT_CODE must NOT be upgraded to 4 from forged status.json without host sentinel"
+    _teardown_test_env
+}
+
+test_override_does_not_fire_with_empty_sentinel_arg() {
+    log_test "Override does NOT fire when sentinel arg is empty (watchdog disabled)"
+    TEST_AGENT_ID="exec-override-11"
+    _setup_test_env
+    status_set_error_type "exec_channel_hang"
+    status_complete 4 "test"
+    local status_file="$KAPSIS_STATUS_DIR/kapsis-test-project-$TEST_AGENT_ID.json"
+    local result
+    result=$(_simulate_override 1 "$status_file" "" "")
+    assert_equals "1" "$result" "EXIT_CODE must remain 1 when watchdog never fired"
+    _teardown_test_env
+}
+
+#===============================================================================
+# MAIN
+#===============================================================================
+
+main() {
+    print_test_header "exec-channel Watchdog (Issue #382)"
+
+    log_info "=== Watchdog core behavior ==="
+    run_test test_watchdog_fires_after_threshold
+    run_test test_watchdog_does_not_fire_on_transient_failure
+    run_test test_watchdog_killed_early_does_not_fire
+
+    log_info "=== Skip paths (input validation) ==="
+    run_test test_watchdog_skipped_when_disabled
+    run_test test_watchdog_skipped_when_agent_id_invalid
+    run_test test_watchdog_skipped_when_container_name_invalid
+    run_test test_watchdog_invalid_timing_uses_defaults
+
+    log_info "=== Post-container exit-code override ==="
+    run_test test_override_upgrades_signal_exit_to_4
+    run_test test_override_preserves_exit_0
+    run_test test_override_yields_to_vfkit_when_both_fired
+    run_test test_override_does_not_fire_without_sentinel
+    run_test test_override_does_not_fire_with_empty_sentinel_arg
+
+    print_summary
+}
+
+main "$@"

--- a/tests/test-exec-channel-watchdog.sh
+++ b/tests/test-exec-channel-watchdog.sh
@@ -288,6 +288,89 @@ test_watchdog_killed_early_does_not_fire() {
 }
 
 #===============================================================================
+# Orphan protection: when the parent shell ($$) is gone, the watchdog must
+# exit silently without firing — otherwise a stale watchdog could SIGTERM
+# a future agent that reuses the same AGENT_ID via --agent-id resume.
+#===============================================================================
+
+test_watchdog_exits_silently_when_parent_dies() {
+    log_test "Watchdog exits without firing when parent shell PID is reaped (orphan protection)"
+    TEST_AGENT_ID="exec-orphan-X"
+    _setup_test_env
+    _install_fakes
+    # Hang mode: every probe would normally accumulate failures. The orphan
+    # check must take precedence so the watchdog never reaches threshold.
+    export FAKE_PODMAN_EXEC_MODE=hang
+
+    local sentinel="$TEST_TMP/exec-hang-fired"
+    local pid_file="$TEST_TMP/orphan-watchdog-pid"
+
+    # Spawn a child bash so the watchdog's parent_pid=$$ captures that child's
+    # PID, NOT this test script's PID. When the child bash exits and is
+    # reaped (implicitly by waiting on the foreground command), its PID is
+    # gone from the process table — the watchdog's next
+    # `kill -0 $parent_pid` check will fail and the watchdog must exit
+    # without firing. Values are passed via env to avoid nested-quote
+    # gymnastics in the inline script.
+    PATH="$PATH" TEST_TMP="$TEST_TMP" \
+        KAPSIS_STATUS_DIR="$KAPSIS_STATUS_DIR" \
+        EXEC_ORPHAN_AGENT_ID="$TEST_AGENT_ID" \
+        EXEC_ORPHAN_SENTINEL="$sentinel" \
+        EXEC_ORPHAN_PID_FILE="$pid_file" \
+        LIB_DIR="$LIB_DIR" \
+        bash -c '
+            unset _KAPSIS_STATUS_LOADED _KAPSIS_EXEC_CHANNEL_WATCHDOG_LOADED
+            # shellcheck source=/dev/null
+            source "$LIB_DIR/status.sh"
+            log_warn()  { :; }
+            log_debug() { :; }
+            log_info()  { :; }
+            is_macos()  { return 0; }
+            # shellcheck source=/dev/null
+            source "$LIB_DIR/exec-channel-watchdog.sh"
+            status_init "test-project" "$EXEC_ORPHAN_AGENT_ID" "test-branch" "worktree" "$TEST_TMP/wt" >/dev/null
+            # Tight knobs: interval=1, timeout=1, threshold=10 — large enough
+            # that threshold would never be reached within our wait window
+            # if the orphan check failed; small enough that the watchdog
+            # checks the parent on every tick.
+            start_exec_channel_watchdog "$EXEC_ORPHAN_AGENT_ID" "" "1" "1" "10" "$EXEC_ORPHAN_SENTINEL"
+            printf "%s" "$_EXEC_CHANNEL_WATCHDOG_PID" > "$EXEC_ORPHAN_PID_FILE"
+            exit 0
+        '
+
+    local watchdog_pid=""
+    [[ -f "$pid_file" ]] && watchdog_pid=$(cat "$pid_file" 2>/dev/null || true)
+    if [[ -z "$watchdog_pid" ]]; then
+        log_test "FAIL: orphan watchdog never reported its PID"
+        _teardown_test_env
+        return 1
+    fi
+
+    # Wait up to 8s for the orphaned watchdog to detect the parent's death
+    # and exit. With interval=1 and the orphan check happening at the top
+    # of every loop iteration, this should complete within 1-2 ticks.
+    local waited=0
+    while kill -0 "$watchdog_pid" 2>/dev/null && (( waited < 8 )); do
+        sleep 1
+        waited=$((waited + 1))
+    done
+
+    if kill -0 "$watchdog_pid" 2>/dev/null; then
+        # Best-effort cleanup so the test framework doesn't leak processes.
+        kill "$watchdog_pid" 2>/dev/null || true
+        log_test "FAIL: watchdog did not exit after parent died (orphan protection broken)"
+        _teardown_test_env
+        return 1
+    fi
+
+    [[ ! -f "$sentinel" ]]
+    assert_equals "0" "$?" "sentinel must NOT exist — orphan watchdog must exit without firing"
+    [[ ! -f "$TEST_TMP/pkill.argv" ]]
+    assert_equals "0" "$?" "pkill must NOT have been invoked — orphan watchdog must exit without firing"
+    _teardown_test_env
+}
+
+#===============================================================================
 # Skip paths: invalid inputs do not crash and do not start a watchdog
 #===============================================================================
 
@@ -339,29 +422,73 @@ test_watchdog_invalid_timing_uses_defaults() {
 #===============================================================================
 # Post-container exit-code override (mirrors launch-agent.sh override block)
 #
-# The override block at scripts/launch-agent.sh requires THREE conditions:
+# The production override block at scripts/launch-agent.sh requires:
 #   1. EXIT_CODE != 0
 #   2. exec-hang sentinel exists on the HOST (NOT bind-mounted, forgery-proof)
-#   3. _VFKIT_FIRED_SENTINEL is NOT present (vfkit override has priority)
+#   3. _KAPSIS_VFKIT_HANG_DETECTED boolean is not "true" (vfkit takes priority)
+# Then it reads status.json and branches:
+#   confirmed path: status.json has exit_code=4 + error_type=exec_channel_hang
+#   fallback path:  sentinel present but status.json mismatch (status_complete
+#                   failed inside the watchdog subshell, e.g. disk full)
+# Both branches upgrade EXIT_CODE to 4 and set _KAPSIS_EXEC_HANG_DETECTED=true
+# — the sentinel is the host-trusted authority; status.json is defense in
+# depth, used only to distinguish the log message.
+#
+# This helper reproduces that logic faithfully so tests catch drift between
+# the simulator and the production override. The branch label is written to
+# $TEST_TMP/last-override-branch so tests called via $(_simulate_override ...)
+# can read it back across the subshell boundary (the var alone wouldn't
+# survive a command-substitution subshell).
 #===============================================================================
 
 _simulate_override() {
     local EXIT_CODE="$1"
     local status_file="$2"
     local exec_sentinel="${3:-}"
-    local vfkit_sentinel="${4:-}"
+    # 4th arg is the boolean _KAPSIS_VFKIT_HANG_DETECTED state. Pass "true" to
+    # simulate vfkit having fired; anything else (default "false") simulates
+    # vfkit did not fire.
+    local vfkit_hang_detected="${4:-false}"
+    local branch="no-fire"
 
     if [[ "$EXIT_CODE" -ne 0 ]] \
        && [[ -n "$exec_sentinel" && -f "$exec_sentinel" ]] \
-       && [[ ! -f "${vfkit_sentinel:-/dev/null}" ]]; then
-        # Status.json is defense-in-depth; sentinel is the trust anchor.
+       && [[ "$vfkit_hang_detected" != "true" ]]; then
+        # Read status.json defensively — both branches upgrade EXIT_CODE, but
+        # the branch label differentiates confirmed-by-status-json from the
+        # sentinel-only fallback. This mirrors the production override.
+        local status_exit_exec status_err_exec
+        status_exit_exec=""
+        status_err_exec=""
+        if [[ -f "$status_file" ]]; then
+            local content
+            content=$(<"$status_file")
+            if [[ "$content" =~ \"exit_code\":\ *([0-9]+) ]]; then
+                status_exit_exec="${BASH_REMATCH[1]}"
+            fi
+            if grep -Eq '"error_type":[[:space:]]*"exec_channel_hang"' "$status_file" 2>/dev/null; then
+                status_err_exec="exec_channel_hang"
+            fi
+        fi
+        if [[ "$status_exit_exec" == "4" && "$status_err_exec" == "exec_channel_hang" ]]; then
+            branch="confirmed"
+        else
+            branch="fallback"
+        fi
         EXIT_CODE=4
     fi
+    # Persist branch label so callers using $(...) can read it back.
+    [[ -n "${TEST_TMP:-}" ]] && printf '%s' "$branch" > "$TEST_TMP/last-override-branch"
     echo "$EXIT_CODE"
 }
 
+# Read the branch label set by the most recent _simulate_override call.
+_last_override_branch() {
+    [[ -f "$TEST_TMP/last-override-branch" ]] && cat "$TEST_TMP/last-override-branch" || echo "(unset)"
+}
+
 test_override_upgrades_signal_exit_to_4() {
-    log_test "Override upgrades signal exit (143) to 4 when exec-hang sentinel + status.json exec_channel_hang"
+    log_test "Override upgrades signal exit (143) to 4 via 'confirmed' branch when sentinel + status.json exec_channel_hang"
     TEST_AGENT_ID="exec-override-7"
     _setup_test_env
     status_set_error_type "exec_channel_hang"
@@ -370,8 +497,9 @@ test_override_upgrades_signal_exit_to_4() {
     local sentinel="$TEST_TMP/exec-hang-fired"
     : > "$sentinel"
     local result
-    result=$(_simulate_override 143 "$status_file" "$sentinel" "")
+    result=$(_simulate_override 143 "$status_file" "$sentinel" "false")
     assert_equals "4" "$result" "EXIT_CODE 143 must be upgraded to 4 when exec-hang sentinel + status.json"
+    assert_equals "confirmed" "$(_last_override_branch)" "Branch must be 'confirmed' when status.json carries exec_channel_hang"
     _teardown_test_env
 }
 
@@ -385,26 +513,27 @@ test_override_preserves_exit_0() {
     local sentinel="$TEST_TMP/exec-hang-fired"
     : > "$sentinel"
     local result
-    result=$(_simulate_override 0 "$status_file" "$sentinel" "")
+    result=$(_simulate_override 0 "$status_file" "$sentinel" "false")
     assert_equals "0" "$result" "EXIT_CODE 0 must NOT be silently upgraded to 4"
+    assert_equals "no-fire" "$(_last_override_branch)" "Branch must be 'no-fire' for exit 0"
     _teardown_test_env
 }
 
-test_override_yields_to_vfkit_when_both_fired() {
-    log_test "Override yields to vfkit when BOTH sentinels exist (vfkit has more specific diagnosis)"
+test_override_yields_to_vfkit_when_vfkit_hang_detected() {
+    log_test "Override yields to vfkit when _KAPSIS_VFKIT_HANG_DETECTED is true (vfkit has more specific diagnosis)"
     TEST_AGENT_ID="exec-override-9"
     _setup_test_env
     local status_file="$KAPSIS_STATUS_DIR/kapsis-test-project-$TEST_AGENT_ID.json"
     local exec_sentinel="$TEST_TMP/exec-hang-fired"
-    local vfkit_sentinel="$TEST_TMP/vfkit-fired"
     : > "$exec_sentinel"
-    : > "$vfkit_sentinel"
-    # The exec override is the one being tested here — and it must NOT fire
-    # when vfkit also fired (vfkit override would have already upgraded to 4
-    # and set the more specific error_type=mount_failure).
+    # Exec sentinel exists, but vfkit override already ran and set the
+    # _KAPSIS_VFKIT_HANG_DETECTED boolean. The yield guards on the boolean
+    # (not on the vfkit sentinel file) so the cleanup trap deleting the
+    # sentinel before this block runs cannot cause an incorrect override.
     local result
-    result=$(_simulate_override 1 "$status_file" "$exec_sentinel" "$vfkit_sentinel")
-    assert_equals "1" "$result" "Exec override must yield to vfkit override when both sentinels fired"
+    result=$(_simulate_override 1 "$status_file" "$exec_sentinel" "true")
+    assert_equals "1" "$result" "Exec override must yield when _KAPSIS_VFKIT_HANG_DETECTED=true"
+    assert_equals "no-fire" "$(_last_override_branch)" "Branch must be 'no-fire' when yielding to vfkit"
     _teardown_test_env
 }
 
@@ -418,8 +547,9 @@ test_override_does_not_fire_without_sentinel() {
     # Note: no sentinel file at $TEST_TMP/exec-hang-fired
     local sentinel="$TEST_TMP/exec-hang-fired-nonexistent"
     local result
-    result=$(_simulate_override 1 "$status_file" "$sentinel" "")
+    result=$(_simulate_override 1 "$status_file" "$sentinel" "false")
     assert_equals "1" "$result" "EXIT_CODE must NOT be upgraded to 4 from forged status.json without host sentinel"
+    assert_equals "no-fire" "$(_last_override_branch)" "Branch must be 'no-fire' when sentinel is missing"
     _teardown_test_env
 }
 
@@ -431,8 +561,59 @@ test_override_does_not_fire_with_empty_sentinel_arg() {
     status_complete 4 "test"
     local status_file="$KAPSIS_STATUS_DIR/kapsis-test-project-$TEST_AGENT_ID.json"
     local result
-    result=$(_simulate_override 1 "$status_file" "" "")
+    result=$(_simulate_override 1 "$status_file" "" "false")
     assert_equals "1" "$result" "EXIT_CODE must remain 1 when watchdog never fired"
+    assert_equals "no-fire" "$(_last_override_branch)" "Branch must be 'no-fire' when watchdog disabled"
+    _teardown_test_env
+}
+
+#-------------------------------------------------------------------------------
+# Sentinel-only fallback: sentinel is present but status.json was never written
+# with exec_channel_hang (e.g. disk full inside the watchdog subshell, or the
+# subshell was SIGTERMed mid-write between status_set_error_type and
+# status_complete). Override must still upgrade EXIT_CODE because the sentinel
+# is host-trusted. Mirrors test-vfkit-watchdog.sh::test_post_container_override_fires_with_sentinel_only.
+#-------------------------------------------------------------------------------
+test_override_fires_with_sentinel_only_when_status_missing() {
+    log_test "Override fires (fallback branch) when sentinel exists but status.json was never written (status_complete failure path)"
+    TEST_AGENT_ID="exec-override-12"
+    _setup_test_env
+    # Don't write any status — simulate status_complete having failed inside
+    # the watchdog subshell (e.g. disk full or SIGTERM mid-write).
+    local status_file="$KAPSIS_STATUS_DIR/kapsis-test-project-$TEST_AGENT_ID.json"
+    rm -f "$status_file"
+    local sentinel="$TEST_TMP/exec-hang-fired"
+    : > "$sentinel"
+    local result
+    result=$(_simulate_override 1 "$status_file" "$sentinel" "false")
+    assert_equals "4" "$result" "EXIT_CODE must upgrade to 4 on sentinel alone (host-trusted, status_complete may have failed)"
+    assert_equals "fallback" "$(_last_override_branch)" "Branch must be 'fallback' when status.json is missing"
+    _teardown_test_env
+}
+
+#-------------------------------------------------------------------------------
+# Sentinel-only fallback variant: sentinel exists AND status.json exists, but
+# status.json carries the wrong error_type (e.g. mount_failure leaked in from
+# an earlier vfkit fire that was then cleared, or the watchdog subshell wrote
+# the file but never reached the error_type update). The host sentinel still
+# wins. Exercises the production grep that the previous simpler stub omitted.
+#-------------------------------------------------------------------------------
+test_override_fires_with_sentinel_when_status_mismatch() {
+    log_test "Override fires (fallback branch) when sentinel exists but status.json carries a mismatched error_type"
+    TEST_AGENT_ID="exec-override-13"
+    _setup_test_env
+    # Write a DIFFERENT error_type into status.json so the grep for
+    # exec_channel_hang misses. This exercises the production grep that the
+    # previous simpler simulator omitted entirely.
+    status_set_error_type "mount_failure"
+    status_complete 4 "spurious vfkit-like leak"
+    local status_file="$KAPSIS_STATUS_DIR/kapsis-test-project-$TEST_AGENT_ID.json"
+    local sentinel="$TEST_TMP/exec-hang-fired"
+    : > "$sentinel"
+    local result
+    result=$(_simulate_override 1 "$status_file" "$sentinel" "false")
+    assert_equals "4" "$result" "EXIT_CODE must upgrade to 4 (sentinel trusted) even with status.json error_type mismatch"
+    assert_equals "fallback" "$(_last_override_branch)" "Branch must be 'fallback' when status.json error_type does not match"
     _teardown_test_env
 }
 
@@ -448,6 +629,9 @@ main() {
     run_test test_watchdog_does_not_fire_on_transient_failure
     run_test test_watchdog_killed_early_does_not_fire
 
+    log_info "=== Orphan protection ==="
+    run_test test_watchdog_exits_silently_when_parent_dies
+
     log_info "=== Skip paths (input validation) ==="
     run_test test_watchdog_skipped_when_disabled
     run_test test_watchdog_skipped_when_agent_id_invalid
@@ -457,9 +641,11 @@ main() {
     log_info "=== Post-container exit-code override ==="
     run_test test_override_upgrades_signal_exit_to_4
     run_test test_override_preserves_exit_0
-    run_test test_override_yields_to_vfkit_when_both_fired
+    run_test test_override_yields_to_vfkit_when_vfkit_hang_detected
     run_test test_override_does_not_fire_without_sentinel
     run_test test_override_does_not_fire_with_empty_sentinel_arg
+    run_test test_override_fires_with_sentinel_only_when_status_missing
+    run_test test_override_fires_with_sentinel_when_status_mismatch
 
     print_summary
 }


### PR DESCRIPTION
## Summary

Catches the silent-wedge mode that none of the existing defences detect (issue #382): vfkit alive, container reporting `Up`, but the in-VM podman daemon's exec channel hangs forever — `phase: running` until a human runs `podman machine stop`.

- New host-side watchdog `scripts/lib/exec-channel-watchdog.sh` probes every 30s with `timeout 5 podman exec <ctr> true`. After **3 consecutive failures (~90s blind window)** it:
  - touches a **host-only sentinel** under `$TMPDIR` (NOT bind-mounted — forgery-resistant, mirroring the vfkit sentinel),
  - writes `exit_code: 4` + `error_type: exec_channel_hang` to status.json,
  - SIGTERMs the agent's `podman run` via the same BSD-portable pkill boundary class the vfkit watchdog uses.

- `launch-agent.sh` sources, spawns, cleans up, and adds a post-container override that **yields to the vfkit watchdog when both fire**, so the more specific `mount_failure` error_type wins. The `EXIT_CODE=4` branch now switches the status message + error_type based on which sentinel fired, so the slack-bot / `--watch` UIs show the correct diagnosis.

- Knobs: `KAPSIS_EXEC_WATCHDOG_{ENABLED,INTERVAL,TIMEOUT,THRESHOLD}`.
- macOS-only; no-op on Linux (the FB16008360 / podman#23061 family is Apple Hypervisor specific).

## Design rationale

This is a **near-copy of the v2.24.0 vfkit watchdog (#303)** — same lifecycle, same trust model, same orphan/race protections. Specifically:

| Aspect | vfkit watchdog (#303) | exec-channel watchdog (#382) |
|---|---|---|
| What it watches | `kill -0 <vfkit_pid>` | `timeout 5 podman exec <ctr> true` |
| Detects | vfkit died → mounts gone | exec channel hung while vfkit alive |
| Poll interval | 5s | 30s (lighter touch; daemon-managed) |
| Failure trigger | 1 (PID gone) | 3 consecutive (transient daemon hiccups must not misfire) |
| Exit code | 4 | 4 (same — VM restart required) |
| `error_type` | `mount_failure` | `exec_channel_hang` (new) |
| Sentinel | `$TMPDIR/kapsis-<id>.vfkit-fired` | `$TMPDIR/kapsis-<id>.exec-hang-fired` |

The `exec_channel_hang` error_type is distinct from `mount_failure` so ops can differentiate the two symptom families in audit logs and so the user message accurately describes the failure mode (`Container exec channel wedged (podman daemon hang while vfkit alive)` vs `Workspace mount lost (virtio-fs drop)`).

## Test plan

- [x] `./tests/test-exec-channel-watchdog.sh` — **12/12 pass** locally (Linux CI path with `is_macos` forced true; fake `podman`/`timeout`/`pkill` on PATH).
- [x] `./tests/test-vfkit-watchdog.sh` — **15/15 pass**, unchanged.
- [x] `bash -n` syntax check on all touched scripts.
- [x] shellcheck clean (no new diagnostics over the pre-existing SC1090/SC2329 patterns the repo already accepts).
- [ ] Manual macOS verification (open-loop): start an agent, send `SIGSTOP` to the in-VM podman socket to simulate a hang, confirm escalation within ~90s and status.json reports `error_type: exec_channel_hang`.

### Test cases covered

**Watchdog core:**
- Fires (status.json + sentinel + pkill) after N consecutive exec timeouts
- Does NOT fire on a single transient failure that recovers (counter reset semantics)
- Killing the watchdog before threshold leaves sentinel/status.json/pkill untouched

**Input validation (skip paths, no crash):**
- `KAPSIS_EXEC_WATCHDOG_ENABLED=false`
- Malformed AGENT_ID (shell metacharacters)
- Malformed container_name (defense in depth)
- Garbage timing knobs → fall back to documented defaults

**Post-container override (forgery resistance):**
- Upgrades signal exit (143) to 4 when exec-hang sentinel + status.json `exec_channel_hang`
- Preserves EXIT_CODE 0 (legitimate completion before exec channel wedged)
- **Yields to vfkit override when BOTH sentinels exist** (vfkit's `mount_failure` has more specific diagnosis)
- Does NOT fire from forged status.json without host sentinel
- Does NOT fire when watchdog arg is empty (disabled / Linux)

Closes #382.

🤖 Generated with [Claude Code](https://claude.com/claude-code)