### PR TITLE
fix(mount-failure): match krunkit alongside vfkit in hypervisor process patterns

### DIFF
--- a/scripts/lib/compat.sh
+++ b/scripts/lib/compat.sh
@@ -318,7 +318,7 @@ _podman_ssh_probe() {
 #-------------------------------------------------------------------------------
 _kill_vfkit_zombie() {
     local machine="${1:-podman-machine-default}"
-    declare -f log_warn &>/dev/null && log_warn "Killing vfkit hypervisor for '$machine' (zombie VM recovery)"
+    declare -f log_warn &>/dev/null && log_warn "Killing vfkit/krunkit hypervisor for '$machine' (zombie VM recovery)"
     pkill -9 -f "(vfkit|krunkit).*${machine}" &>/dev/null || true
 
     # Remove stale runtime artefacts left by the hard-killed hypervisor so that

--- a/scripts/lib/compat.sh
+++ b/scripts/lib/compat.sh
@@ -319,7 +319,7 @@ _podman_ssh_probe() {
 _kill_vfkit_zombie() {
     local machine="${1:-podman-machine-default}"
     declare -f log_warn &>/dev/null && log_warn "Killing vfkit hypervisor for '$machine' (zombie VM recovery)"
-    pkill -9 -f "vfkit.*${machine}" &>/dev/null || true
+    pkill -9 -f "(vfkit|krunkit).*${machine}" &>/dev/null || true
 
     # Remove stale runtime artefacts left by the hard-killed hypervisor so that
     # the subsequent `podman machine start` does not refuse to start or silently

--- a/scripts/lib/podman-health.sh
+++ b/scripts/lib/podman-health.sh
@@ -30,7 +30,7 @@ declare -f is_linux    &>/dev/null || is_linux()    { [[ "$(uname -s)" == "Linux
 # Intentionally trivial: compat.sh (sourced first in all production paths) owns
 # the full implementation including stale-file cleanup (Issue #297).  This stub
 # only fires in isolated test contexts that load podman-health.sh alone.
-declare -f _kill_vfkit_zombie &>/dev/null || _kill_vfkit_zombie() { pkill -9 -f "vfkit.*${1:-podman-machine-default}" &>/dev/null || true; sleep 3; }
+declare -f _kill_vfkit_zombie &>/dev/null || _kill_vfkit_zombie() { pkill -9 -f "(vfkit|krunkit).*${1:-podman-machine-default}" &>/dev/null || true; sleep 3; }
 
 #-------------------------------------------------------------------------------
 # _vfs_timeout_cmd

--- a/scripts/lib/vfkit-watchdog.sh
+++ b/scripts/lib/vfkit-watchdog.sh
@@ -91,9 +91,9 @@ start_vfkit_watchdog() {
     local vfkit_pid
     # `pgrep -o` (oldest) is more stable than `-n` (newest) when vfkit was
     # just restarted — `-n` could pick up a transient helper still in argv.
-    vfkit_pid=$(pgrep -o -f "vfkit.*${machine}" 2>/dev/null || true)
+    vfkit_pid=$(pgrep -o -f "(vfkit|krunkit).*${machine}" 2>/dev/null || true)
     if [[ -z "$vfkit_pid" ]]; then
-        log_debug "vfkit process not found for machine '$machine' — skipping watchdog"
+        log_warn "vfkit/krunkit process not found for machine '$machine' — mount-drop protection is NOT armed for this session"
         return 0
     fi
 

--- a/scripts/lib/vfkit-watchdog.sh
+++ b/scripts/lib/vfkit-watchdog.sh
@@ -140,11 +140,11 @@ start_vfkit_watchdog() {
             : > "$sentinel_path" 2>/dev/null || true
         fi
         status_set_error_type "mount_failure" 2>/dev/null || true
-        status_complete 4 "Workspace mount lost: vfkit (PID $vfkit_pid) exited (host-side watchdog). Recovery: podman machine stop && podman machine start, then re-run." 2>/dev/null || true
-        log_warn "KAPSIS_MOUNT_FAILURE[vfkit_watchdog]: vfkit (PID $vfkit_pid) exited — virtio-fs mounts lost"
+        status_complete 4 "Workspace mount lost: vfkit/krunkit (PID $vfkit_pid) exited (host-side watchdog). Recovery: podman machine stop && podman machine start, then re-run." 2>/dev/null || true
+        log_warn "KAPSIS_MOUNT_FAILURE[vfkit_watchdog]: vfkit/krunkit (PID $vfkit_pid) exited — virtio-fs mounts lost"
         pkill -TERM -f "podman run .*--name kapsis-${agent_id}(${boundary}|\$)" 2>/dev/null || true
     ) &
     _VFKIT_WATCHDOG_PID=$!
 
-    log_debug "vfkit watchdog active (vfkit PID: $vfkit_pid, poll: ${interval}s, watchdog PID: $_VFKIT_WATCHDOG_PID)"
+    log_debug "vfkit watchdog active (vfkit/krunkit PID: $vfkit_pid, poll: ${interval}s, watchdog PID: $_VFKIT_WATCHDOG_PID)"
 }

--- a/tests/test-compat.sh
+++ b/tests/test-compat.sh
@@ -703,6 +703,34 @@ test_kill_vfkit_zombie_scoped_to_named_machine() {
     rm -rf "$fake_home"
 }
 
+test_kill_vfkit_zombie_pkill_pattern_matches_krunkit() {
+    log_test "_kill_vfkit_zombie: pkill -f pattern matches krunkit in addition to vfkit (Issue #409)"
+
+    local fake_home
+    fake_home=$(mktemp -d "${TMPDIR:-/tmp}/kapsis-zombie-krunkit.XXXXXX")
+    local argv_log="${fake_home}/pkill.argv"
+
+    # Capture the argv pkill is invoked with, instead of just stubbing return 0.
+    pkill() { printf '%s\n' "$@" > "$argv_log"; return 0; }
+    sleep() { return 0; }
+
+    local saved_xdg="${XDG_DATA_HOME:-}"
+    unset XDG_DATA_HOME
+    HOME="$fake_home" _kill_vfkit_zombie "podman-machine-krunkit-test"
+    [[ -n "$saved_xdg" ]] && XDG_DATA_HOME="$saved_xdg" || true
+
+    unset -f pkill sleep
+
+    local argv
+    argv=$(cat "$argv_log" 2>/dev/null || echo "")
+    rm -rf "$fake_home"
+
+    assert_contains "$argv" "vfkit" "pkill pattern must still match vfkit (applehv)"
+    assert_contains "$argv" "krunkit" "pkill pattern must also match krunkit (libkrun/AVF)"
+    assert_contains "$argv" "(vfkit|krunkit)" "pkill pattern must use an alternation, not a fixed vfkit-only string"
+    assert_contains "$argv" "podman-machine-krunkit-test" "pkill pattern must still be scoped to the target machine name"
+}
+
 #===============================================================================
 # MAIN
 #===============================================================================
@@ -771,6 +799,7 @@ main() {
     run_test test_kill_vfkit_zombie_removes_runtime_files
     run_test test_kill_vfkit_zombie_respects_xdg_data_home
     run_test test_kill_vfkit_zombie_scoped_to_named_machine
+    run_test test_kill_vfkit_zombie_pkill_pattern_matches_krunkit
 
     # Summary
     print_summary

--- a/tests/test-podman-health.sh
+++ b/tests/test-podman-health.sh
@@ -822,6 +822,40 @@ EOF
 }
 
 #===============================================================================
+# _kill_vfkit_zombie — vfkit/krunkit alternation pattern (Issue #409)
+#===============================================================================
+
+test_kill_vfkit_zombie_pattern_matches_krunkit() {
+    log_test "_kill_vfkit_zombie's pkill -f pattern matches krunkit in addition to vfkit"
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    local fake_bin="$tmpdir/bin"
+    mkdir -p "$fake_bin"
+
+    # Fake pkill: record argv, don't actually signal anything.
+    cat > "$fake_bin/pkill" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$@" > "$tmpdir/pkill.argv"
+exit 0
+EOF
+    chmod +x "$fake_bin/pkill"
+
+    bash -c "
+        $(_load_lib_with_macos)
+        PATH=\"$fake_bin:\$PATH\"
+        _kill_vfkit_zombie 'podman-machine-krunkit-test'
+    " &>/dev/null || true
+
+    local argv
+    argv=$(cat "$tmpdir/pkill.argv" 2>/dev/null || echo "")
+    rm -rf "$tmpdir"
+    assert_contains "$argv" "vfkit" "pkill pattern must still match vfkit (applehv)"
+    assert_contains "$argv" "krunkit" "pkill pattern must also match krunkit (libkrun/AVF)"
+    assert_contains "$argv" "(vfkit|krunkit)" "pkill pattern must use an alternation, not a fixed vfkit-only string"
+    assert_contains "$argv" "podman-machine-krunkit-test" "pkill pattern must still be scoped to the target machine name"
+}
+
+#===============================================================================
 # MAIN
 #===============================================================================
 
@@ -863,6 +897,9 @@ main() {
     run_test test_probe_pulls_image_when_skip_disabled
     run_test test_vfs_timeout_cmd_returns_empty_when_missing
     run_test test_probe_runs_podman_without_timeout_when_tmo_missing
+
+    log_info "=== _kill_vfkit_zombie — vfkit/krunkit alternation (Issue #409) ==="
+    run_test test_kill_vfkit_zombie_pattern_matches_krunkit
 
     print_summary
 }

--- a/tests/test-vfkit-watchdog.sh
+++ b/tests/test-vfkit-watchdog.sh
@@ -279,7 +279,7 @@ test_watchdog_pgrep_pattern_matches_krunkit() {
     # — i.e. it would match a krunkit-only process on a real libkrun/AVF host.
     FAKE_PGREP_PID="$fake_krunkit_pid" _install_fakes
 
-    KAPSIS_VFKIT_WATCHDOG_INTERVAL=5 start_vfkit_watchdog "$TEST_AGENT_ID"
+    KAPSIS_VFKIT_WATCHDOG_INTERVAL=5 start_vfkit_watchdog "$TEST_AGENT_ID" "" "podman-machine-krunkit-test"
     local watchdog_pid="$_VFKIT_WATCHDOG_PID"
 
     assert_file_exists "$TEST_TMP/pgrep.argv" "pgrep must be invoked by the watchdog to locate the hypervisor process"
@@ -288,6 +288,7 @@ test_watchdog_pgrep_pattern_matches_krunkit() {
     assert_contains "$argv" "vfkit" "pgrep pattern must still match vfkit (applehv)"
     assert_contains "$argv" "krunkit" "pgrep pattern must also match krunkit (libkrun/AVF)"
     assert_contains "$argv" "(vfkit|krunkit)" "pgrep pattern must use an alternation, not a fixed vfkit-only string"
+    assert_contains "$argv" "podman-machine-krunkit-test" "pgrep pattern must still be scoped to the target machine name"
 
     kill "$watchdog_pid" 2>/dev/null || true
     wait "$watchdog_pid" 2>/dev/null || true

--- a/tests/test-vfkit-watchdog.sh
+++ b/tests/test-vfkit-watchdog.sh
@@ -90,10 +90,13 @@ _install_fakes() {
     local fake_bin="$TEST_TMP/bin"
     mkdir -p "$fake_bin"
 
-    # pgrep: print the PID the test wants the watchdog to watch.
+    # pgrep: print the PID the test wants the watchdog to watch, and record
+    # the argv it was called with (so tests can assert on the -f pattern,
+    # e.g. that it contains the vfkit|krunkit alternation).
     # FAKE_PGREP_PID is expanded at host time (caller-supplied env var).
     cat > "$fake_bin/pgrep" <<EOF
 #!/usr/bin/env bash
+printf '%s\n' "\$@" > "$TEST_TMP/pgrep.argv"
 echo "${FAKE_PGREP_PID:-}"
 EOF
 
@@ -254,6 +257,69 @@ test_watchdog_skipped_when_vfkit_not_found() {
     FAKE_PGREP_PID="" _install_fakes
     start_vfkit_watchdog "$TEST_AGENT_ID"
     assert_equals "" "${_VFKIT_WATCHDOG_PID:-}" "watchdog must not start when pgrep finds no vfkit"
+    _teardown_test_env
+}
+
+#===============================================================================
+# krunkit/vfkit alternation pattern (Issue #409)
+#===============================================================================
+
+test_watchdog_pgrep_pattern_matches_krunkit() {
+    log_test "Watchdog's pgrep -f pattern matches krunkit (libkrun/AVF) in addition to vfkit"
+    TEST_AGENT_ID="vfkit-krunkit-15"
+    _setup_test_env
+
+    sleep 30 &
+    local fake_krunkit_pid=$!
+    TEST_CHILD_PIDS="$fake_krunkit_pid"
+
+    # The fake pgrep does not itself pattern-match; it always echoes
+    # FAKE_PGREP_PID. What we assert here is that the *pattern the watchdog
+    # constructs and passes to pgrep* now includes krunkit as an alternative
+    # — i.e. it would match a krunkit-only process on a real libkrun/AVF host.
+    FAKE_PGREP_PID="$fake_krunkit_pid" _install_fakes
+
+    KAPSIS_VFKIT_WATCHDOG_INTERVAL=5 start_vfkit_watchdog "$TEST_AGENT_ID"
+    local watchdog_pid="$_VFKIT_WATCHDOG_PID"
+
+    assert_file_exists "$TEST_TMP/pgrep.argv" "pgrep must be invoked by the watchdog to locate the hypervisor process"
+    local argv
+    argv=$(<"$TEST_TMP/pgrep.argv")
+    assert_contains "$argv" "vfkit" "pgrep pattern must still match vfkit (applehv)"
+    assert_contains "$argv" "krunkit" "pgrep pattern must also match krunkit (libkrun/AVF)"
+    assert_contains "$argv" "(vfkit|krunkit)" "pgrep pattern must use an alternation, not a fixed vfkit-only string"
+
+    kill "$watchdog_pid" 2>/dev/null || true
+    wait "$watchdog_pid" 2>/dev/null || true
+    kill "$fake_krunkit_pid" 2>/dev/null || true
+    wait "$fake_krunkit_pid" 2>/dev/null || true
+    TEST_CHILD_PIDS=""
+    _teardown_test_env
+}
+
+test_watchdog_not_found_branch_warns_not_debug() {
+    log_test "Watchdog's not-found branch logs at WARN (visible by default), not silent DEBUG"
+    TEST_AGENT_ID="vfkit-warn-16"
+    _setup_test_env
+    FAKE_PGREP_PID="" _install_fakes
+
+    # Re-capture log_warn/log_debug calls (the quiet stubs installed in
+    # _setup_test_env are no-ops — override them here to record whether
+    # each was invoked, and with what message).
+    : > "$TEST_TMP/log_warn.calls"
+    : > "$TEST_TMP/log_debug.calls"
+    log_warn()  { printf '%s\n' "$*" >> "$TEST_TMP/log_warn.calls"; }
+    log_debug() { printf '%s\n' "$*" >> "$TEST_TMP/log_debug.calls"; }
+
+    start_vfkit_watchdog "$TEST_AGENT_ID"
+    assert_equals "" "${_VFKIT_WATCHDOG_PID:-}" "watchdog must not start when no hypervisor process is found"
+
+    local warn_content debug_content
+    warn_content=$(<"$TEST_TMP/log_warn.calls")
+    debug_content=$(<"$TEST_TMP/log_debug.calls")
+    assert_contains "$warn_content" "vfkit/krunkit process not found" "not-found branch must log at WARN level (visible by default)"
+    assert_contains "$warn_content" "mount-drop protection is NOT armed" "WARN message must make the security-relevant consequence explicit"
+    assert_not_contains "$debug_content" "process not found" "not-found branch must no longer be silently logged at DEBUG only"
     _teardown_test_env
 }
 
@@ -465,6 +531,10 @@ main() {
     run_test test_watchdog_skipped_when_machine_name_invalid
     run_test test_watchdog_skipped_when_agent_id_invalid
     run_test test_watchdog_skipped_when_vfkit_not_found
+
+    log_info "=== krunkit/vfkit alternation pattern (Issue #409) ==="
+    run_test test_watchdog_pgrep_pattern_matches_krunkit
+    run_test test_watchdog_not_found_branch_warns_not_debug
 
     log_info "=== Post-container exit-code override ==="
     run_test test_post_container_override_to_4_for_signal_exit


### PR DESCRIPTION
## Summary

Addresses part of #409.

vfkit and krunkit are mutually-exclusive Podman machine hypervisor processes on macOS (the `applehv` and `libkrun`/AVF providers, respectively) — only one runs per machine. The three sites that pattern-match the hypervisor process by name only matched the literal string `vfkit`:

- `scripts/lib/vfkit-watchdog.sh` — `pgrep -o -f "vfkit.*${machine}"`
- `scripts/lib/podman-health.sh` — test-context stub `_kill_vfkit_zombie`'s `pkill -9 -f "vfkit.*${1:-podman-machine-default}"`
- `scripts/lib/compat.sh` — the production `_kill_vfkit_zombie`'s `pkill -9 -f "vfkit.*${machine}"`

Any host running the `libkrun` provider therefore had **zero mount-drop protection**: the host-side vfkit watchdog (Issue #303) never found a PID to watch and silently never armed.

## Fix

Generalize the fixed `vfkit` pattern to the alternation `(vfkit|krunkit)` at all three sites — the identical string edit applied at three call sites, no provider-detection abstraction needed for a two-value union.

Also promotes the vfkit-watchdog's "process not found" branch from `log_debug` (invisible by default) to `log_warn`, since after this fix that branch only fires when the machine is up but genuinely no hypervisor process was found — a real anomaly worth surfacing by default. **This is a user-visible behavior change**: hosts that have silently run an inert watchdog since adopting libkrun/Podman 6.x will see a WARN on next run if the pattern still doesn't match (e.g. misconfigured machine name). `return 0` (non-fatal, no exit-code change) is preserved.

## Verification of the `krunkit` process-name claim

This host defaults to `applehv`, so the `krunkit` argv claim was verified against podman upstream source (v5.8.4) rather than a live libkrun machine:

- `pkg/machine/libkrun/stubber.go` defines `krunkitBinary = "krunkit"`, passed as the binary (argv[0]) to `apple.StartGenericAppleVM(...)`.
- Both the `libkrun` and `applehv` providers build their process arguments through the *same* shared `pkg/machine/apple/apple.go:StartGenericAppleVM` — so the machine name lands in argv (via socket/vsock paths derived from `mc.Name`) through an identical code path for both hypervisors. Since the existing `vfkit.*${machine}` pattern is the shipping basis for the entire zombie-recovery feature on `applehv` already, `krunkit` inherits the same match by construction.

## Deliberately out of scope (deferred to #409 follow-ups)

- `get_podman_machine_provider()` / `hypervisor_process_pattern()` abstraction, a `provider` config key in `agent-sandbox.yaml.template`, or a `machine_provider` field in `status.json` — the provider value only ever fed a log-level decision here, never a behavioral branch, so it doesn't warrant the Dashboard Sync Rule surface (types.ts / UI / CI gate). No dashboard changes are included in this PR.
- Gating `launch-lock.sh` / `exec-channel-watchdog.sh` on provider — their libkrun failure mode is "runs without benefit" (harmless overhead), not "silently provides zero protection." No change without field evidence of real cost.
- The unverified `${state_base}/libkrun/${machine}` stale-artifact path guess in `compat.sh`'s cleanup loop — no libkrun machine was available on this host to confirm the path shape.
- Calling `podman machine inspect` (or any podman subprocess) from `podman-health.sh`'s auto-heal path — that path exists specifically to handle podman being unresponsive; adding a detection subprocess there risks a hang.

`#409` is left open for these follow-ups.

## Test plan

Extended the three already-registered QUICK_TESTS suites (no new files, no `run-all-tests.sh` registration changes needed):

- `tests/test-vfkit-watchdog.sh` — added a case asserting the constructed `pgrep -f` pattern contains the `krunkit` alternative (`(vfkit|krunkit)`), and a case asserting the not-found branch now logs at WARN (not silently at DEBUG).
- `tests/test-podman-health.sh` — added an argv-capture case asserting the `pkill` pattern passed by `_kill_vfkit_zombie` contains `krunkit` as an alternative.
- `tests/test-compat.sh` — same argv-capture assertion for compat.sh's production `_kill_vfkit_zombie`.

Results:
- `shellcheck --severity=warning` (matching CI's threshold) on all 6 changed files: clean.
- All three modified/extended suites pass standalone: `test-compat.sh` (43/43), `test-podman-health.sh` (25/25), `test-vfkit-watchdog.sh` (17/17).
- The full `./tests/run-all-tests.sh --quick` aggregate did not complete cleanly in this local macOS sandbox — `test-dry-run-completeness.sh` (and, in a later full run, a couple of other unrelated `test-agent-*` files) hung/timed out. This reproduces identically with this PR's changes reverted (`git stash` back to unmodified `main`), and the hang point is non-deterministic across runs, indicating pre-existing local/environmental flakiness (podman/dry-run process interaction in this sandboxed shell) unrelated to this change — consistent with `CLAUDE.md`'s note that macOS container-adjacent tests can misbehave locally. CI's quick-test job (`.github/workflows/ci.yml`) runs on `ubuntu-latest`, which is unaffected by this class of issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)