### PR TITLE
fix(cleanup): add in-use guard to clean_worktrees to prevent deleting active agent worktrees

### DIFF
--- a/docs/CLEANUP.md
+++ b/docs/CLEANUP.md
@@ -104,10 +104,14 @@ cd ~/project && git worktree prune
 checks whether the worktree still belongs to an active agent, using a
 proportional-certainty guard (`scripts/lib/worktree-guard.sh`):
 
-1. **Terminal success (`phase: "complete"`)** — reaped unconditionally, with
-   zero Podman dependency. This is the only unambiguous "safe to reap"
-   signal, so a Podman outage or `podman` being absent from `PATH` never
-   blocks reclaiming these worktrees.
+1. **Terminal success (`phase: "complete"` with `exit_code: 0`)** — reaped
+   fast, with zero Podman dependency. This is the only unambiguous "safe to
+   reap" signal, so a Podman outage or `podman` being absent from `PATH`
+   never blocks reclaiming these worktrees. A non-zero `exit_code` (e.g. 3 —
+   uncommitted changes remain, or 6 — commit failure, both of which preserve
+   the worktree for manual recovery) or a missing/unparseable `exit_code` is
+   **not** fast-reaped: it falls through to the Podman corroboration and the
+   same age heuristic as step 2.
 2. **Terminal failure (`phase: error/failed/killed`)** — falls back to the
    same age heuristic as `worktree-manager.sh`'s opportunistic GC: directory
    mtime vs. `KAPSIS_CLEANUP_WORKTREE_MAX_AGE_HOURS` (default 168h/7 days).

--- a/docs/CLEANUP.md
+++ b/docs/CLEANUP.md
@@ -36,6 +36,7 @@ Reclaim disk space and clean up artifacts after agent work.
 | `--snapshots` | Clean per-agent snapshot dirs in `~/.kapsis/snapshots/` (included by default; explicit form for scripting) |
 | `--snapshots-older-than <days>` | Override the default 14-day TTL when cleaning snapshots |
 | `--vm-health` | Check Podman VM health: inode %, disk %, journal size (**macOS only**) |
