### PR TITLE
fix(audit): prevent audit_log_event from aborting the status hook under set -e

### DIFF
--- a/dashboard/server/src/types.ts
+++ b/dashboard/server/src/types.ts
@@ -14,4 +14,12 @@
 // Last sync added HostEvent for Issue #407 (host-side commit-strip audit
 // sidecar <agent-id>-host-events.jsonl; non-chained, not matched by
 // AUDIT_FILE_RE).
+//
+// PR #435 (Issue #431) touched scripts/lib/audit.sh but is a set -e
+// robustness fix only (guards audit_log_event's internal
+// audit_check_patterns call with `|| true` so its no-alert return code of 1
+// can't abort the caller) plus a doc comment — no event schema or field
+// changed, so nothing here needed updating. This comment satisfies
+// dashboard-sync.yml's file-presence check, which can't distinguish a
+// schema change from a no-op-for-types change.
 export * from "@kapsis/dashboard-shared";

--- a/scripts/hooks/kapsis-status-hook.sh
+++ b/scripts/hooks/kapsis-status-hook.sh
@@ -441,10 +441,10 @@ print(json.dumps(state))
             if [[ "${_KAPSIS_AUDIT_INITIALIZED:-false}" != "true" ]]; then
                 audit_init "$_safe_agent_id" \
                            "${KAPSIS_STATUS_PROJECT:-unknown}" \
-                           "${KAPSIS_AGENT_TYPE:-claude-cli}"
+                           "${KAPSIS_AGENT_TYPE:-claude-cli}" || true
             fi
             audit_log_event "auto" "$tool_name" \
-                "{\"command\":\"$(json_escape_string "${command:0:1000}")\",\"file_path\":\"$(json_escape_string "$file_path")\",\"category\":\"$category\"}"
+                "{\"command\":\"$(json_escape_string "${command:0:1000}")\",\"file_path\":\"$(json_escape_string "$file_path")\",\"category\":\"$category\"}" || true
         fi
     fi
 

--- a/scripts/hooks/kapsis-status-hook.sh
+++ b/scripts/hooks/kapsis-status-hook.sh
@@ -438,6 +438,12 @@ print(json.dumps(state))
         if [[ -f "$KAPSIS_HOME/lib/audit.sh" ]]; then
             source "$KAPSIS_HOME/lib/audit.sh"
             source "$KAPSIS_HOME/lib/audit-patterns.sh"
+            # NOTE: The || true guards below intentionally suppress ALL failures
+            # (not just the audit_check_patterns exit-1 case) — including
+            # disk-full or permission errors. This hook runs under set -e and
+            # its robustness contract requires that it never break the agent:
+            # it must always reach the final `echo "{}"` below. Audit logging
+            # is best-effort here; do NOT narrow these guards.
             if [[ "${_KAPSIS_AUDIT_INITIALIZED:-false}" != "true" ]]; then
                 audit_init "$_safe_agent_id" \
                            "${KAPSIS_STATUS_PROJECT:-unknown}" \

--- a/scripts/lib/audit.sh
+++ b/scripts/lib/audit.sh
@@ -9,7 +9,7 @@
 #
 # Integrity model: this in-container writer is authored by the same process
 # tree the agent controls; treat the chain as tamper-EVIDENT for accidental
-# corruption, not tamper-PROOF against a compromised agent. See issue <TBD>
+# corruption, not tamper-PROOF against a compromised agent. See issue #439
 # for a host-authored redesign.
 #
 # Features:

--- a/scripts/lib/audit.sh
+++ b/scripts/lib/audit.sh
@@ -7,6 +7,11 @@
 # previous one via SHA-256, creating an immutable chain that can be verified
 # after the session.
 #
+# Integrity model: this in-container writer is authored by the same process
+# tree the agent controls; treat the chain as tamper-EVIDENT for accidental
+# corruption, not tamper-PROOF against a compromised agent. See issue <TBD>
+# for a host-authored redesign.
+#
 # Features:
 #   - Hash-chained JSONL events (tamper detection)
 #   - Auto-classification of event types
@@ -206,7 +211,11 @@ audit_log_event() {
 
     # Check patterns if pattern detection is available
     if declare -f audit_check_patterns &>/dev/null; then
-        audit_check_patterns "$event_type" "$tool_name" "$sanitized_detail"
+        # Return code intentionally discarded: audit_check_patterns returns 1 for
+        # the common no-alert case, which would otherwise abort this function
+        # (and its caller) under set -e. Any caller that needs the alert signal
+        # must call audit_check_patterns directly, not rely on audit_log_event.
+        audit_check_patterns "$event_type" "$tool_name" "$sanitized_detail" || true
     fi
 }
 

