### PR TITLE
fix(cleanup): match localhost/ prefixed images in clean_images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+
+### Fixed
+- `kapsis-cleanup --images` now correctly matches `localhost/kapsis-*` images. Podman on macOS stores locally built images with a `localhost/` registry prefix; the previous `^kapsis-` grep pattern never matched those, so `--images` always found 0 images to remove.
+
 ## [2.28.9] - 2026-05-17
 
 ### Fixed

--- a/scripts/kapsis-cleanup.sh
+++ b/scripts/kapsis-cleanup.sh
@@ -717,7 +717,7 @@ clean_images() {
 
     # Get kapsis images (kapsis-sandbox, kapsis-claude-cli, etc.)
     local images
-    images=$(podman images --format "{{.Repository}}:{{.Tag}} {{.ID}} {{.Size}}" 2>/dev/null | grep -E "^kapsis-" || true)
+    images=$(podman images --format "{{.Repository}}:{{.Tag}} {{.ID}} {{.Size}}" 2>/dev/null | grep -E "(^|/)kapsis-" || true)
 
     if [[ -n "$images" ]]; then
         while IFS= read -r line; do

--- a/tests/test-volume-cleanup.sh
+++ b/tests/test-volume-cleanup.sh
@@ -116,6 +116,18 @@ test_clean_images_function_exists() {
     assert_contains "$content" "podman image prune" "Should prune dangling images"
 }
 
+test_cleanup_images_pattern_matches_localhost_prefix() {
+    log_test "Testing image pattern matches localhost/ prefixed repository names"
+
+    local content
+    content=$(cat "$CLEANUP_SCRIPT")
+
+    # Podman on macOS stores locally built images as localhost/kapsis-*:tag.
+    # grep -E "^kapsis-" never matches those — pattern must handle the prefix.
+    assert_contains "$content" 'grep -E "(^|/)kapsis-"' \
+        "Image grep should match both bare and localhost/ prefixed repos"
+}
+
 test_cleanup_keep_volumes_documented() {
     log_test "Testing --keep-volumes is documented in usage"
 
@@ -143,6 +155,7 @@ main() {
     run_test test_launch_has_cleanup_agent_volumes
     run_test test_launch_auto_cleanup_invocation
     run_test test_clean_images_function_exists
+    run_test test_cleanup_images_pattern_matches_localhost_prefix
     run_test test_cleanup_keep_volumes_documented
 
     print_summary


### PR DESCRIPTION
## Summary

- `kapsis-cleanup --images` was silently cleaning 0 images on macOS
- Root cause: `grep -E "^kapsis-"` does not match `localhost/kapsis-*:tag` — the format Podman uses for locally built images
- Fix: change pattern to `(^|/)kapsis-` which matches both bare and `localhost/`-prefixed repository names

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #191 follow-up — image cleanup was a no-op on macOS despite the feature being added in that issue.

## Changes Made

- `scripts/kapsis-cleanup.sh`: `grep -E "^kapsis-"` → `grep -E "(^ |/)kapsis-"` in `clean_images()`
- `tests/test-volume-cleanup.sh`: added `test_cleanup_images_pattern_matches_localhost_prefix` to assert the new pattern
- `CHANGELOG.md`: documented the fix under `[Unreleased]`

## Testing

All 11 tests in `test-volume-cleanup.sh` pass.

Verified with `kapsis-cleanup --images --dry-run` against a live Podman machine — the fixed binary correctly lists `localhost/kapsis-slack-bot:latest` and `localhost/kapsis-claude-cli:latest` as candidates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)