+| `--include-active` | Bypass the worktree in-use guard (Issue #428) and remove worktrees even if they appear to belong to an active agent. Requires `--force`. **Dangerous** — see [In-Use Guard](#in-use-guard-issue-428) |
 | `--force`, `-f` | Skip confirmation prompts |
 | `--help`, `-h` | Show help message |
 
@@ -95,6 +96,44 @@ ls -la ~/.kapsis/worktrees/
 
 # Manual cleanup
 cd ~/project && git worktree prune
+```
+
+#### In-Use Guard (Issue #428)
+
+`clean_worktrees()` no longer removes a worktree unconditionally — it first
+checks whether the worktree still belongs to an active agent, using a
+proportional-certainty guard (`scripts/lib/worktree-guard.sh`):
+
+1. **Terminal success (`phase: "complete"`)** — reaped unconditionally, with
+   zero Podman dependency. This is the only unambiguous "safe to reap"
+   signal, so a Podman outage or `podman` being absent from `PATH` never
+   blocks reclaiming these worktrees.
+2. **Terminal failure (`phase: error/failed/killed`)** — falls back to the
+   same age heuristic as `worktree-manager.sh`'s opportunistic GC: directory
+   mtime vs. `KAPSIS_CLEANUP_WORKTREE_MAX_AGE_HOURS` (default 168h/7 days).
+3. **Ambiguous (`phase: running/initializing/...`, or a missing status
+   file)** — freshness of `status.json`'s `updated_at` against the liveness
+   timeout+grace (`KAPSIS_LIVENESS_TIMEOUT` + `KAPSIS_LIVENESS_GRACE_PERIOD`,
+   default 900s+300s = 1200s) decides "in use" (skipped) vs. "stale" (falls
+   through to step 4).
+4. **Best-effort Podman corroboration** — for stale/ambiguous entries only,
+   a `podman ps --filter label=kapsis.agent-id=<id>` check (timeout-wrapped)
+   can confirm a live container and force a skip. **Fail-open**: if Podman
+   is unreachable, times out, or has no timeout binary available, the check
+   is skipped and the verdict degrades to the age heuristic above — it
+   never blocks reaping unrelated complete-phase worktrees in the same run,
+   and it never forces a "reap" verdict by itself.
+
+Skipped worktrees are reported as `[SKIPPED]` with a reason and are **not**
+counted toward the cleaned-item/space-freed totals.
+
+**Escape hatch:** `--include-active` (requires `--force`) bypasses the guard
+entirely and removes worktrees regardless of phase or heartbeat freshness.
+This is logged at `WARN` and intended only for operators who understand the
+risk of deleting a live agent's uncommitted work:
+
+```bash
+./scripts/kapsis-cleanup.sh --worktrees --include-active --force
 ```
 
 ### Sandboxes

--- a/scripts/kapsis-cleanup.sh
+++ b/scripts/kapsis-cleanup.sh
@@ -41,6 +41,11 @@ if [[ -f "$SCRIPT_DIR/lib/constants.sh" ]]; then
     source "$SCRIPT_DIR/lib/constants.sh"
 fi
 
+# Source the worktree in-use guard (Issue #428)
+if [[ -f "$SCRIPT_DIR/lib/worktree-guard.sh" ]]; then
+    source "$SCRIPT_DIR/lib/worktree-guard.sh"
+fi
+
 # Directories
 KAPSIS_DIR="${KAPSIS_DIR:-$HOME/.kapsis}"
 WORKTREE_DIR="${KAPSIS_WORKTREE_DIR:-$KAPSIS_DIR/worktrees}"
@@ -64,6 +69,7 @@ CLEAN_WORKTREES=false
 CLEAN_SNAPSHOTS=false
 CLEAN_REPAIR=false
 PRUNE_DANGLING=false
+INCLUDE_ACTIVE=false
 SNAPSHOTS_TTL_OVERRIDE=""
 
 # Module-level corruption tracking (set by clean_containers when store errors detected)
@@ -110,6 +116,10 @@ OPTIONS:
     --ssh-cache         Clear cached SSH host keys from keychain
     --branches          Clean stale agent branches (requires --project)
     --worktrees         Clean git worktrees (included by default, explicit for scripting)
+    --include-active    Bypass the in-use guard and remove worktrees even if
+                        they appear to belong to an active agent (requires
+                        --force). DANGEROUS: only for operators who
+                        understand the risk of deleting a live agent's work.
     --snapshots         Clean per-agent snapshot dirs in ~/.kapsis/snapshots/
                         (included by default; explicit form for scripting)
     --snapshots-older-than <days>
@@ -314,6 +324,17 @@ clean_worktrees() {
         fi
         if [[ -n "$AGENT_FILTER" ]] && [[ "$name" != "${PROJECT_FILTER}-${AGENT_FILTER}" ]]; then
             continue
+        fi
+
+        # In-use guard (Issue #428): skip worktrees that belong to agents
+        # which are not in a terminal-complete phase and are not old enough
+        # (or podman-confirmed idle) to reap. --include-active bypasses this.
+        if [[ "$INCLUDE_ACTIVE" != "true" ]] && declare -f worktree_is_safe_to_reap &>/dev/null; then
+            local status_file="${STATUS_DIR}/kapsis-${name}.json"
+            if ! worktree_is_safe_to_reap "$status_file" "$worktree"; then
+                print_item_skipped "worktree" "$name" "${WORKTREE_GUARD_SKIP_REASON:-in use}"
+                continue
+            fi
         fi
 
         local size
@@ -1751,6 +1772,10 @@ main() {
                 explicit_action_requested=true
                 shift
                 ;;
+            --include-active)
+                INCLUDE_ACTIVE=true
+                shift
+                ;;
             --snapshots)
                 CLEAN_SNAPSHOTS=true
                 explicit_action_requested=true
@@ -1796,6 +1821,17 @@ main() {
                 ;;
         esac
     done
+
+    # --include-active bypasses the Issue #428 in-use guard entirely, so
+    # require --force too (mirrors CLEAN_ALL's confirmation precedent below)
+    # to make sure an operator opts in deliberately.
+    if [[ "$INCLUDE_ACTIVE" == "true" ]]; then
+        if [[ "$FORCE" != "true" ]]; then
+            log_error "--include-active requires --force"
+            exit 1
+        fi
+        log_warn "--include-active: bypassing the in-use guard -- worktrees belonging to active agents may be removed"
+    fi
 
     echo -e "${BOLD}Kapsis Cleanup${NC}"
     if [[ "$DRY_RUN" == "true" ]]; then

--- a/scripts/kapsis-cleanup.sh
+++ b/scripts/kapsis-cleanup.sh
@@ -41,9 +41,12 @@ if [[ -f "$SCRIPT_DIR/lib/constants.sh" ]]; then
     source "$SCRIPT_DIR/lib/constants.sh"
 fi
 
-# Source the worktree in-use guard (Issue #428)
+# Source the worktree in-use guard (Issue #428). Fail-open by design: if the
+# library is missing or fails to source, clean_worktrees() reverts to
+# unconditional deletion (pre-#428 behavior) -- clean_worktrees() warns once
+# when that degradation is active.
 if [[ -f "$SCRIPT_DIR/lib/worktree-guard.sh" ]]; then
-    source "$SCRIPT_DIR/lib/worktree-guard.sh"
+    source "$SCRIPT_DIR/lib/worktree-guard.sh" || true
 fi
 
 # Directories
@@ -291,6 +294,15 @@ print_item_skipped() {
 # Clean worktrees
 clean_worktrees() {
     section "Worktrees"
+
+    # Degradation visibility (Issue #428): if lib/worktree-guard.sh could not
+    # be loaded, the loop below falls back to unconditional deletion (the
+    # pre-#428 behavior). That fail-open fallback is by design, but it must
+    # not be silent -- warn once per run. (--include-active is a deliberate
+    # operator bypass and already warns at argument parsing time.)
+    if [[ "$INCLUDE_ACTIVE" != "true" ]] && ! declare -f worktree_is_safe_to_reap &>/dev/null; then
+        log_warn "worktree in-use guard unavailable (lib/worktree-guard.sh missing or failed to load) -- worktrees will be removed unconditionally"
+    fi
 
     if [[ ! -d "$WORKTREE_DIR" ]]; then
         echo "  No worktree directory found"

--- a/scripts/lib/worktree-guard.sh
+++ b/scripts/lib/worktree-guard.sh
@@ -194,13 +194,41 @@ worktree_is_safe_to_reap() {
     local phase
     phase=$(grep -o '"phase"[[:space:]]*:[[:space:]]*"[^"]*"' "$status_file" 2>/dev/null | cut -d'"' -f4)
 
-    # --- Terminal success: reap unconditionally, zero Podman dependency ---
-    if [[ "$phase" == "complete" ]]; then
-        return 0
-    fi
-
     local agent_id=""
     agent_id=$(_worktree_guard_agent_id "$worktree_name") || true
+
+    # --- Terminal phase "complete": exit_code determines the verdict.
+    # status_complete() writes phase="complete" for EVERY exit code,
+    # including 3 (uncommitted changes remain) and 6 (commit failed) --
+    # both of which are designed to preserve the worktree for manual
+    # recovery. Only exit_code 0 is a true zero-Podman-dependency,
+    # unambiguous "safe to reap" signal. Any other exit_code (or a
+    # missing/unparseable one) must NOT be fast-reaped.
+    if [[ "$phase" == "complete" ]]; then
+        local exit_code
+        exit_code=$(grep -o '"exit_code"[[:space:]]*:[[:space:]]*[0-9]*' "$status_file" 2>/dev/null | grep -o '[0-9]*$')
+
+        if [[ "$exit_code" == "0" ]]; then
+            return 0
+        fi
+
+        if [[ -z "$exit_code" ]]; then
+            # Missing/unparseable exit_code -- fail-safe: skip rather than
+            # risk deleting a worktree preserved for manual recovery.
+            WORKTREE_GUARD_SKIP_REASON="phase: complete, exit_code unavailable"
+            return 1
+        fi
+
+        # Non-zero exit_code (e.g. 3, 6): route through the same
+        # age-fallback used for terminal failure phases below.
+        if [[ -n "$agent_id" ]] && _worktree_guard_podman_live "$agent_id"; then
+            WORKTREE_GUARD_SKIP_REASON="live container found (phase: complete, exit_code: ${exit_code})"
+            return 1
+        fi
+        _worktree_guard_age_verdict "$worktree_path" && return 0
+        [[ -z "$WORKTREE_GUARD_SKIP_REASON" ]] && WORKTREE_GUARD_SKIP_REASON="phase: complete, exit_code: ${exit_code}, not yet aged out"
+        return 1
+    fi
 
     # --- Terminal failure phases: same age-fallback as gc_stale_worktrees() ---
     if [[ "$phase" == "error" || "$phase" == "failed" || "$phase" == "killed" ]]; then

--- a/scripts/lib/worktree-guard.sh
+++ b/scripts/lib/worktree-guard.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+#===============================================================================
+# worktree-guard.sh - Proportional-certainty in-use guard for worktree reaping
+#                     (Issue #428)
+#
+# Sourced-only library. Do not execute directly.
+#
+# Problem: kapsis-cleanup.sh's clean_worktrees() removed every directory
+# under the worktree root unconditionally -- including worktrees belonging
+# to agents that are still actively running. This library adds a guard that
+# callers invoke before deleting a worktree.
+#
+# Design (see design brief for Issue #428 for full rationale):
+#   - status.json phase == "complete" is the sole zero-Podman-dependency,
+#     unambiguous "safe to reap" signal -- reaped unconditionally.
+#   - phase in error/failed/killed, or a missing status file, fall back to
+#     the same age heuristic already used by worktree-manager.sh's
+#     gc_stale_worktrees() (KAPSIS_CLEANUP_WORKTREE_MAX_AGE_HOURS, default
+#     168h), optionally corroborated by a best-effort Podman label check
+#     that can force a "skip" verdict if a live container is found.
+#   - Any other phase (running/initializing/preparing/starting/committing/
+#     pushing/post_processing/...) is treated as ambiguous: freshness of
+#     status.json's updated_at against the liveness timeout+grace decides
+#     "in use" (skip) vs. "stale" (fall through to the Podman check, then
+#     the age heuristic).
+#
+# Fail-open guarantee: a Podman query failure/timeout/absence NEVER causes
+# a skip-by-itself and NEVER blocks reaping of unrelated complete-phase
+# worktrees in the same run -- it only removes the corroboration signal for
+# the one ambiguous entry being evaluated, which then falls back to the age
+# heuristic (matches the existing 168h caution baked into
+# gc_stale_worktrees()'s error/failed/killed branch).
+#
+# Public API:
+#   worktree_is_safe_to_reap <status_file> <worktree_path>
+#     Returns 0 = safe to reap, 1 = skip (in use / ambiguous / retain).
+#     On return 1, sets WORKTREE_GUARD_SKIP_REASON to a short human-readable
+#     explanation suitable for print_item_skipped()'s "reason" argument.
+#===============================================================================
+
+[[ -n "${_KAPSIS_WORKTREE_GUARD_LOADED:-}" ]] && return 0
+_KAPSIS_WORKTREE_GUARD_LOADED=1
+
+WORKTREE_GUARD_SKIP_REASON=""
+
+#-------------------------------------------------------------------------------
+# _worktree_guard_agent_id <worktree_dirname>
+#
+# Extracts the trailing agent-id from a worktree directory name using the
+# verified naming convention <project>-<6-hex-agent-id> (matches
+# worktree-manager.sh's create_worktree()/generate_agent_id()).
+#
+# Prints the agent-id and returns 0 on match; prints nothing and returns 1
+# if the name doesn't match the convention (unparseable -> caller should
+# fail toward retaining, not deleting).
+#-------------------------------------------------------------------------------
+_worktree_guard_agent_id() {
+    local dirname="$1"
+    if [[ "$dirname" =~ ^(.+)-([0-9a-f]{6})$ ]]; then
+        echo "${BASH_REMATCH[2]}"
+        return 0
+    fi
+    return 1
+}
+
+#-------------------------------------------------------------------------------
+# _worktree_guard_ts_to_epoch <iso8601_timestamp>
+#
+# Converts a status.json ISO-8601 UTC timestamp (e.g. 2026-07-03T12:34:56Z,
+# written by status.sh's _status_timestamp) to Unix epoch seconds.
+# Cross-platform (GNU date -d / BSD date -j -f). Prints "0" on failure.
+#-------------------------------------------------------------------------------
+_worktree_guard_ts_to_epoch() {
+    local ts="$1"
+    ts="${ts%Z}"
+    ts="${ts/T/ }"
+    date -u -d "$ts" +%s 2>/dev/null || \
+        date -u -j -f "%Y-%m-%d %H:%M:%S" "$ts" +%s 2>/dev/null || \
+        echo "0"
+}
+
+#-------------------------------------------------------------------------------
+# _worktree_guard_age_verdict <worktree_path>
+#
+# Age-based fallback verdict shared by the missing-status-file and
+# error/failed/killed branches. Mirrors gc_stale_worktrees()
+# (worktree-manager.sh) exactly: directory mtime vs.
+# KAPSIS_CLEANUP_WORKTREE_MAX_AGE_HOURS (default 168h).
+#
+# Returns 0 = reap (older than max age, or max age disabled via 0),
+# 1 = skip (younger than max age, or mtime unavailable).
+#-------------------------------------------------------------------------------
+_worktree_guard_age_verdict() {
+    local worktree_path="$1"
+    local max_age_hours="${KAPSIS_CLEANUP_WORKTREE_MAX_AGE_HOURS:-${KAPSIS_DEFAULT_CLEANUP_WORKTREE_MAX_AGE_HOURS:-168}}"
+
+    if ! [[ "$max_age_hours" =~ ^[0-9]+$ ]] || (( max_age_hours <= 0 )); then
+        # max_age_hours=0 (or invalid) disables age-based reaping entirely.
+        WORKTREE_GUARD_SKIP_REASON="age-based cleanup disabled"
+        return 1
+    fi
+
+    if ! declare -f get_dir_mtime &>/dev/null; then
+        WORKTREE_GUARD_SKIP_REASON="mtime helper unavailable"
+        return 1
+    fi
+
+    local mtime
+    mtime=$(get_dir_mtime "$worktree_path") || {
+        WORKTREE_GUARD_SKIP_REASON="mtime unavailable"
+        return 1
+    }
+    [[ -z "$mtime" ]] && {
+        WORKTREE_GUARD_SKIP_REASON="mtime unavailable"
+        return 1
+    }
+
+    local age_secs max_age_secs
+    age_secs=$(( $(date +%s) - mtime ))
+    max_age_secs=$(( max_age_hours * 3600 ))
+
+    if (( age_secs > max_age_secs )); then
+        return 0
+    fi
+
+    WORKTREE_GUARD_SKIP_REASON="younger than ${max_age_hours}h max age"
+    return 1
+}
+
+#-------------------------------------------------------------------------------
+# _worktree_guard_podman_live <agent_id>
+#
+# Best-effort, fail-open Podman corroboration: is there a running container
+# labeled kapsis.agent-id=<agent_id>? Uses the existing timeout helper
+# (compat.sh's _KAPSIS_TIMEOUT_CMD) so a hung Podman VM cannot hang the
+# housekeeper. Never used to force a "reap" verdict -- only ever to force
+# or confirm a "skip" verdict when a live container is actually found.
+#
+# Returns 0 = live container found (skip), 1 = not found or check
+# unavailable/failed (no signal either way -- caller falls back to the age
+# heuristic; this is the fail-open path).
+#-------------------------------------------------------------------------------
+_worktree_guard_podman_live() {
+    local agent_id="$1"
+
+    command -v podman &>/dev/null || return 1
+
+    # Guardrail: never issue an unwrapped Podman call. If no timeout binary
+    # is available, skip the check entirely (fail open) rather than risk
+    # hanging the housekeeper on a stuck VM.
+    [[ -n "${_KAPSIS_TIMEOUT_CMD:-}" ]] || return 1
+
+    local container_id
+    container_id=$("$_KAPSIS_TIMEOUT_CMD" 5 podman ps \
+        --filter "label=kapsis.agent-id=${agent_id}" \
+        --format "{{.ID}}" 2>/dev/null | head -1) || return 1
+
+    [[ -n "$container_id" ]]
+}
+
+#-------------------------------------------------------------------------------
+# worktree_is_safe_to_reap <status_file> <worktree_path>
+#
+# Public entry point. See file header for full decision logic.
+#-------------------------------------------------------------------------------
+worktree_is_safe_to_reap() {
+    local status_file="$1"
+    local worktree_path="$2"
+    local worktree_name
+    worktree_name=$(basename "$worktree_path")
+
+    WORKTREE_GUARD_SKIP_REASON=""
+
+    # --- Missing status file: age-fallback, optionally corroborated ---
+    if [[ ! -f "$status_file" ]]; then
+        local agent_id
+        if agent_id=$(_worktree_guard_agent_id "$worktree_name"); then
+            if _worktree_guard_podman_live "$agent_id"; then
+                WORKTREE_GUARD_SKIP_REASON="live container found (no status file)"
+                return 1
+            fi
+        else
+            # Unparseable name -- fail toward retaining, not deleting.
+            WORKTREE_GUARD_SKIP_REASON="unparseable worktree name, no status file"
+            return 1
+        fi
+        _worktree_guard_age_verdict "$worktree_path" && return 0
+        [[ -z "$WORKTREE_GUARD_SKIP_REASON" ]] && WORKTREE_GUARD_SKIP_REASON="no status file, not yet aged out"
+        return 1
+    fi
+
+    # Dependency-free phase extraction -- mirrors clean_status()'s existing
+    # grep pattern (kapsis-cleanup.sh) rather than requiring jq.
+    local phase
+    phase=$(grep -o '"phase"[[:space:]]*:[[:space:]]*"[^"]*"' "$status_file" 2>/dev/null | cut -d'"' -f4)
+
+    # --- Terminal success: reap unconditionally, zero Podman dependency ---
+    if [[ "$phase" == "complete" ]]; then
+        return 0
+    fi
+
+    local agent_id=""
+    agent_id=$(_worktree_guard_agent_id "$worktree_name") || true
+
+    # --- Terminal failure phases: same age-fallback as gc_stale_worktrees() ---
+    if [[ "$phase" == "error" || "$phase" == "failed" || "$phase" == "killed" ]]; then
+        if [[ -n "$agent_id" ]] && _worktree_guard_podman_live "$agent_id"; then
+            WORKTREE_GUARD_SKIP_REASON="live container found (phase: ${phase})"
+            return 1
+        fi
+        _worktree_guard_age_verdict "$worktree_path" && return 0
+        [[ -z "$WORKTREE_GUARD_SKIP_REASON" ]] && WORKTREE_GUARD_SKIP_REASON="phase: ${phase}, not yet aged out"
+        return 1
+    fi
+
+    # --- Ambiguous phase (running/initializing/... or unrecognized/empty) ---
+    # Never use top-level directory mtime here -- get_dir_mtime only updates
+    # on direct-child add/remove/rename, so a long agent run editing nested
+    # files won't bump it (verified trap). Use status.json's updated_at
+    # against the liveness timeout+grace instead.
+    local updated_at
+    updated_at=$(grep -o '"updated_at"[[:space:]]*:[[:space:]]*"[^"]*"' "$status_file" 2>/dev/null | cut -d'"' -f4)
+
+    local heartbeat_fresh=false
+    if [[ -n "$updated_at" ]]; then
+        local updated_epoch now stale_secs threshold_secs
+        updated_epoch=$(_worktree_guard_ts_to_epoch "$updated_at")
+        if [[ "$updated_epoch" != "0" ]]; then
+            now=$(date +%s)
+            stale_secs=$(( now - updated_epoch ))
+            local liveness_timeout="${KAPSIS_LIVENESS_TIMEOUT:-900}"
+            local liveness_grace="${KAPSIS_LIVENESS_GRACE_PERIOD:-300}"
+            threshold_secs=$(( liveness_timeout + liveness_grace ))
+            if (( stale_secs < threshold_secs )); then
+                heartbeat_fresh=true
+            fi
+        fi
+    fi
+
+    if [[ "$heartbeat_fresh" == "true" ]]; then
+        WORKTREE_GUARD_SKIP_REASON="in use (phase: ${phase:-unknown}, fresh heartbeat)"
+        return 1
+    fi
+
+    # Heartbeat is stale (or missing/unparseable) -- try the Podman
+    # corroboration as a tiebreaker, then fall back to the age heuristic.
+    # A Podman failure/timeout here degrades to the age verdict (fail-open),
+    # it never forces a "reap".
+    if [[ -n "$agent_id" ]] && _worktree_guard_podman_live "$agent_id"; then
+        WORKTREE_GUARD_SKIP_REASON="live container found (phase: ${phase:-unknown}, stale heartbeat)"
+        return 1
+    fi
+
+    _worktree_guard_age_verdict "$worktree_path" && return 0
+    [[ -z "$WORKTREE_GUARD_SKIP_REASON" ]] && WORKTREE_GUARD_SKIP_REASON="phase: ${phase:-unknown}, stale heartbeat, not yet aged out"
+    return 1
+}

--- a/scripts/lib/worktree-guard.sh
+++ b/scripts/lib/worktree-guard.sh
@@ -50,9 +50,15 @@ WORKTREE_GUARD_SKIP_REASON=""
 # verified naming convention <project>-<6-hex-agent-id> (matches
 # worktree-manager.sh's create_worktree()/generate_agent_id()).
 #
+# Known limitation: launch-agent.sh also accepts a user-supplied --agent-id
+# matching ^[a-zA-Z0-9_-]+$, which this parser deliberately does NOT try to
+# handle -- project names may themselves contain hyphens, so splitting
+# <project>-<arbitrary-agent-id> is ambiguous. Callers must treat a parse
+# failure as "no Podman corroboration available" and fall back to the age
+# heuristic, NOT as a reason to retain the worktree forever.
+#
 # Prints the agent-id and returns 0 on match; prints nothing and returns 1
-# if the name doesn't match the convention (unparseable -> caller should
-# fail toward retaining, not deleting).
+# if the name doesn't match the convention.
 #-------------------------------------------------------------------------------
 _worktree_guard_agent_id() {
     local dirname="$1"
@@ -179,11 +185,13 @@ worktree_is_safe_to_reap() {
                 WORKTREE_GUARD_SKIP_REASON="live container found (no status file)"
                 return 1
             fi
-        else
-            # Unparseable name -- fail toward retaining, not deleting.
-            WORKTREE_GUARD_SKIP_REASON="unparseable worktree name, no status file"
-            return 1
         fi
+        # An unparseable name (e.g. a user-supplied --agent-id that doesn't
+        # match the <project>-<6-hex> convention -- see
+        # _worktree_guard_agent_id) simply means Podman corroboration is
+        # unavailable; the age heuristic below still decides the verdict.
+        # Retaining unconditionally here would make such a worktree
+        # permanently un-reapable.
         _worktree_guard_age_verdict "$worktree_path" && return 0
         [[ -z "$WORKTREE_GUARD_SKIP_REASON" ]] && WORKTREE_GUARD_SKIP_REASON="no status file, not yet aged out"
         return 1

--- a/tests/test-worktree-cleanup.sh
+++ b/tests/test-worktree-cleanup.sh
@@ -458,6 +458,11 @@ setup_guard_test() {
     local agent_id="$1"
     local phase="$2"
     local updated_at="${3:-}"
+    # Real status_complete() always writes a concrete exit_code (default 0)
+    # once phase=complete -- default to "0" here so complete-phase fixtures
+    # match production JSON shape and exercise the fast-reap path rather
+    # than the guard's fail-safe (missing exit_code) branch.
+    local exit_code="${4:-0}"
 
     source "$KAPSIS_ROOT/scripts/worktree-manager.sh"
 
@@ -484,10 +489,10 @@ setup_guard_test() {
     create_worktree "$GUARD_PROJECT" "$agent_id" "feature/guard-test-${agent_id}" >/dev/null
 
     if [[ -n "$updated_at" ]]; then
-        echo '{"phase": "'"$phase"'", "agent_id": "'"$agent_id"'", "updated_at": "'"$updated_at"'"}' \
+        echo '{"phase": "'"$phase"'", "agent_id": "'"$agent_id"'", "updated_at": "'"$updated_at"'", "exit_code": '"$exit_code"'}' \
             > "$GUARD_STATUS_FILE"
     else
-        echo '{"phase": "'"$phase"'", "agent_id": "'"$agent_id"'"}' > "$GUARD_STATUS_FILE"
+        echo '{"phase": "'"$phase"'", "agent_id": "'"$agent_id"'", "exit_code": '"$exit_code"'}' > "$GUARD_STATUS_FILE"
     fi
 }
 
@@ -524,7 +529,7 @@ test_clean_worktrees_reaps_complete_without_podman() {
 
     local agent_id
     agent_id=$(printf '%06x' "$(( $$ + 1 ))")
-    setup_guard_test "$agent_id" "complete"
+    setup_guard_test "$agent_id" "complete" "" 0
 
     local cleanup_script="$KAPSIS_ROOT/scripts/kapsis-cleanup.sh"
     # Minimal system PATH with no podman -- proves the complete-phase fast
@@ -575,7 +580,7 @@ test_clean_worktrees_podman_failure_does_not_block_other_removals() {
 
     local complete_agent_id
     complete_agent_id=$(printf '%06x' "$(( $$ + 3 ))")
-    setup_guard_test "$complete_agent_id" "complete"
+    setup_guard_test "$complete_agent_id" "complete" "" 0
     local complete_worktree_path="$GUARD_WORKTREE_PATH"
     local shared_tmp="$GUARD_TMP_DIR"
     local shared_project="$GUARD_PROJECT"

--- a/tests/test-worktree-cleanup.sh
+++ b/tests/test-worktree-cleanup.sh
@@ -635,6 +635,124 @@ EOF
     return 0
 }
 
+test_clean_worktrees_preserves_complete_exit_code_3() {
+    log_test "Testing clean_worktrees preserves phase=complete with exit_code=3"
+
+    # Exit code 3 = uncommitted changes remain -- the worktree is deliberately
+    # preserved for manual recovery, so the guard must NOT fast-reap it.
+    local agent_id
+    agent_id=$(printf '%06x' "$(( $$ + 5 ))")
+    setup_guard_test "$agent_id" "complete" "" 3
+
+    local cleanup_script="$KAPSIS_ROOT/scripts/kapsis-cleanup.sh"
+    # Minimal PATH with no podman -- isolates the exit_code branch from any
+    # live-container corroboration on the host.
+    PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        KAPSIS_DIR="$GUARD_TMP_DIR" "$cleanup_script" --force >/dev/null 2>&1 || true
+
+    assert_dir_exists "$GUARD_WORKTREE_PATH" \
+        "phase=complete, exit_code=3 worktree must survive kapsis-cleanup --force"
+
+    teardown_guard_test "$agent_id"
+}
+
+test_clean_worktrees_preserves_complete_exit_code_6() {
+    log_test "Testing clean_worktrees preserves phase=complete with exit_code=6"
+
+    # Exit code 6 = commit failure -- worktree kept with staged changes.
+    local agent_id
+    agent_id=$(printf '%06x' "$(( $$ + 6 ))")
+    setup_guard_test "$agent_id" "complete" "" 6
+
+    local cleanup_script="$KAPSIS_ROOT/scripts/kapsis-cleanup.sh"
+    PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        KAPSIS_DIR="$GUARD_TMP_DIR" "$cleanup_script" --force >/dev/null 2>&1 || true
+
+    assert_dir_exists "$GUARD_WORKTREE_PATH" \
+        "phase=complete, exit_code=6 worktree must survive kapsis-cleanup --force"
+
+    teardown_guard_test "$agent_id"
+}
+
+test_include_active_without_force_rejected() {
+    log_test "Testing --include-active without --force is rejected"
+
+    local cleanup_script="$KAPSIS_ROOT/scripts/kapsis-cleanup.sh"
+    local tmp_dir output
+    local exit_code=0
+    tmp_dir=$(mktemp -d)
+    output=$(KAPSIS_DIR="$tmp_dir" "$cleanup_script" --worktrees --include-active 2>&1) || exit_code=$?
+    rm -rf "$tmp_dir" 2>/dev/null || true
+
+    assert_equals "1" "$exit_code" "--include-active without --force should exit 1"
+    assert_contains "$output" "requires --force" \
+        "Rejection message should explain that --force is required"
+}
+
+test_clean_worktrees_include_active_reaps_guarded() {
+    log_test "Testing --include-active --force reaps a worktree the guard would retain"
+
+    # phase=running with a fresh heartbeat -- the guard retains this (see
+    # test_clean_worktrees_preserves_running_fresh_heartbeat); the operator
+    # escape hatch must bypass the guard and reap it anyway.
+    local agent_id
+    agent_id=$(printf '%06x' "$(( $$ + 7 ))")
+    local now
+    now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    setup_guard_test "$agent_id" "running" "$now"
+
+    local cleanup_script="$KAPSIS_ROOT/scripts/kapsis-cleanup.sh"
+    KAPSIS_DIR="$GUARD_TMP_DIR" "$cleanup_script" --force --include-active >/dev/null 2>&1 || true
+
+    if [[ -d "$GUARD_WORKTREE_PATH" ]]; then
+        log_fail "--include-active --force should bypass the guard and reap a fresh-heartbeat worktree"
+        teardown_guard_test "$agent_id"
+        return 1
+    fi
+
+    rm -rf "$GUARD_TMP_DIR" 2>/dev/null || true
+    return 0
+}
+
+test_clean_worktrees_unparseable_name_age_fallback() {
+    log_test "Testing unparseable-name worktree with no status file uses the age fallback"
+
+    # Agent id whose trailing 6 chars are NOT lowercase hex, so
+    # _worktree_guard_agent_id cannot parse the worktree name (mirrors a
+    # user-supplied --agent-id, which launch-agent.sh permits). No status
+    # file either -- previously this combination was retained forever.
+    local agent_id="notparsezz"
+    setup_guard_test "$agent_id" "running" ""
+    rm -f "$GUARD_STATUS_FILE"
+
+    local cleanup_script="$KAPSIS_ROOT/scripts/kapsis-cleanup.sh"
+
+    # Fresh worktree: younger than the 168h max age -- must be retained.
+    PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        KAPSIS_DIR="$GUARD_TMP_DIR" "$cleanup_script" --force >/dev/null 2>&1 || true
+    assert_dir_exists "$GUARD_WORKTREE_PATH" \
+        "Fresh unparseable-name worktree should be retained by the age fallback"
+
+    # Backdate past the 168h max age: the age fallback must now reap it
+    # (before the follow-up fix it was permanently un-reapable).
+    local old_time=$(($(date +%s) - 8 * 24 * 3600))
+    touch -t "$(date -r "$old_time" +%Y%m%d%H%M.%S 2>/dev/null || date -d "@$old_time" +%Y%m%d%H%M.%S 2>/dev/null)" "$GUARD_WORKTREE_PATH" 2>/dev/null || {
+        # Fallback: try GNU touch
+        touch -d "@$old_time" "$GUARD_WORKTREE_PATH" 2>/dev/null || true
+    }
+    PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        KAPSIS_DIR="$GUARD_TMP_DIR" "$cleanup_script" --force >/dev/null 2>&1 || true
+
+    if [[ -d "$GUARD_WORKTREE_PATH" ]]; then
+        log_fail "Aged-out unparseable-name worktree should be reaped via the age fallback"
+        teardown_guard_test "$agent_id"
+        return 1
+    fi
+
+    rm -rf "$GUARD_TMP_DIR" 2>/dev/null || true
+    return 0
+}
+
 #===============================================================================
 # MAIN
 #===============================================================================
@@ -679,6 +797,11 @@ main() {
     run_test test_clean_worktrees_reaps_complete_without_podman
     run_test test_clean_worktrees_skips_running_stale_heartbeat_no_podman_hit
     run_test test_clean_worktrees_podman_failure_does_not_block_other_removals
+    run_test test_clean_worktrees_preserves_complete_exit_code_3
+    run_test test_clean_worktrees_preserves_complete_exit_code_6
+    run_test test_include_active_without_force_rejected
+    run_test test_clean_worktrees_include_active_reaps_guarded
+    run_test test_clean_worktrees_unparseable_name_age_fallback
 
     # Cleanup
     cleanup_test_project

--- a/tests/test-worktree-cleanup.sh
+++ b/tests/test-worktree-cleanup.sh
@@ -437,42 +437,243 @@ test_cleanup_config_env_override() {
 }
 
 #===============================================================================
+# IN-USE GUARD TESTS (Issue #428)
+#
+# clean_worktrees() in kapsis-cleanup.sh previously removed every worktree
+# unconditionally -- these tests exercise that function directly (via
+# `kapsis-cleanup.sh --force`), fully isolated from the real ~/.kapsis tree
+# via a per-test KAPSIS_DIR override, so they never touch a developer's
+# live agents or unrelated projects.
+#===============================================================================
+
+# Create a worktree + status file pair, isolated under a temp KAPSIS_DIR.
+# Sets GUARD_TMP_DIR, GUARD_PROJECT, GUARD_WORKTREE_PATH, GUARD_STATUS_FILE
+# for the caller.
+#
+# Uses a dedicated project dir (NOT $TEST_PROJECT) because $TEST_PROJECT is
+# named "$HOME/.kapsis-test-project-$$" (leading dot) -- clean_worktrees()'s
+# `"$WORKTREE_DIR"/*` glob does not match dotfiles, which would make these
+# guard tests spuriously fail regardless of the guard's own correctness.
+setup_guard_test() {
+    local agent_id="$1"
+    local phase="$2"
+    local updated_at="${3:-}"
+
+    source "$KAPSIS_ROOT/scripts/worktree-manager.sh"
+
+    GUARD_TMP_DIR=$(mktemp -d)
+    KAPSIS_WORKTREE_BASE="${GUARD_TMP_DIR}/worktrees"
+    mkdir -p "${GUARD_TMP_DIR}/status"
+
+    GUARD_PROJECT="${GUARD_TMP_DIR}/project"
+    mkdir -p "$GUARD_PROJECT"
+    git init -q "$GUARD_PROJECT"
+    git -C "$GUARD_PROJECT" config user.email "test@kapsis.local"
+    git -C "$GUARD_PROJECT" config user.name "Kapsis Test"
+    git -C "$GUARD_PROJECT" config commit.gpgsign false
+    git -C "$GUARD_PROJECT" config tag.gpgsign false
+    echo "guard test" > "$GUARD_PROJECT/README.md"
+    git -C "$GUARD_PROJECT" add -A
+    git -C "$GUARD_PROJECT" commit -q -m "Initial guard test project"
+
+    local project_name
+    project_name=$(basename "$GUARD_PROJECT")
+    GUARD_WORKTREE_PATH="${KAPSIS_WORKTREE_BASE}/${project_name}-${agent_id}"
+    GUARD_STATUS_FILE="${GUARD_TMP_DIR}/status/kapsis-${project_name}-${agent_id}.json"
+
+    create_worktree "$GUARD_PROJECT" "$agent_id" "feature/guard-test-${agent_id}" >/dev/null
+
+    if [[ -n "$updated_at" ]]; then
+        echo '{"phase": "'"$phase"'", "agent_id": "'"$agent_id"'", "updated_at": "'"$updated_at"'"}' \
+            > "$GUARD_STATUS_FILE"
+    else
+        echo '{"phase": "'"$phase"'", "agent_id": "'"$agent_id"'"}' > "$GUARD_STATUS_FILE"
+    fi
+}
+
+teardown_guard_test() {
+    local agent_id="$1"
+
+    source "$KAPSIS_ROOT/scripts/worktree-manager.sh" 2>/dev/null || true
+    cleanup_worktree "$GUARD_PROJECT" "$agent_id" 2>/dev/null || true
+    rm -rf "$GUARD_TMP_DIR" 2>/dev/null || true
+}
+
+test_clean_worktrees_preserves_running_fresh_heartbeat() {
+    log_test "Testing clean_worktrees preserves phase=running with fresh heartbeat"
+
+    local agent_id
+    agent_id=$(printf '%06x' "$$")
+    local now
+    now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    setup_guard_test "$agent_id" "running" "$now"
+
+    local cleanup_script="$KAPSIS_ROOT/scripts/kapsis-cleanup.sh"
+    KAPSIS_DIR="$GUARD_TMP_DIR" "$cleanup_script" --force >/dev/null 2>&1 || true
+
+    assert_dir_exists "$GUARD_WORKTREE_PATH" \
+        "Worktree with fresh heartbeat should survive kapsis-cleanup --force"
+    assert_file_exists "$GUARD_WORKTREE_PATH/.git" \
+        "Worktree .git metadata should survive kapsis-cleanup --force"
+
+    teardown_guard_test "$agent_id"
+}
+
+test_clean_worktrees_reaps_complete_without_podman() {
+    log_test "Testing clean_worktrees reaps phase=complete with podman absent from PATH"
+
+    local agent_id
+    agent_id=$(printf '%06x' "$(( $$ + 1 ))")
+    setup_guard_test "$agent_id" "complete"
+
+    local cleanup_script="$KAPSIS_ROOT/scripts/kapsis-cleanup.sh"
+    # Minimal system PATH with no podman -- proves the complete-phase fast
+    # path has zero podman dependency (Issue #428 acceptance criterion 2).
+    PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        KAPSIS_DIR="$GUARD_TMP_DIR" "$cleanup_script" --force >/dev/null 2>&1 || true
+
+    if [[ -d "$GUARD_WORKTREE_PATH" ]]; then
+        log_fail "Complete-phase worktree should be reaped even without podman in PATH"
+        teardown_guard_test "$agent_id"
+        return 1
+    fi
+
+    rm -rf "$GUARD_TMP_DIR" 2>/dev/null || true
+    return 0
+}
+
+test_clean_worktrees_skips_running_stale_heartbeat_no_podman_hit() {
+    log_test "Testing clean_worktrees skips phase=running with stale heartbeat and no podman hit"
+
+    local agent_id
+    agent_id=$(printf '%06x' "$(( $$ + 2 ))")
+    # Stale: older than liveness timeout(900s) + grace(300s) = 1200s default
+    local stale
+    stale=$(date -u -v-2H +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || \
+        date -u -d "2 hours ago" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null)
+    setup_guard_test "$agent_id" "running" "$stale"
+
+    local cleanup_script="$KAPSIS_ROOT/scripts/kapsis-cleanup.sh"
+    # Minimal PATH with no podman -- guarantees no podman label hit is
+    # possible, isolating the "stale heartbeat, no corroboration" branch.
+    local output
+    output=$(PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        KAPSIS_DIR="$GUARD_TMP_DIR" "$cleanup_script" --force 2>&1) || true
+
+    assert_dir_exists "$GUARD_WORKTREE_PATH" \
+        "Worktree with stale heartbeat and no podman hit should be skipped, not deleted"
+    assert_contains "$output" "SKIPPED" \
+        "Skipped worktree should be reported via print_item_skipped"
+    assert_not_contains "$output" "Total: 1 worktrees" \
+        "Skipped worktree must not be counted in ITEMS_CLEANED"
+
+    teardown_guard_test "$agent_id"
+}
+
+test_clean_worktrees_podman_failure_does_not_block_other_removals() {
+    log_test "Testing a podman failure on one ambiguous entry doesn't block other reaps"
+
+    local complete_agent_id
+    complete_agent_id=$(printf '%06x' "$(( $$ + 3 ))")
+    setup_guard_test "$complete_agent_id" "complete"
+    local complete_worktree_path="$GUARD_WORKTREE_PATH"
+    local shared_tmp="$GUARD_TMP_DIR"
+    local shared_project="$GUARD_PROJECT"
+
+    # Second, ambiguous (stale-heartbeat, no status "complete") worktree in
+    # the SAME run, sharing the same isolated KAPSIS_DIR/project.
+    local stale_agent_id
+    stale_agent_id=$(printf '%06x' "$(( $$ + 4 ))")
+    source "$KAPSIS_ROOT/scripts/worktree-manager.sh"
+    KAPSIS_WORKTREE_BASE="${shared_tmp}/worktrees"
+    local project_name
+    project_name=$(basename "$shared_project")
+    local stale_worktree_path="${KAPSIS_WORKTREE_BASE}/${project_name}-${stale_agent_id}"
+    local stale_status_file="${shared_tmp}/status/kapsis-${project_name}-${stale_agent_id}.json"
+    create_worktree "$shared_project" "$stale_agent_id" "feature/guard-test-${stale_agent_id}" >/dev/null
+    local stale
+    stale=$(date -u -v-2H +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || \
+        date -u -d "2 hours ago" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null)
+    echo '{"phase": "running", "agent_id": "'"$stale_agent_id"'", "updated_at": "'"$stale"'"}' \
+        > "$stale_status_file"
+
+    # Simulate a podman query failure/timeout: point PATH at a fake "podman"
+    # binary that always fails, wrapped with the real timeout binary so the
+    # guard's timeout-wrapped call path is actually exercised.
+    local fake_bin_dir
+    fake_bin_dir=$(mktemp -d)
+    cat > "$fake_bin_dir/podman" << 'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+    chmod +x "$fake_bin_dir/podman"
+
+    local output
+    output=$(PATH="$fake_bin_dir:/usr/bin:/bin:/usr/sbin:/sbin" \
+        KAPSIS_DIR="$shared_tmp" "$KAPSIS_ROOT/scripts/kapsis-cleanup.sh" --force 2>&1) || true
+
+    # The complete-phase worktree must still be removed despite the
+    # ambiguous entry's podman failure (fail-open, no cross-entry blocking).
+    if [[ -d "$complete_worktree_path" ]]; then
+        log_fail "podman failure on one entry must not block removal of a complete-phase worktree"
+        rm -rf "$fake_bin_dir" "$shared_tmp" 2>/dev/null || true
+        return 1
+    fi
+
+    # The ambiguous entry degrades to the age heuristic (fail-open) and,
+    # being freshly created, is retained -- not deleted outright.
+    assert_dir_exists "$stale_worktree_path" \
+        "Ambiguous entry should fall back to age heuristic on podman failure, not be deleted"
+
+    rm -rf "$fake_bin_dir" "$shared_tmp" 2>/dev/null || true
+    unset output
+    return 0
+}
+
+#===============================================================================
 # MAIN
 #===============================================================================
 
 main() {
-    print_test_header "Worktree Auto-Cleanup (Fix #169, #183)"
-
-    # Check for jq (required by gc_stale_worktrees)
-    if ! command -v jq &>/dev/null; then
-        log_skip "jq not installed (required for GC tests)"
-        exit 0
-    fi
+    print_test_header "Worktree Auto-Cleanup (Fix #169, #183, #428)"
 
     # Setup
     setup_test_project
     source "$KAPSIS_ROOT/scripts/worktree-manager.sh"
 
-    # Run original tests (Fix #169)
-    run_test test_cleanup_worktree_removes_worktree
-    run_test test_keep_worktree_preserves_worktree
-    run_test test_default_cleanup_removes_worktree
-    run_test test_gc_cleans_stale_completed_worktrees
-    run_test test_gc_preserves_running_worktrees
-    run_test test_gc_handles_no_status_dir
+    # gc_stale_worktrees() requires jq; the Issue #428 in-use guard tests
+    # below are grep-based (mirroring clean_status()'s dependency-free
+    # pattern) and must run regardless of jq availability.
+    if command -v jq &>/dev/null; then
+        # Run original tests (Fix #169)
+        run_test test_cleanup_worktree_removes_worktree
+        run_test test_keep_worktree_preserves_worktree
+        run_test test_default_cleanup_removes_worktree
+        run_test test_gc_cleans_stale_completed_worktrees
+        run_test test_gc_preserves_running_worktrees
+        run_test test_gc_handles_no_status_dir
 
-    # Run new tests (Fix #183)
-    run_test test_cleanup_branch_deletes_agent_branch
-    run_test test_cleanup_branch_preserves_protected
-    run_test test_cleanup_branch_preserves_checked_out
-    run_test test_cleanup_branch_preserves_unpushed
-    run_test test_gc_age_cleans_old_worktrees
-    run_test test_gc_age_preserves_recent_worktrees
-    run_test test_gc_age_zero_disables
-    run_test test_cleanup_worktree_with_branch_deletion
-    run_test test_cleanup_worktrees_flag_accepted
-    run_test test_cleanup_volumes_and_worktrees_combined
-    run_test test_cleanup_config_env_override
+        # Run new tests (Fix #183)
+        run_test test_cleanup_branch_deletes_agent_branch
+        run_test test_cleanup_branch_preserves_protected
+        run_test test_cleanup_branch_preserves_checked_out
+        run_test test_cleanup_branch_preserves_unpushed
+        run_test test_gc_age_cleans_old_worktrees
+        run_test test_gc_age_preserves_recent_worktrees
+        run_test test_gc_age_zero_disables
+        run_test test_cleanup_worktree_with_branch_deletion
+        run_test test_cleanup_worktrees_flag_accepted
+        run_test test_cleanup_volumes_and_worktrees_combined
+        run_test test_cleanup_config_env_override
+    else
+        log_skip "jq not installed (skipping GC tests that require it)"
+    fi
+
+    # Run new tests (Issue #428 -- clean_worktrees() in-use guard)
+    run_test test_clean_worktrees_preserves_running_fresh_heartbeat
+    run_test test_clean_worktrees_reaps_complete_without_podman
+    run_test test_clean_worktrees_skips_running_stale_heartbeat_no_podman_hit
+    run_test test_clean_worktrees_podman_failure_does_not_block_other_removals
 
     # Cleanup
     cleanup_test_project


### PR DESCRIPTION
## Problem

`clean_worktrees()` in `scripts/kapsis-cleanup.sh` removed every directory under the worktree root unconditionally, including worktrees belonging to agents that are still actively running. `worktree-manager.sh`'s `gc_stale_worktrees()` (the opportunistic-GC path run at launch time) already has an age/phase guard for this; `kapsis-cleanup.sh`'s standalone housekeeping path had none.

## Fix

Adds `scripts/lib/worktree-guard.sh`, a new sourced-only library exposing `worktree_is_safe_to_reap(status_file, worktree_path)`, wired into `clean_worktrees()` only (not into `gc_stale_worktrees()` — see Deferred below):

- **`phase: "complete"`** — reaped unconditionally, zero Podman dependency. This is the sole zero-ambiguity "safe to reap" signal, so a Podman outage or `podman` missing from `PATH` never blocks reclaiming these.
- **`phase: error/failed/killed`, or missing status file** — falls back to the existing age heuristic (`KAPSIS_CLEANUP_WORKTREE_MAX_AGE_HOURS`, default 168h), same as `gc_stale_worktrees()`'s existing branch.
- **Any other phase (running/initializing/...)** — ambiguous. `status.json`'s `updated_at` freshness against the liveness timeout+grace (default 1200s) decides "in use" (skip) vs. "stale" (falls through to a best-effort, fail-open Podman `label=kapsis.agent-id=<id>` check, then the age heuristic).

A Podman query failure/timeout/absence never blocks reaping unrelated complete-phase worktrees in the same run, and never forces a "reap" verdict by itself — it only removes the corroboration signal for the one ambiguous entry, which then falls back to the age heuristic.

Skipped worktrees go through `print_item_skipped()` and are **not** counted in `ITEMS_CLEANED`/`TOTAL_SIZE_FREED`.

Adds `--include-active` (requires `--force`) as an explicit escape hatch, logged at `WARN`, mirroring the existing `CLEAN_ALL` override pattern in `clean_status()`.

Does **not** use top-level directory mtime as the signal for phase=running (verified trap: `get_dir_mtime` only updates on direct-child add/remove/rename — a long agent run editing nested files won't bump it).

## Deferred (see design brief for #428)

- Refactoring `worktree-manager.sh`'s `gc_stale_worktrees()` onto the same `worktree-guard.sh` primitive (would also add Podman corroboration there) — separate, non-P0 follow-up to avoid touching the launch-critical path in this fix PR.
- Rate-limiting/env-gating the optional Podman label check for very frequent cleanup cron cadences.
- A dashboard "clean now" UI action reusing the guard primitive.
- Documenting the `KAPSIS_LIVENESS_TIMEOUT`/`GRACE` <-> cleanup-heartbeat-threshold coupling in `docs/CONFIG-REFERENCE.md`.

## Dashboard sync

Not needed — no `status.sh`/`audit.sh` schema fields were added or changed; the guard reads existing `phase`/`updated_at` fields only.

## Testing

- `shellcheck scripts/lib/worktree-guard.sh scripts/kapsis-cleanup.sh tests/test-worktree-cleanup.sh` — clean.
- Added 4 new tests to the already-whitelisted `tests/test-worktree-cleanup.sh` (no `run-all-tests.sh` registration change needed): `test_clean_worktrees_preserves_running_fresh_heartbeat`, `test_clean_worktrees_reaps_complete_without_podman`, `test_clean_worktrees_skips_running_stale_heartbeat_no_podman_hit`, `test_clean_worktrees_podman_failure_does_not_block_other_removals`.
- `./tests/test-worktree-cleanup.sh` standalone: 21/21 pass (all pre-existing tests + all 4 new ones).
- `./tests/run-all-tests.sh --quick`: no failures observed across the run.
- Updated `docs/CLEANUP.md` with the guard's phase/heartbeat/Podman-fallback logic and the `--include-active` escape hatch.

Closes #428