--- a/tests/lib/mock-api-server.py
+++ b/tests/lib/mock-api-server.py
@@ -65,7 +65,7 @@ def _tool_use_sse() -> bytes:
             "type": "content_block_delta", "index": 0,
             "delta": {
                 "type": "input_json_delta",
-                "partial_json": json.dumps({"command": "echo kapsis-mock-hook-test"}),
+                "partial_json": json.dumps({"command": "echo kapsis-mock-hook-ran"}),
             },
         }),
         ("content_block_stop", {"type": "content_block_stop", "index": 0}),
@@ -112,7 +112,7 @@ def _tool_use_json() -> bytes:
         "id": "msg_mock_001", "type": "message", "role": "assistant",
         "content": [{
             "type": "tool_use", "id": "toolu_mock_001", "name": "Bash",
-            "input": {"command": "echo kapsis-mock-hook-test"},
+            "input": {"command": "echo kapsis-mock-hook-ran"},
         }],
         "model": "claude-haiku-4-5-20251001",
         "stop_reason": "tool_use", "stop_sequence": None,

--- a/tests/test-audit-system.sh
+++ b/tests/test-audit-system.sh
@@ -153,24 +153,52 @@ test_audit_log_event_appends() {
 # returns non-zero for the common no-alert case. Regression test for the
 # hook crash where bare `audit_log_event ...` statements (no `if`/`||` guard)
 # aborted the hook process before its mandatory `echo "{}"`.
+#
+# IMPORTANT: this must run in a genuinely separate `bash` PROCESS with
+# `set -e` active, not merely as a function invoked from run_test(). When
+# run_test() invokes a test function as `$test_func || test_exit_code=$?`,
+# bash suspends errexit for the *entire* call chain underneath that `||`
+# (per POSIX/bash semantics: errexit is ignored for any command that is
+# part of the compound list controlling `&&`/`||`), so a bare `set -e`
+# abort inside audit_log_event would silently NOT terminate the test body
+# even if the fix were fully reverted -- the test would pass regardless.
+# Spawning a fresh `bash -c` subprocess sidesteps that: its exit status is
+# observed via `$?` on the outer (non-suspended) statement, so a genuine
+# errexit abort inside the subprocess is faithfully reported here.
 test_audit_log_event_survives_pattern_check_under_set_e() {
     log_test "audit_log_event survives audit_check_patterns non-zero exit under set -e"
 
     setup
-    source_audit
-    source_audit_patterns
+    local test_audit_dir="$TEST_AUDIT_DIR"
 
-    audit_init "test-agent-003" "project-y" "claude-cli"
+    local subprocess_script
+    subprocess_script=$(cat <<EOF
+set -euo pipefail
+export KAPSIS_AUDIT_DIR="$test_audit_dir"
+export KAPSIS_AUDIT_ENABLED="true"
+source "$AUDIT_SCRIPT"
+source "$AUDIT_PATTERNS_SCRIPT"
+audit_init "test-agent-003" "project-y" "claude-cli"
+# Bare statements (no if/||), exactly as kapsis-status-hook.sh does in
+# production. If audit_check_patterns' exit code were allowed to
+# propagate, set -e would abort this subprocess right here.
+audit_log_event "shell_command" "Bash" '{"command":"ls -la"}'
+audit_log_event "filesystem_op" "Read" '{"file_path":"/workspace/README.md"}'
+EOF
+)
 
-    # Call audit_log_event as bare statements (no if/||), exactly as
-    # kapsis-status-hook.sh does in production. If audit_check_patterns'
-    # exit code were still allowed to propagate, `set -e` would abort this
-    # function (and the test) right here.
-    audit_log_event "shell_command" "Bash" '{"command":"ls -la"}'
-    audit_log_event "filesystem_op" "Read" '{"file_path":"/workspace/README.md"}'
+    local subprocess_rc=0
+    bash -c "$subprocess_script" || subprocess_rc=$?
 
+    assert_equals "0" "$subprocess_rc" \
+        "Subprocess running bare audit_log_event calls under set -e should exit 0, not abort"
+
+    # The subprocess has its own PID, so its audit file name (which embeds
+    # $$) is unknown here. TEST_AUDIT_DIR is exclusive to this test, so
+    # there is exactly one *.audit.jsonl file to find.
     local audit_file
-    audit_file=$(audit_get_file)
+    audit_file=$(find "$test_audit_dir" -maxdepth 1 -name '*.audit.jsonl' -print -quit)
+    assert_not_equals "" "$audit_file" "Subprocess should have created an audit file"
 
     local line_count
     line_count=$(wc -l < "$audit_file" | tr -d ' ')

--- a/tests/test-audit-system.sh
+++ b/tests/test-audit-system.sh
@@ -148,6 +148,37 @@ test_audit_log_event_appends() {
     teardown
 }
 
+# 2b. audit_log_event must not abort under set -e when audit_check_patterns
+# (sourced alongside audit.sh, matching kapsis-status-hook.sh's real usage)
+# returns non-zero for the common no-alert case. Regression test for the
+# hook crash where bare `audit_log_event ...` statements (no `if`/`||` guard)
+# aborted the hook process before its mandatory `echo "{}"`.
+test_audit_log_event_survives_pattern_check_under_set_e() {
+    log_test "audit_log_event survives audit_check_patterns non-zero exit under set -e"
+
+    setup
+    source_audit
+    source_audit_patterns
+
+    audit_init "test-agent-003" "project-y" "claude-cli"
+
+    # Call audit_log_event as bare statements (no if/||), exactly as
+    # kapsis-status-hook.sh does in production. If audit_check_patterns'
+    # exit code were still allowed to propagate, `set -e` would abort this
+    # function (and the test) right here.
+    audit_log_event "shell_command" "Bash" '{"command":"ls -la"}'
+    audit_log_event "filesystem_op" "Read" '{"file_path":"/workspace/README.md"}'
+
+    local audit_file
+    audit_file=$(audit_get_file)
+
+    local line_count
+    line_count=$(wc -l < "$audit_file" | tr -d ' ')
+    assert_equals "3" "$line_count" "Audit file should have 3 events (genesis + 2) without aborting"
+
+    teardown
+}
+
 # 3. Hash chain verifies after multiple events
 test_audit_hash_chain_valid() {
     log_test "Hash chain verifies after multiple events"
@@ -1165,6 +1196,7 @@ main() {
     # Core tests (1-11)
     run_test test_audit_init_creates_file
     run_test test_audit_log_event_appends
+    run_test test_audit_log_event_survives_pattern_check_under_set_e
     run_test test_audit_hash_chain_valid
     run_test test_audit_hash_chain_broken
     run_test test_audit_classify_credential_access

--- a/tests/test-host-claude-mock-api.sh
+++ b/tests/test-host-claude-mock-api.sh
@@ -123,12 +123,33 @@ setup_mock_env() {
     mkdir -p "$TEST_HOME/.kapsis/logs"
     mkdir -p "$TEST_HOME/.claude"
 
-    # Install real hook scripts at the paths inject-status-hooks.sh will write
+    # Install real hook scripts at the paths inject-status-hooks.sh will write.
+    # tool-phase-mapping.sh must ship alongside kapsis-status-hook.sh: it's
+    # sourced from $SCRIPT_DIR (the hook's own directory) and defines
+    # map_tool_to_category(), which main() calls unconditionally before
+    # reaching the audit branch. Without it, kapsis-status-hook.sh aborts
+    # under set -e on the undefined function before ever getting to audit.
     mkdir -p "$KAPSIS_ROOT/hooks"
-    cp "$HOOKS_SRC/kapsis-gist-hook.sh"   "$KAPSIS_ROOT/hooks/"
-    cp "$HOOKS_SRC/kapsis-status-hook.sh" "$KAPSIS_ROOT/hooks/"
-    cp "$HOOKS_SRC/kapsis-stop-hook.sh"   "$KAPSIS_ROOT/hooks/"
+    cp "$HOOKS_SRC/kapsis-gist-hook.sh"     "$KAPSIS_ROOT/hooks/"
+    cp "$HOOKS_SRC/kapsis-status-hook.sh"   "$KAPSIS_ROOT/hooks/"
+    cp "$HOOKS_SRC/kapsis-stop-hook.sh"     "$KAPSIS_ROOT/hooks/"
+    cp "$HOOKS_SRC/tool-phase-mapping.sh"   "$KAPSIS_ROOT/hooks/"
     chmod +x "$KAPSIS_ROOT/hooks/"*.sh
+
+    # Stage audit.sh/audit-patterns.sh (+ their own same-directory dependencies:
+    # logging.sh, json-utils.sh, compat.sh, constants.sh) at $KAPSIS_HOME/lib/,
+    # mirroring the flattened installed-container layout (KAPSIS_HOME=/opt/kapsis,
+    # libs directly under lib/) that kapsis-status-hook.sh's audit branch expects
+    # via `[[ -f "$KAPSIS_HOME/lib/audit.sh" ]]`. audit.sh sources its deps
+    # relative to its own directory, so all of them must be staged together.
+    # Without this, the audit branch is silently skipped (or aborts on a
+    # missing source) in this harness since KAPSIS_HOME here is the repo
+    # root, where libs live under scripts/lib/, not lib/.
+    mkdir -p "$KAPSIS_ROOT/lib"
+    cp "$LIB_DIR/audit.sh" "$LIB_DIR/audit-patterns.sh" \
+       "$LIB_DIR/logging.sh" "$LIB_DIR/json-utils.sh" \
+       "$LIB_DIR/compat.sh" "$LIB_DIR/constants.sh" \
+       "$KAPSIS_ROOT/lib/"
 
     _start_mock_server
 }
@@ -136,9 +157,10 @@ setup_mock_env() {
 cleanup_mock_env() {
     _stop_mock_server
     export HOME="$_ORIG_HOME"
-    rm -rf "${TEST_HOME:-}" "${TEST_WORKSPACE:-}" "$KAPSIS_ROOT/hooks"
+    rm -rf "${TEST_HOME:-}" "${TEST_WORKSPACE:-}" "$KAPSIS_ROOT/hooks" "${KAPSIS_ROOT:?}/lib"
     unset TEST_HOME TEST_WORKSPACE KAPSIS_HOME KAPSIS_LIB
-    unset KAPSIS_STATUS_AGENT_ID KAPSIS_INJECT_GIST KAPSIS_GIST_FILE 2>/dev/null || true
+    unset KAPSIS_STATUS_AGENT_ID KAPSIS_INJECT_GIST KAPSIS_GIST_FILE \
+          KAPSIS_AUDIT_ENABLED KAPSIS_AUDIT_DIR 2>/dev/null || true
     _KAPSIS_INJECT_STATUS_HOOKS_LOADED=""
     # shellcheck disable=SC2034
     export KAPSIS_LOG_TO_FILE="false"
@@ -158,10 +180,17 @@ test_mock_posttooluse_gist_hook_fires() {
 
     local agent_id="mock-e2e-$$"
     local gist_file="$TEST_HOME/.kapsis/gist.txt"
+    local audit_dir="$TEST_HOME/.kapsis/audit"
+    mkdir -p "$audit_dir"
 
     export KAPSIS_STATUS_AGENT_ID="$agent_id"
     export KAPSIS_INJECT_GIST="true"
     export KAPSIS_GIST_FILE="$gist_file"
+    # Exercise the real hook-dispatch path with audit logging enabled — this is
+    # the crash-regression coverage for #431 (audit_log_event previously could
+    # abort kapsis-status-hook.sh under set -e before its mandatory `echo "{}"`).
+    export KAPSIS_AUDIT_ENABLED="true"
+    export KAPSIS_AUDIT_DIR="$audit_dir"
 
     # Seed settings.json with allowedTools so Claude Code doesn't prompt
     printf '{"allowedTools":["Bash"]}\n' > "$TEST_HOME/.claude/settings.json"
@@ -183,6 +212,8 @@ test_mock_posttooluse_gist_hook_fires() {
         KAPSIS_STATUS_AGENT_ID="$agent_id" \
         KAPSIS_INJECT_GIST="true" \
         KAPSIS_GIST_FILE="$gist_file" \
+        KAPSIS_AUDIT_ENABLED="true" \
+        KAPSIS_AUDIT_DIR="$audit_dir" \
         ANTHROPIC_BASE_URL="$ANTHROPIC_BASE_URL" \
         ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" \
         claude --print \
@@ -197,6 +228,27 @@ test_mock_posttooluse_gist_hook_fires() {
     local gist_content
     gist_content=$(cat "$gist_file")
     assert_not_empty "$gist_content" "gist.txt must not be empty"
+
+    # #431 crash-regression: kapsis-status-hook.sh must have run its audit
+    # branch to completion (not aborted under set -e) and recorded a real
+    # post-genesis tool-use event, not just the genesis session_start line.
+    # kapsis-status-hook.sh calls audit_log_event with event_type="auto", which
+    # audit.sh auto-classifies into a concrete type (e.g. "shell_command") before
+    # writing — "auto" itself never appears in the JSONL. Detect a real
+    # post-genesis event by tool_name instead (genesis events use
+    # tool_name="audit_init"; a real tool call from Claude Code uses the
+    # actual tool name, e.g. "Bash").
+    local audit_files_found="false"
+    local audit_file
+    for audit_file in "$audit_dir"/*.audit.jsonl; do
+        [[ -f "$audit_file" ]] || continue
+        if grep -q '"tool_name":"Bash"' "$audit_file" 2>/dev/null; then
+            audit_files_found="true"
+            break
+        fi
+    done
+    assert_equals "true" "$audit_files_found" \
+        "At least one *.audit.jsonl must contain a real tool-use event (tool_name=Bash) when KAPSIS_AUDIT_ENABLED=true (mock API)"
 
     cleanup_mock_env
 }


### PR DESCRIPTION
## Root cause

`audit_log_event()` (scripts/lib/audit.sh) ends with:
```bash
if declare -f audit_check_patterns &>/dev/null; then
    audit_check_patterns "$event_type" "$tool_name" "$sanitized_detail"
fi
```
The `if` only tests function *existence* — the pattern check's own non-zero return (its documented "no alert" signal, default `1`) becomes `audit_log_event`'s exit status. `scripts/hooks/kapsis-status-hook.sh` sources both `audit.sh` and `audit-patterns.sh` together and runs under `set -euo pipefail`, calling `audit_init`/`audit_log_event` as bare statements — so `set -e` killed the entire hook process the instant the (near-universal) "no alert" case occurred, i.e. on the very first `audit_log_event("session_start", ...)` call inside `audit_init`. The hook never reached the real tool-use event logging, nor its mandatory `echo "{}"` stdout contract with Claude Code.

Reproduced live against origin/main: sourcing `audit.sh` + `audit-patterns.sh` together and calling `audit_init` then a second `audit_log_event` under `set -e` exits 1 immediately after `audit_init`, having written exactly one line to the audit file.

## Why CI was green

`tests/test-audit-system.sh`'s `source_audit()` helper sources ONLY `audit.sh`, never `audit-patterns.sh` — so `declare -f audit_check_patterns` was false in every existing unit test and the fatal path was dead code there. No test previously sourced both files together the way `kapsis-status-hook.sh` does in production.

## Fix

1. `scripts/lib/audit.sh`: append `|| true` to the `audit_check_patterns` call so its return code can't propagate as `audit_log_event`'s own exit status. Added a 1-2 line integrity-model caveat to the module docstring (this in-container writer is tamper-evident for accidental corruption, not tamper-proof against a compromised agent).
2. `scripts/hooks/kapsis-status-hook.sh`: guard the `audit_init`/`audit_log_event` calls with `|| true` so a future regression anywhere in the audit call graph can never again take down the hook process before its mandatory `echo "{}"`.
3. New regression test in `tests/test-audit-system.sh` that sources both files together (the exact combination production uses) and calls `audit_log_event` twice under `set -e`, asserting it doesn't abort.
4. Extended `tests/test-host-claude-mock-api.sh` with a real `claude --print` scenario running `KAPSIS_AUDIT_ENABLED=true`, asserting a post-genesis tool-use event lands in the audit file — proves the fix holds through the actual hook-dispatch path, not just in isolation.

## Deliberately deferred (see issue for tracking)

- Session-state persistence across hook invocations so one coherent per-agent `.audit.jsonl` accumulates instead of one file per tool call (today's fragmentation is a data-quality issue, not the data-loss bug this PR fixes).
- `audit_health` heartbeat field in `status.json` for dashboard visibility of future silent breakage (would need its own dashboard-sync PR).
- Host-side audit re-architecture (the tamper-evidence redesign hinted at by the new docstring caveat).
- `AUDIT_FILE_RE` hyphenated-agent-id parsing fix in `dashboard/server/src/store/audit.ts` — narrower, independent, pre-existing.
- Manual post-merge smoke test still required to confirm `KAPSIS_AUDIT_ENABLED`/`KAPSIS_STATUS_AGENT_ID` actually reach the claude-spawned hook subprocess in a real container run (unit/e2e tests here control the environment directly and can't fully rule this out) — see checklist on #431.

## Testing

- `shellcheck --severity=warning` clean on all modified files.
- New regression test passes (`test_audit_log_event_survives_pattern_check_under_set_e`), registered in `test-audit-system.sh`'s explicit `run_test` dispatch list.
- Extended mock-API e2e scenario passes.
- The one other failure observed while testing (`test_k8s_cr_includes_audit_env` / `test_mock_stop_hook_fires` transient) reproduces identically on unmodified `origin/main` — confirmed pre-existing/environmental, unrelated to this change.

Closes #431