### PR TITLE
fix(ci): disable Go module cache for stdlib-only kapsis-ctl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -630,8 +630,10 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: cmd/kapsis-ctl/go.mod
-          # No go.sum — stdlib-only module; Go tool cache is still useful
-          cache: true
+          # No go.sum — stdlib-only module. setup-go@v6 hard-fails the cache
+          # restore step when go.sum is missing, cancelling the CI run and the
+          # downstream Auto Release workflow. Re-enable once a go.sum exists.
+          cache: false
 
       - name: vet
         working-directory: cmd/kapsis-ctl


### PR DESCRIPTION
## Summary
- `setup-go@v6` hard-fails the cache restore step when `go.sum` is missing
- kapsis-ctl is stdlib-only and intentionally has no `go.sum`, so the cache step has been cancelling every CI run on `main`
- A cancelled CI is a `workflow_run` failure for Auto Release, so no releases have shipped since the kapsis-ctl Phase 1 merge

Failing step (e.g. run [26385578387](https://github.com/aviadshiber/kapsis/actions/runs/26385578387)):

```
Restore cache failed: Dependencies file is not found in /home/runner/work/kapsis/kapsis.
Supported file pattern: go.sum
```

Fix: set `cache: false` for the kapsis-ctl `setup-go` step. Re-enable when a `go.sum` exists.

## Test plan
- [ ] CI on this PR passes the `kapsis-ctl Build & Test` job (no cache-restore failure)
- [ ] After merge to `main`, the post-merge CI run completes (not cancelled)
- [ ] Auto Release fires on the post-merge run (no longer `skipped`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)