### PR TITLE
feat(git): resolve committer identity from --author / config / host

### DIFF
--- a/scripts/launch-agent.sh
+++ b/scripts/launch-agent.sh
@@ -271,10 +271,12 @@ Options:
   --security-profile <profile>
                         Security hardening: minimal, standard (default), strict, paranoid
   --co-author "Name <email>"
-                        Add a git Co-authored-by trailer (repeatable; merges with config)
+                        Append a git Co-authored-by: trailer on commits.
+                        Repeatable; merges with git.co_authors from config.
   --author "Name <email>"
-                        Override the committer identity for this run.
-                        Takes precedence over config git.co_authors and host git identity.
+                        Set the committer/author identity (the name shown in
+                        \`git log\`). Single value. Takes precedence over the
+                        first git.co_authors entry and the host git config.
   -h, --help            Show this help message
 
 Available Agents:
@@ -375,6 +377,19 @@ handle_global_flags() {
             exit $?
             ;;
     esac
+}
+
+# Validate "Name <email>" format for --author, --co-author, and YAML
+# git.co_authors entries. Tightened over the original (PR #416 security review):
+# - Name uses a literal-space separator (not [[:space:]]) so newlines/tabs
+#   are rejected outright.
+# - Email portion forbids ALL whitespace, preventing multi-line injection
+#   into the heredoc written by create_safe_git_config.
+# Returns 0 if valid, 1 otherwise.
+_KAPSIS_AUTHOR_FORMAT_REGEX='^[A-Za-z0-9.'"'"'\",_-]+( [A-Za-z0-9.'"'"'\",_-]+)* <[^>[:space:]]+@[^>[:space:]]+>$'
+validate_author_format() {
+    local value="$1"
+    [[ "$value" =~ $_KAPSIS_AUTHOR_FORMAT_REGEX ]]
 }
 
 parse_args() {
@@ -507,8 +522,7 @@ parse_args() {
                     log_error "--co-author requires an argument"
                     exit 1
                 fi
-                # Validate format: "Name <email>" — reject shell metacharacters in name
-                if [[ ! "$2" =~ ^[[:alnum:][:space:].\'\",_-]+\ \<[^\>]+@[^\>]+\>$ ]]; then
+                if ! validate_author_format "$2"; then
                     log_error "Invalid --co-author format (expected 'Name <email>'): $2"
                     exit 1
                 fi
@@ -520,7 +534,7 @@ parse_args() {
                     log_error "--author requires an argument"
                     exit 1
                 fi
-                if [[ ! "$2" =~ ^[[:alnum:][:space:].\'\",_-]+\ \<[^\>]+@[^\>]+\>$ ]]; then
+                if ! validate_author_format "$2"; then
                     log_error "Invalid --author format (expected 'Name <email>'): $2"
                     exit 1
                 fi
@@ -567,22 +581,32 @@ parse_args() {
 resolve_committer_identity() {
     KAPSIS_COMMITTER_NAME=""
     KAPSIS_COMMITTER_EMAIL=""
-    local source=""
+    local identity_source=""
     local raw=""
 
     if [[ -n "${CLI_AUTHOR:-}" ]]; then
         raw="$CLI_AUTHOR"
-        source="--author flag"
+        identity_source="--author flag"
     elif [[ -n "${GIT_CO_AUTHORS:-}" ]]; then
         raw="${GIT_CO_AUTHORS%%|*}"
-        source="config git.co_authors"
+        identity_source="config git.co_authors"
     fi
 
     if [[ -n "$raw" ]]; then
-        # Parse "Name <email>"
-        KAPSIS_COMMITTER_NAME="${raw% <*}"
-        KAPSIS_COMMITTER_EMAIL="${raw#*<}"
-        KAPSIS_COMMITTER_EMAIL="${KAPSIS_COMMITTER_EMAIL%>}"
+        # Re-validate the raw entry. CLI_AUTHOR was validated at parse time and
+        # GIT_CO_AUTHORS entries are filtered in parse_config, but cheap to recheck
+        # — guards against any future code path that bypasses those gates.
+        if validate_author_format "$raw"; then
+            # Parse "Name <email>". Both extractions only run on validated input,
+            # so they cannot produce an email with whitespace or angle brackets.
+            KAPSIS_COMMITTER_NAME="${raw% <*}"
+            KAPSIS_COMMITTER_EMAIL="${raw#*<}"
+            KAPSIS_COMMITTER_EMAIL="${KAPSIS_COMMITTER_EMAIL%>}"
+        else
+            log_warn "Committer source (${identity_source}) failed format validation; falling through"
+            KAPSIS_COMMITTER_NAME=""
+            KAPSIS_COMMITTER_EMAIL=""
+        fi
     fi
 
     if [[ -z "$KAPSIS_COMMITTER_NAME" || -z "$KAPSIS_COMMITTER_EMAIL" ]]; then
@@ -592,17 +616,17 @@ resolve_committer_identity() {
         if [[ -n "$host_name" && -n "$host_email" ]]; then
             KAPSIS_COMMITTER_NAME="$host_name"
             KAPSIS_COMMITTER_EMAIL="$host_email"
-            source="host git config"
+            identity_source="host git config"
         fi
     fi
 
     if [[ -z "$KAPSIS_COMMITTER_NAME" || -z "$KAPSIS_COMMITTER_EMAIL" ]]; then
         KAPSIS_COMMITTER_NAME="Kapsis Agent ${AGENT_ID}"
         KAPSIS_COMMITTER_EMAIL="kapsis-agent-${AGENT_ID}@localhost"
-        source="synthetic fallback"
+        identity_source="synthetic fallback"
     fi
 
-    log_info "Committer identity resolved from ${source}: ${KAPSIS_COMMITTER_NAME} <${KAPSIS_COMMITTER_EMAIL}>"
+    log_debug "Committer identity resolved from ${identity_source}: ${KAPSIS_COMMITTER_NAME} <${KAPSIS_COMMITTER_EMAIL}>"
 }
 
 #===============================================================================
@@ -893,8 +917,24 @@ parse_config() {
         GIT_REMOTE=$(yq -r '.git.auto_push.remote // "origin"' "$CONFIG_FILE")
         GIT_COMMIT_MSG=$(yq -r '.git.auto_push.commit_message // "feat: AI agent changes"' "$CONFIG_FILE")
 
-        # Parse co-authors (newline-separated list)
-        GIT_CO_AUTHORS=$(yq -r '.git.co_authors[]' "$CONFIG_FILE" 2>/dev/null | tr '\n' '|' | sed 's/|$//' || echo "")
+        # Parse co-authors (newline-separated list). Each entry is run through
+        # validate_author_format to block multi-line / shell-metachar injection
+        # via .kapsis/config.yaml (security review of PR #416). Invalid entries
+        # are dropped with a warning rather than failing the launch, so a
+        # single typo doesn't block the whole run.
+        GIT_CO_AUTHORS=""
+        while IFS= read -r _co_author_entry; do
+            [[ -z "$_co_author_entry" ]] && continue
+            if ! validate_author_format "$_co_author_entry"; then
+                log_warn "Skipping invalid git.co_authors entry (expected 'Name <email>'): $_co_author_entry"
+                continue
+            fi
+            if [[ -n "$GIT_CO_AUTHORS" ]]; then
+                GIT_CO_AUTHORS+="|$_co_author_entry"
+            else
+                GIT_CO_AUTHORS="$_co_author_entry"
+            fi
+        done < <(yq -r '.git.co_authors[]' "$CONFIG_FILE" 2>/dev/null || true)
 
         # Parse attribution templates (commit trailer + PR description).
         # A null/missing value yields the string "null" from yq -r; treat that as unset
@@ -3685,5 +3725,9 @@ post_container_overlay() {
     fi
 }
 
-# Run main
-main "$@"
+# Run main — but only when executed directly. When the script is sourced
+# (e.g. from a test that wants to call a single helper like
+# resolve_committer_identity or validate_author_format), skip the main flow.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/scripts/launch-agent.sh
+++ b/scripts/launch-agent.sh
@@ -101,6 +101,7 @@ FORCE_CLEAN=false      # Fix #1: Force remove existing worktree
 KEEP_WORKTREE="${KAPSIS_KEEP_WORKTREE:-false}"  # Fix #169: Preserve worktree after completion
 KEEP_VOLUMES="${KAPSIS_KEEP_VOLUMES:-false}"  # Fix #191: Preserve build cache volumes after completion
 CLI_CO_AUTHORS=()  # Co-authors added via --co-author CLI flag (merged with config)
+CLI_AUTHOR=""  # Committer identity override via --author CLI flag (Name <email>)
 INTERACTIVE=false
 DRY_RUN=false
 # Use KAPSIS_IMAGE env var if set (for CI), otherwise default
@@ -271,6 +272,9 @@ Options:
                         Security hardening: minimal, standard (default), strict, paranoid
   --co-author "Name <email>"
                         Add a git Co-authored-by trailer (repeatable; merges with config)
+  --author "Name <email>"
+                        Override the committer identity for this run.
+                        Takes precedence over config git.co_authors and host git identity.
   -h, --help            Show this help message
 
 Available Agents:
@@ -511,6 +515,18 @@ parse_args() {
                 CLI_CO_AUTHORS+=("$2")
                 shift 2
                 ;;
+            --author)
+                if [[ $# -lt 2 ]]; then
+                    log_error "--author requires an argument"
+                    exit 1
+                fi
+                if [[ ! "$2" =~ ^[[:alnum:][:space:].\'\",_-]+\ \<[^\>]+@[^\>]+\>$ ]]; then
+                    log_error "Invalid --author format (expected 'Name <email>'): $2"
+                    exit 1
+                fi
+                CLI_AUTHOR="$2"
+                shift 2
+                ;;
             -h|--help)
                 usage
                 ;;
@@ -537,6 +553,56 @@ parse_args() {
     # Reinitialize logging with agent-specific log file
     # This prevents log interleaving when running parallel agents
     log_reinit_with_agent_id "$AGENT_ID"
+}
+
+#===============================================================================
+# RESOLVE COMMITTER IDENTITY
+#
+# Sets KAPSIS_COMMITTER_NAME / KAPSIS_COMMITTER_EMAIL in precedence order:
+#   1. --author CLI flag (CLI_AUTHOR)
+#   2. First entry of git.co_authors (GIT_CO_AUTHORS, pipe-separated)
+#   3. Host git config user.name / user.email
+#   4. Synthetic "Kapsis Agent <id>" fallback
+#===============================================================================
+resolve_committer_identity() {
+    KAPSIS_COMMITTER_NAME=""
+    KAPSIS_COMMITTER_EMAIL=""
+    local source=""
+    local raw=""
+
+    if [[ -n "${CLI_AUTHOR:-}" ]]; then
+        raw="$CLI_AUTHOR"
+        source="--author flag"
+    elif [[ -n "${GIT_CO_AUTHORS:-}" ]]; then
+        raw="${GIT_CO_AUTHORS%%|*}"
+        source="config git.co_authors"
+    fi
+
+    if [[ -n "$raw" ]]; then
+        # Parse "Name <email>"
+        KAPSIS_COMMITTER_NAME="${raw% <*}"
+        KAPSIS_COMMITTER_EMAIL="${raw#*<}"
+        KAPSIS_COMMITTER_EMAIL="${KAPSIS_COMMITTER_EMAIL%>}"
+    fi
+
+    if [[ -z "$KAPSIS_COMMITTER_NAME" || -z "$KAPSIS_COMMITTER_EMAIL" ]]; then
+        local host_name host_email
+        host_name=$(git config --global user.name 2>/dev/null || echo "")
+        host_email=$(git config --global user.email 2>/dev/null || echo "")
+        if [[ -n "$host_name" && -n "$host_email" ]]; then
+            KAPSIS_COMMITTER_NAME="$host_name"
+            KAPSIS_COMMITTER_EMAIL="$host_email"
+            source="host git config"
+        fi
+    fi
+
+    if [[ -z "$KAPSIS_COMMITTER_NAME" || -z "$KAPSIS_COMMITTER_EMAIL" ]]; then
+        KAPSIS_COMMITTER_NAME="Kapsis Agent ${AGENT_ID}"
+        KAPSIS_COMMITTER_EMAIL="kapsis-agent-${AGENT_ID}@localhost"
+        source="synthetic fallback"
+    fi
+
+    log_info "Committer identity resolved from ${source}: ${KAPSIS_COMMITTER_NAME} <${KAPSIS_COMMITTER_EMAIL}>"
 }
 
 #===============================================================================
@@ -1039,6 +1105,11 @@ parse_config() {
         done
         log_debug "Merged ${#CLI_CO_AUTHORS[@]} CLI co-author(s) with config"
     fi
+
+    # Resolve committer identity (KAPSIS_COMMITTER_NAME / KAPSIS_COMMITTER_EMAIL)
+    # Precedence: --author > first git.co_authors entry > host git config > synthetic
+    resolve_committer_identity
+    export KAPSIS_COMMITTER_NAME KAPSIS_COMMITTER_EMAIL
 
     # Resolve attribution templates — fall back to Kapsis-only default when
     # config has no attribution key (yq returns "null" for missing keys).
@@ -1970,6 +2041,14 @@ generate_env_vars() {
     ENV_VARS+=("-e" "KAPSIS_AGENT_ID=${AGENT_ID}")
     ENV_VARS+=("-e" "KAPSIS_PROJECT=$(basename "$PROJECT_PATH")")
     ENV_VARS+=("-e" "KAPSIS_SANDBOX_MODE=${SANDBOX_MODE}")
+
+    # Committer identity for in-container git commits (resolved by resolve_committer_identity)
+    if [[ -n "${KAPSIS_COMMITTER_NAME:-}" ]]; then
+        ENV_VARS+=("-e" "KAPSIS_COMMITTER_NAME=${KAPSIS_COMMITTER_NAME}")
+    fi
+    if [[ -n "${KAPSIS_COMMITTER_EMAIL:-}" ]]; then
+        ENV_VARS+=("-e" "KAPSIS_COMMITTER_EMAIL=${KAPSIS_COMMITTER_EMAIL}")
+    fi
 
     # Status reporting environment variables (for container to update status)
     ENV_VARS+=("-e" "KAPSIS_STATUS_PROJECT=$(basename "$PROJECT_PATH")")

--- a/scripts/post-container-git.sh
+++ b/scripts/post-container-git.sh
@@ -494,10 +494,20 @@ commit_changes() {
     fi
 
     # Commit with full error capture (Issue #256)
+    # Override committer/author identity from resolved env when set, so the
+    # post-container commit matches what in-container commits used.
     local _commit_output
     local _commit_exit=0
     # shellcheck disable=SC2086  # _no_verify_flag intentionally unquoted (empty or --no-verify)
-    _commit_output=$(git commit $_no_verify_flag -m "$full_message" 2>&1) || _commit_exit=$?
+    if [[ -n "${KAPSIS_COMMITTER_NAME:-}" && -n "${KAPSIS_COMMITTER_EMAIL:-}" ]]; then
+        _commit_output=$(GIT_COMMITTER_NAME="$KAPSIS_COMMITTER_NAME" \
+                         GIT_COMMITTER_EMAIL="$KAPSIS_COMMITTER_EMAIL" \
+                         GIT_AUTHOR_NAME="$KAPSIS_COMMITTER_NAME" \
+                         GIT_AUTHOR_EMAIL="$KAPSIS_COMMITTER_EMAIL" \
+                         git commit $_no_verify_flag -m "$full_message" 2>&1) || _commit_exit=$?
+    else
+        _commit_output=$(git commit $_no_verify_flag -m "$full_message" 2>&1) || _commit_exit=$?
+    fi
 
     if [[ $_commit_exit -eq 0 ]]; then
         log_success "Changes committed"

--- a/scripts/worktree-manager.sh
+++ b/scripts/worktree-manager.sh
@@ -576,20 +576,24 @@ create_safe_git_config() {
     local committer_name="${KAPSIS_COMMITTER_NAME:-Kapsis Agent $agent_id}"
     local committer_email="${KAPSIS_COMMITTER_EMAIL:-kapsis-agent-${agent_id}@localhost}"
 
-    cat > "$config_path" << EOF
+    # Write static sections via a quoted heredoc — no shell interpolation,
+    # no injection surface. User identity is written separately via
+    # `git config --file` below, which handles escaping correctly even if a
+    # value contains git-special characters (defense-in-depth on top of the
+    # validate_author_format() regex enforced upstream).
+    cat > "$config_path" << 'EOF'
 [core]
     repositoryformatversion = 0
     filemode = true
     bare = false
     # No fsmonitor, no hooks path, no credential helper
-[user]
-    name = $committer_name
-    email = $committer_email
 [init]
     defaultBranch = main
 [receive]
     denyCurrentBranch = updateInstead
 EOF
+    git config --file "$config_path" user.name "$committer_name"
+    git config --file "$config_path" user.email "$committer_email"
 
     # Add remote if available (allows push via host post-processing)
     if [[ -n "$remote_url" ]]; then

--- a/scripts/worktree-manager.sh
+++ b/scripts/worktree-manager.sh
@@ -570,6 +570,12 @@ create_safe_git_config() {
         remote_url=$(git remote get-url origin 2>/dev/null || echo "")
     fi
 
+    # Resolve committer identity from env (set by launch-agent.sh's
+    # resolve_committer_identity). Fall back to the synthetic "Kapsis Agent"
+    # identity only when nothing was resolved upstream.
+    local committer_name="${KAPSIS_COMMITTER_NAME:-Kapsis Agent $agent_id}"
+    local committer_email="${KAPSIS_COMMITTER_EMAIL:-kapsis-agent-${agent_id}@localhost}"
+
     cat > "$config_path" << EOF
 [core]
     repositoryformatversion = 0
@@ -577,8 +583,8 @@ create_safe_git_config() {
     bare = false
     # No fsmonitor, no hooks path, no credential helper
 [user]
-    name = Kapsis Agent $agent_id
-    email = kapsis-agent-${agent_id}@localhost
+    name = $committer_name
+    email = $committer_email
 [init]
     defaultBranch = main
 [receive]

--- a/tests/test-committer-identity.sh
+++ b/tests/test-committer-identity.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+#===============================================================================
+# Test: Committer Identity Resolution
+#
+# Verifies that launch-agent.sh and worktree-manager.sh resolve the git
+# committer identity in the documented precedence order:
+#   1. --author CLI flag (CLI_AUTHOR)
+#   2. First entry of git.co_authors (GIT_CO_AUTHORS)
+#   3. Host git config user.name / user.email
+#   4. Synthetic "Kapsis Agent <id>" fallback
+#
+# Also verifies the sanitized git config written by create_safe_git_config
+# honours KAPSIS_COMMITTER_NAME / KAPSIS_COMMITTER_EMAIL env vars.
+#===============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/test-framework.sh"
+
+LAUNCH_AGENT="$KAPSIS_ROOT/scripts/launch-agent.sh"
+WORKTREE_MANAGER="$KAPSIS_ROOT/scripts/worktree-manager.sh"
+
+# Extract the resolve_committer_identity function into a sourceable form so we
+# can exercise it without running the full launch-agent.sh main() flow.
+# We use awk to slice out the function definition.
+extract_resolver() {
+    awk '/^resolve_committer_identity\(\) \{/,/^\}$/' "$LAUNCH_AGENT"
+}
+
+run_resolver() {
+    # Runs resolve_committer_identity in a clean subshell with given vars.
+    # Args: AGENT_ID, CLI_AUTHOR, GIT_CO_AUTHORS, host_git_name, host_git_email
+    local agent_id="$1"
+    local cli_author="$2"
+    local git_co_authors="$3"
+    local host_name="$4"
+    local host_email="$5"
+
+    local fn_body
+    fn_body=$(extract_resolver)
+
+    # Use a fake HOME with isolated git config
+    local fake_home
+    fake_home=$(mktemp -d)
+
+    # Provide minimal log_info stub to avoid framework dependency
+    bash -c "
+        set -euo pipefail
+        export HOME='$fake_home'
+        export XDG_CONFIG_HOME='$fake_home/.config'
+        if [[ -n '$host_name' ]]; then
+            git config --global user.name '$host_name'
+        fi
+        if [[ -n '$host_email' ]]; then
+            git config --global user.email '$host_email'
+        fi
+        log_info() { :; }
+        AGENT_ID='$agent_id'
+        CLI_AUTHOR='$cli_author'
+        GIT_CO_AUTHORS='$git_co_authors'
+        $fn_body
+        resolve_committer_identity
+        echo \"\$KAPSIS_COMMITTER_NAME|\$KAPSIS_COMMITTER_EMAIL\"
+    "
+
+    rm -rf "$fake_home"
+}
+
+#===============================================================================
+# TEST CASES
+#===============================================================================
+
+test_cli_author_takes_precedence() {
+    log_test "Testing --author flag takes precedence over config and host"
+    local result
+    result=$(run_resolver "abc123" \
+        "Alice <alice@example.com>" \
+        "Bob <bob@example.com>|Carol <carol@example.com>" \
+        "Host User" "host@example.com")
+    assert_equals "Alice|alice@example.com" "$result" \
+        "Should resolve to --author"
+}
+
+test_first_co_author_used_when_no_cli_author() {
+    log_test "Testing first git.co_authors entry used when --author absent"
+    local result
+    result=$(run_resolver "abc123" \
+        "" \
+        "Bob <bob@example.com>|Carol <carol@example.com>" \
+        "Host User" "host@example.com")
+    assert_equals "Bob|bob@example.com" "$result" \
+        "Should resolve to first co-author"
+}
+
+test_host_git_used_when_no_config() {
+    log_test "Testing host git config used when no --author and no co_authors"
+    local result
+    result=$(run_resolver "abc123" "" "" "Host User" "host@example.com")
+    assert_equals "Host User|host@example.com" "$result" \
+        "Should resolve to host git identity"
+}
+
+test_synthetic_fallback_when_nothing_set() {
+    log_test "Testing synthetic Kapsis Agent fallback when nothing configured"
+    local result
+    result=$(run_resolver "abc123" "" "" "" "")
+    assert_equals "Kapsis Agent abc123|kapsis-agent-abc123@localhost" "$result" \
+        "Should fall back to synthetic identity"
+}
+
+test_create_safe_git_config_honours_env() {
+    log_test "Testing create_safe_git_config writes resolved identity"
+
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    local worktree_path="$tmpdir/worktree"
+    local config_path="$tmpdir/config"
+    mkdir -p "$worktree_path"
+    (cd "$worktree_path" && git init -q)
+
+    # Source only the function — guard sourcing in a subshell
+    (
+        # Stub logging functions that worktree-manager.sh expects
+        log_info() { :; }
+        log_debug() { :; }
+        log_warn() { :; }
+        log_error() { :; }
+        log_success() { :; }
+        export KAPSIS_COMMITTER_NAME="Resolved User"
+        export KAPSIS_COMMITTER_EMAIL="resolved@example.com"
+        # shellcheck disable=SC1090
+        source "$WORKTREE_MANAGER"
+        create_safe_git_config "$config_path" "$worktree_path" "agent-xyz"
+    )
+
+    assert_file_contains "$config_path" "name = Resolved User" \
+        "Config should contain resolved committer name"
+    assert_file_contains "$config_path" "email = resolved@example.com" \
+        "Config should contain resolved committer email"
+
+    rm -rf "$tmpdir"
+}
+
+test_create_safe_git_config_falls_back_when_env_unset() {
+    log_test "Testing create_safe_git_config falls back to synthetic identity"
+
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    local worktree_path="$tmpdir/worktree"
+    local config_path="$tmpdir/config"
+    mkdir -p "$worktree_path"
+    (cd "$worktree_path" && git init -q)
+
+    (
+        log_info() { :; }
+        log_debug() { :; }
+        log_warn() { :; }
+        log_error() { :; }
+        log_success() { :; }
+        unset KAPSIS_COMMITTER_NAME KAPSIS_COMMITTER_EMAIL
+        # shellcheck disable=SC1090
+        source "$WORKTREE_MANAGER"
+        create_safe_git_config "$config_path" "$worktree_path" "fallback-id"
+    )
+
+    assert_file_contains "$config_path" "name = Kapsis Agent fallback-id" \
+        "Config should fall back to synthetic name"
+    assert_file_contains "$config_path" "email = kapsis-agent-fallback-id@localhost" \
+        "Config should fall back to synthetic email"
+
+    rm -rf "$tmpdir"
+}
+
+#===============================================================================
+# MAIN
+#===============================================================================
+
+main() {
+    print_test_header "Committer Identity Resolution"
+
+    run_test test_cli_author_takes_precedence
+    run_test test_first_co_author_used_when_no_cli_author
+    run_test test_host_git_used_when_no_config
+    run_test test_synthetic_fallback_when_nothing_set
+    run_test test_create_safe_git_config_honours_env
+    run_test test_create_safe_git_config_falls_back_when_env_unset
+
+    print_summary
+}
+
+main "$@"

--- a/tests/test-committer-identity.sh
+++ b/tests/test-committer-identity.sh
@@ -9,96 +9,104 @@
 #   3. Host git config user.name / user.email
 #   4. Synthetic "Kapsis Agent <id>" fallback
 #
-# Also verifies the sanitized git config written by create_safe_git_config
-# honours KAPSIS_COMMITTER_NAME / KAPSIS_COMMITTER_EMAIL env vars.
+# Also verifies that:
+#   - The sanitized git config written by create_safe_git_config honours
+#     KAPSIS_COMMITTER_NAME / KAPSIS_COMMITTER_EMAIL env vars.
+#   - validate_author_format rejects multi-line / shell-metachar injection
+#     (PR #416 security review).
+#   - post-container-git's commit_changes records the resolved identity in
+#     the actual git commit (PR #416 test review).
 #===============================================================================
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/test-framework.sh
 source "$SCRIPT_DIR/lib/test-framework.sh"
 
 LAUNCH_AGENT="$KAPSIS_ROOT/scripts/launch-agent.sh"
 WORKTREE_MANAGER="$KAPSIS_ROOT/scripts/worktree-manager.sh"
+POST_CONTAINER_GIT="$KAPSIS_ROOT/scripts/post-container-git.sh"
 
-# Extract the resolve_committer_identity function into a sourceable form so we
-# can exercise it without running the full launch-agent.sh main() flow.
-# We use awk to slice out the function definition.
-extract_resolver() {
-    awk '/^resolve_committer_identity\(\) \{/,/^\}$/' "$LAUNCH_AGENT"
-}
-
+# Runs resolve_committer_identity in an isolated subshell.
+#
+# Args via env (NOT positional, NOT string interpolation) so values with
+# quotes / spaces / special chars cannot break the test harness — see
+# PR #416 test-reviewer's "critical" finding.
+#
+# Env consumed:
+#   T_AGENT_ID, T_CLI_AUTHOR, T_GIT_CO_AUTHORS, T_HOST_NAME, T_HOST_EMAIL
 run_resolver() {
-    # Runs resolve_committer_identity in a clean subshell with given vars.
-    # Args: AGENT_ID, CLI_AUTHOR, GIT_CO_AUTHORS, host_git_name, host_git_email
-    local agent_id="$1"
-    local cli_author="$2"
-    local git_co_authors="$3"
-    local host_name="$4"
-    local host_email="$5"
-
-    local fn_body
-    fn_body=$(extract_resolver)
-
-    # Use a fake HOME with isolated git config
     local fake_home
     fake_home=$(mktemp -d)
+    # shellcheck disable=SC2064  # path captured at trap install time intentionally
+    trap "rm -rf '$fake_home'" RETURN
 
-    # Provide minimal log_info stub to avoid framework dependency
-    bash -c "
+    HOME="$fake_home" \
+    XDG_CONFIG_HOME="$fake_home/.config" \
+    GIT_CONFIG_NOSYSTEM=1 \
+    T_AGENT_ID="$1" \
+    T_CLI_AUTHOR="$2" \
+    T_GIT_CO_AUTHORS="$3" \
+    T_HOST_NAME="$4" \
+    T_HOST_EMAIL="$5" \
+    LAUNCH_AGENT="$LAUNCH_AGENT" \
+    bash -c '
         set -euo pipefail
-        export HOME='$fake_home'
-        export XDG_CONFIG_HOME='$fake_home/.config'
-        if [[ -n '$host_name' ]]; then
-            git config --global user.name '$host_name'
+        # Stub logging before sourcing so the script does not require log files
+        log_info()    { :; }
+        log_debug()   { :; }
+        log_warn()    { :; }
+        log_error()   { :; }
+        log_success() { :; }
+        export -f log_info log_debug log_warn log_error log_success
+        # Seed host git config inside the isolated HOME
+        if [[ -n "$T_HOST_NAME" ]]; then
+            git config --global user.name "$T_HOST_NAME"
         fi
-        if [[ -n '$host_email' ]]; then
-            git config --global user.email '$host_email'
+        if [[ -n "$T_HOST_EMAIL" ]]; then
+            git config --global user.email "$T_HOST_EMAIL"
         fi
-        log_info() { :; }
-        AGENT_ID='$agent_id'
-        CLI_AUTHOR='$cli_author'
-        GIT_CO_AUTHORS='$git_co_authors'
-        $fn_body
+        # Sourcing launch-agent.sh: the trailing `main "$@"` is guarded by
+        # `[[ "${BASH_SOURCE[0]}" == "${0}" ]]` so this does not execute main.
+        # shellcheck disable=SC1090
+        source "$LAUNCH_AGENT"
+        AGENT_ID="$T_AGENT_ID"
+        CLI_AUTHOR="$T_CLI_AUTHOR"
+        GIT_CO_AUTHORS="$T_GIT_CO_AUTHORS"
         resolve_committer_identity
-        echo \"\$KAPSIS_COMMITTER_NAME|\$KAPSIS_COMMITTER_EMAIL\"
-    "
-
-    rm -rf "$fake_home"
+        printf "%s|%s\n" "$KAPSIS_COMMITTER_NAME" "$KAPSIS_COMMITTER_EMAIL"
+    '
 }
 
 #===============================================================================
-# TEST CASES
+# TEST CASES: precedence
 #===============================================================================
 
 test_cli_author_takes_precedence() {
-    log_test "Testing --author flag takes precedence over config and host"
+    log_test "Testing --author takes precedence over config and host"
     local result
     result=$(run_resolver "abc123" \
         "Alice <alice@example.com>" \
         "Bob <bob@example.com>|Carol <carol@example.com>" \
         "Host User" "host@example.com")
-    assert_equals "Alice|alice@example.com" "$result" \
-        "Should resolve to --author"
+    assert_equals "Alice|alice@example.com" "$result" "Should resolve to --author"
 }
 
 test_first_co_author_used_when_no_cli_author() {
-    log_test "Testing first git.co_authors entry used when --author absent"
+    log_test "Testing first git.co_authors used when --author absent"
     local result
-    result=$(run_resolver "abc123" \
-        "" \
+    result=$(run_resolver "abc123" "" \
         "Bob <bob@example.com>|Carol <carol@example.com>" \
         "Host User" "host@example.com")
-    assert_equals "Bob|bob@example.com" "$result" \
-        "Should resolve to first co-author"
+    assert_equals "Bob|bob@example.com" "$result" "Should resolve to first co-author"
 }
 
 test_host_git_used_when_no_config() {
     log_test "Testing host git config used when no --author and no co_authors"
     local result
     result=$(run_resolver "abc123" "" "" "Host User" "host@example.com")
-    assert_equals "Host User|host@example.com" "$result" \
-        "Should resolve to host git identity"
+    assert_equals "Host User|host@example.com" "$result" "Should use host git identity"
 }
 
 test_synthetic_fallback_when_nothing_set() {
@@ -109,24 +117,115 @@ test_synthetic_fallback_when_nothing_set() {
         "Should fall back to synthetic identity"
 }
 
+#===============================================================================
+# TEST CASES: edge cases (PR #416 review follow-up)
+#===============================================================================
+
+test_host_name_only_falls_through_to_synthetic() {
+    log_test "Testing partial host git (name only, no email) falls through"
+    local result
+    result=$(run_resolver "abc123" "" "" "Host User" "")
+    assert_equals "Kapsis Agent abc123|kapsis-agent-abc123@localhost" "$result" \
+        "Should fall through when host email missing"
+}
+
+test_host_email_only_falls_through_to_synthetic() {
+    log_test "Testing partial host git (email only, no name) falls through"
+    local result
+    result=$(run_resolver "abc123" "" "" "" "host@example.com")
+    assert_equals "Kapsis Agent abc123|kapsis-agent-abc123@localhost" "$result" \
+        "Should fall through when host name missing"
+}
+
+test_name_with_single_quote_resolves() {
+    log_test "Testing name with single quote (e.g. O'Brien) resolves correctly"
+    local result
+    result=$(run_resolver "abc123" "O'Brien <ob@example.com>" "" "" "")
+    assert_equals "O'Brien|ob@example.com" "$result" \
+        "Single quote in name must survive the harness"
+}
+
+#===============================================================================
+# TEST CASES: validate_author_format (security boundary)
+#===============================================================================
+
+run_validator() {
+    # Returns "0" or "1" — the exit code of validate_author_format.
+    local value="$1"
+    HOME="$(mktemp -d)" GIT_CONFIG_NOSYSTEM=1 LAUNCH_AGENT="$LAUNCH_AGENT" \
+        T_VALUE="$value" bash -c '
+        set -uo pipefail
+        log_info() { :; }; log_debug() { :; }; log_warn() { :; }
+        log_error() { :; }; log_success() { :; }
+        export -f log_info log_debug log_warn log_error log_success
+        # shellcheck disable=SC1090
+        source "$LAUNCH_AGENT"
+        if validate_author_format "$T_VALUE"; then
+            echo 0
+        else
+            echo 1
+        fi
+    '
+}
+
+test_validator_accepts_simple() {
+    log_test "validate_author_format accepts simple Name <email>"
+    assert_equals "0" "$(run_validator "Alice <alice@example.com>")" \
+        "Should accept simple identity"
+}
+
+test_validator_accepts_dotted_name() {
+    log_test "validate_author_format accepts dotted names"
+    assert_equals "0" "$(run_validator "Aviad Shiber <aviad.s@taboola.com>")" \
+        "Should accept names with dots"
+}
+
+test_validator_rejects_newline_in_email() {
+    log_test "validate_author_format rejects newline in email (injection)"
+    local payload
+    payload=$'Alice <alice@x.com\n[core]\n\thooksPath = /tmp/evil>'
+    assert_equals "1" "$(run_validator "$payload")" \
+        "Newline in email portion must be rejected (PR #416 RCE fix)"
+}
+
+test_validator_rejects_no_email() {
+    log_test "validate_author_format rejects bare name (no email)"
+    assert_equals "1" "$(run_validator "JustAName")" \
+        "Bare name without <email> must be rejected"
+}
+
+test_validator_rejects_empty_email() {
+    log_test "validate_author_format rejects empty email <>"
+    assert_equals "1" "$(run_validator "Name <>")" \
+        "Empty email must be rejected"
+}
+
+test_validator_rejects_space_in_email() {
+    log_test "validate_author_format rejects space in email"
+    assert_equals "1" "$(run_validator "Name <a b@x.com>")" \
+        "Space inside email must be rejected"
+}
+
+#===============================================================================
+# TEST CASES: create_safe_git_config
+#===============================================================================
+
 test_create_safe_git_config_honours_env() {
-    log_test "Testing create_safe_git_config writes resolved identity"
+    log_test "create_safe_git_config writes resolved identity"
 
     local tmpdir
     tmpdir=$(mktemp -d)
+    # shellcheck disable=SC2064
+    trap "rm -rf '$tmpdir'" RETURN
+
     local worktree_path="$tmpdir/worktree"
     local config_path="$tmpdir/config"
     mkdir -p "$worktree_path"
     (cd "$worktree_path" && git init -q)
 
-    # Source only the function — guard sourcing in a subshell
     (
-        # Stub logging functions that worktree-manager.sh expects
-        log_info() { :; }
-        log_debug() { :; }
-        log_warn() { :; }
-        log_error() { :; }
-        log_success() { :; }
+        log_info() { :; }; log_debug() { :; }; log_warn() { :; }
+        log_error() { :; }; log_success() { :; }
         export KAPSIS_COMMITTER_NAME="Resolved User"
         export KAPSIS_COMMITTER_EMAIL="resolved@example.com"
         # shellcheck disable=SC1090
@@ -134,42 +233,130 @@ test_create_safe_git_config_honours_env() {
         create_safe_git_config "$config_path" "$worktree_path" "agent-xyz"
     )
 
-    assert_file_contains "$config_path" "name = Resolved User" \
-        "Config should contain resolved committer name"
-    assert_file_contains "$config_path" "email = resolved@example.com" \
-        "Config should contain resolved committer email"
-
-    rm -rf "$tmpdir"
+    # Use git config --file to read back — exercises the same code path used to write
+    local got_name got_email
+    got_name=$(git config --file "$config_path" user.name)
+    got_email=$(git config --file "$config_path" user.email)
+    assert_equals "Resolved User" "$got_name" "user.name should be resolved value"
+    assert_equals "resolved@example.com" "$got_email" "user.email should be resolved value"
 }
 
 test_create_safe_git_config_falls_back_when_env_unset() {
-    log_test "Testing create_safe_git_config falls back to synthetic identity"
+    log_test "create_safe_git_config falls back to synthetic identity"
 
     local tmpdir
     tmpdir=$(mktemp -d)
+    # shellcheck disable=SC2064
+    trap "rm -rf '$tmpdir'" RETURN
+
     local worktree_path="$tmpdir/worktree"
     local config_path="$tmpdir/config"
     mkdir -p "$worktree_path"
     (cd "$worktree_path" && git init -q)
 
     (
-        log_info() { :; }
-        log_debug() { :; }
-        log_warn() { :; }
-        log_error() { :; }
-        log_success() { :; }
+        log_info() { :; }; log_debug() { :; }; log_warn() { :; }
+        log_error() { :; }; log_success() { :; }
         unset KAPSIS_COMMITTER_NAME KAPSIS_COMMITTER_EMAIL
         # shellcheck disable=SC1090
         source "$WORKTREE_MANAGER"
         create_safe_git_config "$config_path" "$worktree_path" "fallback-id"
     )
 
-    assert_file_contains "$config_path" "name = Kapsis Agent fallback-id" \
-        "Config should fall back to synthetic name"
-    assert_file_contains "$config_path" "email = kapsis-agent-fallback-id@localhost" \
-        "Config should fall back to synthetic email"
+    local got_name got_email
+    got_name=$(git config --file "$config_path" user.name)
+    got_email=$(git config --file "$config_path" user.email)
+    assert_equals "Kapsis Agent fallback-id" "$got_name" "Should fall back to synthetic name"
+    assert_equals "kapsis-agent-fallback-id@localhost" "$got_email" "Should fall back to synthetic email"
+}
 
-    rm -rf "$tmpdir"
+#===============================================================================
+# TEST CASES: post-container-git commit override (T2 from PR #416 review)
+#===============================================================================
+
+test_commit_changes_uses_resolved_identity() {
+    log_test "commit_changes records KAPSIS_COMMITTER_NAME/EMAIL in actual commit"
+
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    # shellcheck disable=SC2064
+    trap "rm -rf '$tmpdir'" RETURN
+
+    local repo="$tmpdir/repo"
+    mkdir -p "$repo"
+    (
+        cd "$repo"
+        git init -q
+        git config user.email "default@local"
+        git config user.name "Default User"
+        git config commit.gpgsign false
+        echo "init" > README.md
+        git add README.md
+        git commit -q -m "initial"
+        echo "change" >> README.md
+    )
+
+    (
+        # Stub the logging functions the post-container script needs
+        log_info() { :; }; log_debug() { :; }; log_warn() { :; }
+        log_error() { :; }; log_success() { :; }
+        # Disable attribution / sanitisation noise that would change the assertion
+        export KAPSIS_ATTRIBUTION_COMMIT=""
+        export KAPSIS_COMMITTER_NAME="Resolved Committer"
+        export KAPSIS_COMMITTER_EMAIL="resolved@example.com"
+        # shellcheck disable=SC1090
+        source "$POST_CONTAINER_GIT"
+        cd "$repo"
+        commit_changes "$repo" "test: resolved identity" "agent-zzz" "" >/dev/null 2>&1
+    )
+
+    local cn ce an ae
+    cn=$(git -C "$repo" log -1 --format='%cn')
+    ce=$(git -C "$repo" log -1 --format='%ce')
+    an=$(git -C "$repo" log -1 --format='%an')
+    ae=$(git -C "$repo" log -1 --format='%ae')
+    assert_equals "Resolved Committer" "$cn" "git committer name should be overridden"
+    assert_equals "resolved@example.com" "$ce" "git committer email should be overridden"
+    assert_equals "Resolved Committer" "$an" "git author name should be overridden"
+    assert_equals "resolved@example.com" "$ae" "git author email should be overridden"
+}
+
+test_commit_changes_uses_repo_default_when_env_unset() {
+    log_test "commit_changes uses repo git config when env vars unset"
+
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    # shellcheck disable=SC2064
+    trap "rm -rf '$tmpdir'" RETURN
+
+    local repo="$tmpdir/repo"
+    mkdir -p "$repo"
+    (
+        cd "$repo"
+        git init -q
+        git config user.email "default@local"
+        git config user.name "Default User"
+        git config commit.gpgsign false
+        echo "init" > README.md
+        git add README.md
+        git commit -q -m "initial"
+        echo "change" >> README.md
+    )
+
+    (
+        log_info() { :; }; log_debug() { :; }; log_warn() { :; }
+        log_error() { :; }; log_success() { :; }
+        export KAPSIS_ATTRIBUTION_COMMIT=""
+        unset KAPSIS_COMMITTER_NAME KAPSIS_COMMITTER_EMAIL
+        # shellcheck disable=SC1090
+        source "$POST_CONTAINER_GIT"
+        cd "$repo"
+        commit_changes "$repo" "test: default identity" "agent-zzz" "" >/dev/null 2>&1
+    )
+
+    local cn
+    cn=$(git -C "$repo" log -1 --format='%cn')
+    assert_equals "Default User" "$cn" "Should fall through to repo git config"
 }
 
 #===============================================================================
@@ -179,12 +366,32 @@ test_create_safe_git_config_falls_back_when_env_unset() {
 main() {
     print_test_header "Committer Identity Resolution"
 
+    # Precedence
     run_test test_cli_author_takes_precedence
     run_test test_first_co_author_used_when_no_cli_author
     run_test test_host_git_used_when_no_config
     run_test test_synthetic_fallback_when_nothing_set
+
+    # Edge cases
+    run_test test_host_name_only_falls_through_to_synthetic
+    run_test test_host_email_only_falls_through_to_synthetic
+    run_test test_name_with_single_quote_resolves
+
+    # Validator (security boundary)
+    run_test test_validator_accepts_simple
+    run_test test_validator_accepts_dotted_name
+    run_test test_validator_rejects_newline_in_email
+    run_test test_validator_rejects_no_email
+    run_test test_validator_rejects_empty_email
+    run_test test_validator_rejects_space_in_email
+
+    # Sanitized git config writer
     run_test test_create_safe_git_config_honours_env
     run_test test_create_safe_git_config_falls_back_when_env_unset
+
+    # post-container-git commit override
+    run_test test_commit_changes_uses_resolved_identity
+    run_test test_commit_changes_uses_repo_default_when_env_unset
 
     print_summary
 }


### PR DESCRIPTION
## Summary

Replaces the hardcoded `Kapsis Agent <id>` in-container committer with a configurable identity, fixing the case where commits made *inside* the container show up under a synthetic name in `git log` (e.g. `Kapsis Agent 7207a1 committed ...`) while post-container commits show the real user.

## Resolution precedence (new helper `resolve_committer_identity`)

1. **`--author "Name <email>"`** CLI flag (new on `launch-agent.sh`)
2. First entry of `git.co_authors` from agent config
3. Host `git config --global user.name` / `user.email`
4. Synthetic `Kapsis Agent <id>` fallback (preserves prior behaviour)

The resolved `KAPSIS_COMMITTER_NAME` / `KAPSIS_COMMITTER_EMAIL` flows:
- into the container as env → consumed by `create_safe_git_config()` in `worktree-manager.sh`
- into post-container git commit via explicit `GIT_COMMITTER_*` / `GIT_AUTHOR_*` overrides in `post-container-git.sh`

`build_coauthor_trailers()` already dedupes against the committer email, so configuring `co_authors[0]` as the committer drops that entry from the `Co-authored-by:` trailers automatically — no double-listing.

## Changes

- `scripts/launch-agent.sh` — new `--author` flag, `resolve_committer_identity()`, env injection
- `scripts/worktree-manager.sh` — `create_safe_git_config` honours `KAPSIS_COMMITTER_NAME/EMAIL`
- `scripts/post-container-git.sh` — explicit `GIT_COMMITTER_*` env on commit
- `tests/test-committer-identity.sh` — new test (6 cases, all passing)

## Test plan

- [x] New unit tests in `tests/test-committer-identity.sh` (6/6 pass)
- [x] Existing `tests/test-coauthor-fork.sh` regression (26/26 pass)
- [x] shellcheck clean on modified files
- [ ] End-to-end: launch an agent with `--author "Aviad Shiber <aviad.s@taboola.com>"` and verify `git log -1 --format='%cn <%ce>'` in the worktree
- [ ] End-to-end: launch with `git.co_authors` only (no `--author`) — committer is first co-author
- [ ] End-to-end: launch with neither — committer falls back to host git identity

🤖 Generated with [Claude Code](https://claude.com/claude-code)