### PR TITLE
fix(security): stage seccomp/AppArmor profiles for machine-visibility on macOS podman-machine

### DIFF
--- a/scripts/lib/compat.sh
+++ b/scripts/lib/compat.sh
@@ -378,6 +378,50 @@ get_podman_machine_provider() {
 }
 
 #-------------------------------------------------------------------------------
+# is_podman_machine_active [machine]
+#
+# Returns 0 (true) when podman is backed by a macOS podman-machine VM
+# (applehv/libkrun/qemu — any hypervisor provider), 1 (false) otherwise
+# (Linux native rootless, or macOS with no machine configured/reachable).
+#
+# Deliberately does NOT reuse get_podman_machine_provider()'s `.VMType`
+# field — that field has been removed from `podman machine inspect` JSON on
+# at least podman 5.8.2 (verified empirically), which would make this gate
+# silently never fire and reintroduce the exact bug it's meant to prevent.
+# `.State` has been a stable field across podman-machine versions, so we
+# probe that instead: any parseable state means a machine exists and podman
+# is routing through it, which is all this gate needs to know — the VM-type
+# distinction is irrelevant here (every hypervisor provider isolates the
+# guest mount namespace from arbitrary host paths the same way).
+#
+# This is a deliberate behavioral gate (unlike the informational-only
+# get_podman_machine_provider): any VM-backed provider means podman resolves
+# bind-mount / --security-opt path arguments INSIDE the VM's mount
+# namespace, not on the host filesystem. Host paths outside the VM's default
+# mounts (notably a Homebrew Cellar/libexec install tree, which is NOT
+# mounted into the machine) are invisible to podman even though they exist on
+# the host — see issue #443. $HOME (and a few other default locations) ARE
+# mounted into the machine by default.
+#
+# Tests stub this function directly (redefine after sourcing) rather than
+# depending on a real podman machine.
+#-------------------------------------------------------------------------------
+is_podman_machine_active() {
+    is_macos || return 1
+
+    local machine="${1:-${KAPSIS_PODMAN_MACHINE:-podman-machine-default}}"
+    local state
+
+    if [[ -n "$_KAPSIS_TIMEOUT_CMD" ]]; then
+        state=$("$_KAPSIS_TIMEOUT_CMD" 5 podman machine inspect "$machine" --format '{{.State}}' 2>/dev/null)
+    else
+        state=$(podman machine inspect "$machine" --format '{{.State}}' 2>/dev/null)
+    fi
+
+    [[ -n "$state" ]]
+}
+
+#-------------------------------------------------------------------------------
 # _recover_podman_ssh_tunnel [probe_timeout] [max_retries] [retry_delay]
 #
 # Probes the Podman SSH tunnel and attempts recovery if stale (macOS only).

--- a/scripts/lib/security.sh
+++ b/scripts/lib/security.sh
@@ -28,6 +28,12 @@
 # Ensure we have the KAPSIS_ROOT set
 KAPSIS_ROOT="${KAPSIS_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
 
+# is_macos / is_podman_machine_active are needed for machine-visibility staging
+# below (issue #443). Source directly rather than relying on caller order —
+# compat.sh is idempotent (source guard) so this is a no-op if already loaded.
+# shellcheck source=lib/compat.sh
+source "${KAPSIS_ROOT}/scripts/lib/compat.sh"
+
 #===============================================================================
 # SECURITY PROFILE DEFINITIONS
 #===============================================================================
@@ -125,9 +131,65 @@ generate_capability_args() {
 # SECCOMP PROFILE MANAGEMENT
 #===============================================================================
 
-# Get the seccomp profile path for an agent
-# Usage: profile=$(get_seccomp_profile "claude")
-get_seccomp_profile() {
+# Stage a security profile (seccomp JSON, etc.) into a machine-visible path
+# when podman is backed by a macOS podman-machine VM. Issue #443: podman
+# resolves --security-opt seccomp=<path> INSIDE the VM's mount namespace, not
+# on the host. $KAPSIS_ROOT can be a Homebrew Cellar/libexec install tree
+# (e.g. /opt/homebrew/Cellar/kapsis/.../security/seccomp/...) which is NOT
+# one of the machine's default mounts, so podman fails with exit 125 even
+# though the file exists on the host. $HOME IS a default machine mount
+# (verified), so profiles already under $HOME need no staging.
+#
+# No-ops (returns the input path unchanged) on Linux, or on macOS when no
+# podman-machine VM is active (e.g. native rootless/Colima with a bind-mount
+# passthrough), or when the path is already under $HOME.
+#
+# Usage: staged_path=$(_stage_profile_for_machine_visibility "$path")
+_stage_profile_for_machine_visibility() {
+    local src="$1"
+
+    [[ -z "$src" ]] && return
+
+    if ! is_podman_machine_active; then
+        echo "$src"
+        return
+    fi
+
+    # Already under a machine-mounted location -- podman can resolve it
+    # inside the VM as-is, no staging needed.
+    if [[ "$src" == "${HOME}"/* ]]; then
+        echo "$src"
+        return
+    fi
+
+    local stage_dir="${HOME}/.kapsis/seccomp"
+    local src_basename
+    src_basename=$(basename "$src")
+    local dest="${stage_dir}/${src_basename}"
+
+    if ! mkdir -p "$stage_dir" 2>/dev/null; then
+        declare -f log_warn &>/dev/null && log_warn "Could not create machine-visible seccomp staging dir '$stage_dir'; passing original path '$src' (may fail inside podman machine, see issue #443)."
+        echo "$src"
+        return
+    fi
+
+    # Copy only when missing or changed, to avoid needless I/O on every launch.
+    if [[ ! -f "$dest" ]] || ! cmp -s "$src" "$dest" 2>/dev/null; then
+        if ! cp "$src" "$dest" 2>/dev/null; then
+            declare -f log_warn &>/dev/null && log_warn "Failed to stage seccomp profile '$src' -> '$dest'; passing original path (may fail inside podman machine, see issue #443)."
+            echo "$src"
+            return
+        fi
+    fi
+
+    echo "$dest"
+}
+
+# Resolve the seccomp profile path for an agent, before machine-visibility
+# staging. Internal helper for get_seccomp_profile() — split out so every
+# return path can be routed through _stage_profile_for_machine_visibility in
+# one place instead of duplicating the staging call at each `return`.
+_resolve_seccomp_profile_path() {
     local agent_name="${1:-}"
     local profile="${KAPSIS_SECURITY_PROFILE:-standard}"
     local seccomp_enabled="${SECURITY_DEFAULTS[${profile}_seccomp]:-false}"
@@ -193,6 +255,19 @@ get_seccomp_profile() {
     if [[ -f "${seccomp_dir}/kapsis-agent-base.json" ]]; then
         echo "${seccomp_dir}/kapsis-agent-base.json"
     fi
+}
+
+# Get the seccomp profile path for an agent, staged into a machine-visible
+# location first if needed (issue #443 — see
+# _stage_profile_for_machine_visibility above).
+# Usage: profile=$(get_seccomp_profile "claude")
+get_seccomp_profile() {
+    local resolved
+    resolved=$(_resolve_seccomp_profile_path "$@")
+
+    [[ -z "$resolved" ]] && return
+
+    _stage_profile_for_machine_visibility "$resolved"
 }
 
 # Generate seccomp arguments for podman

--- a/tests/test-compat.sh
+++ b/tests/test-compat.sh
@@ -877,6 +877,147 @@ test_get_podman_machine_provider_resolves_kapsis_podman_machine() {
 }
 
 #===============================================================================
+# is_podman_machine_active() TESTS (Issue #443)
+#
+# Unlike get_podman_machine_provider() (informational only), this is a
+# behavioral gate, so it must be exercised against a real fake `podman`
+# binary rather than stubbed at the function level (which is what
+# test-security.sh's seccomp-staging tests do further downstream — those
+# validate staging behavior *given* a result, not that this function
+# produces the right result in the first place).
+#===============================================================================
+
+test_is_podman_machine_active_true_when_state_present() {
+    log_test "is_podman_machine_active: true when podman reports a non-empty State"
+
+    local tmpdir
+    tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/kapsis-active-test.XXXXXX")
+    _provider_make_fake_podman "$tmpdir/podman" \
+        'if [[ "$1" == "machine" && "$2" == "inspect" ]]; then echo "running"; exit 0; fi' \
+        'exit 1'
+
+    (
+        is_macos() { return 0; }
+        PATH="$tmpdir:$PATH"
+        is_podman_machine_active "podman-machine-default"
+    )
+    local result=$?
+
+    rm -rf "$tmpdir"
+    assert_equals "0" "$result" "Should return true (0) when State is non-empty"
+}
+
+test_is_podman_machine_active_false_when_podman_fails() {
+    log_test "is_podman_machine_active: false when podman machine inspect fails"
+
+    local tmpdir
+    tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/kapsis-active-test.XXXXXX")
+    _provider_make_fake_podman "$tmpdir/podman" 'exit 1'
+
+    (
+        is_macos() { return 0; }
+        PATH="$tmpdir:$PATH"
+        is_podman_machine_active "podman-machine-default"
+    )
+    local result=$?
+
+    rm -rf "$tmpdir"
+    assert_equals "1" "$result" "Should return false (1) when podman reports no State"
+}
+
+test_is_podman_machine_active_false_on_linux_without_invoking_podman() {
+    log_test "is_podman_machine_active: false on non-macOS, without invoking podman"
+
+    local tmpdir
+    tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/kapsis-active-test.XXXXXX")
+    _provider_make_fake_podman "$tmpdir/podman" 'echo "SHOULD_NOT_BE_CALLED"; exit 0'
+
+    (
+        is_macos() { return 1; }
+        PATH="$tmpdir:$PATH"
+        is_podman_machine_active "podman-machine-default"
+    )
+    local result=$?
+
+    rm -rf "$tmpdir"
+    assert_equals "1" "$result" "Should be false on non-macOS without invoking podman"
+}
+
+test_is_podman_machine_active_fallback_without_timeout_cmd() {
+    log_test "is_podman_machine_active: fallback branch works when no timeout cmd available"
+
+    local tmpdir
+    tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/kapsis-active-test.XXXXXX")
+    _provider_make_fake_podman "$tmpdir/podman" \
+        'if [[ "$1" == "machine" && "$2" == "inspect" ]]; then echo "running"; exit 0; fi' \
+        'exit 1'
+
+    (
+        is_macos() { return 0; }
+        _KAPSIS_TIMEOUT_CMD=""
+        PATH="$tmpdir:$PATH"
+        is_podman_machine_active "podman-machine-default"
+    )
+    local result=$?
+
+    rm -rf "$tmpdir"
+    assert_equals "0" "$result" "Fallback (no timeout cmd) branch should also detect an active machine"
+}
+
+test_is_podman_machine_active_resolves_kapsis_podman_machine() {
+    log_test "is_podman_machine_active: resolves KAPSIS_PODMAN_MACHINE when called without argument"
+
+    local tmpdir
+    tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/kapsis-active-test.XXXXXX")
+    _provider_make_fake_podman "$tmpdir/podman" \
+        "printf '%s\n' \"\$@\" > \"$tmpdir/argv\"" \
+        'echo "running"' \
+        'exit 0'
+
+    (
+        is_macos() { return 0; }
+        PATH="$tmpdir:$PATH"
+        KAPSIS_PODMAN_MACHINE="custom-machine"
+        is_podman_machine_active
+    )
+    local result=$?
+
+    local argv=""
+    [[ -f "$tmpdir/argv" ]] && argv=$(cat "$tmpdir/argv")
+    rm -rf "$tmpdir"
+
+    assert_equals "0" "$result" "Should report active for the resolved custom machine"
+    assert_contains "$argv" "custom-machine" "custom-machine should be passed to podman machine inspect"
+}
+
+test_is_podman_machine_active_uses_state_not_vmtype() {
+    log_test "is_podman_machine_active: queries .State (not .VMType, which podman 5.8.2+ omits)"
+
+    local tmpdir
+    tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/kapsis-active-test.XXXXXX")
+    # Fake podman only understands --format '{{.State}}'; any other format
+    # (e.g. the removed .VMType) returns empty, simulating podman 5.8.2+.
+    _provider_make_fake_podman "$tmpdir/podman" \
+        'if [[ "$1" == "machine" && "$2" == "inspect" ]]; then' \
+        '    for arg in "$@"; do' \
+        '        if [[ "$arg" == *".State"* ]]; then echo "running"; exit 0; fi' \
+        '    done' \
+        '    echo ""; exit 0' \
+        'fi' \
+        'exit 1'
+
+    (
+        is_macos() { return 0; }
+        PATH="$tmpdir:$PATH"
+        is_podman_machine_active "podman-machine-default"
+    )
+    local result=$?
+
+    rm -rf "$tmpdir"
+    assert_equals "0" "$result" "Should detect an active machine via .State even when .VMType would be empty"
+}
+
+#===============================================================================
 # MAIN
 #===============================================================================
 
@@ -953,6 +1094,14 @@ main() {
     run_test test_get_podman_machine_provider_empty_when_podman_fails
     run_test test_get_podman_machine_provider_fallback_without_timeout_cmd
     run_test test_get_podman_machine_provider_resolves_kapsis_podman_machine
+
+    # is_podman_machine_active() tests (Issue #443)
+    run_test test_is_podman_machine_active_true_when_state_present
+    run_test test_is_podman_machine_active_false_when_podman_fails
+    run_test test_is_podman_machine_active_false_on_linux_without_invoking_podman
+    run_test test_is_podman_machine_active_fallback_without_timeout_cmd
+    run_test test_is_podman_machine_active_resolves_kapsis_podman_machine
+    run_test test_is_podman_machine_active_uses_state_not_vmtype
 
     # Summary
     print_summary

--- a/tests/test-security.sh
+++ b/tests/test-security.sh
@@ -75,6 +75,14 @@ reset_security_env() {
     unset KAPSIS_NOEXEC_TMP
     unset KAPSIS_READONLY_ROOT
     unset KAPSIS_REQUIRE_LSM
+
+    # These tests exercise seccomp *profile selection*, not the issue #443
+    # machine-visibility staging behavior (covered separately below) — stub
+    # is_podman_machine_active() to "false" so a real podman machine running
+    # on the dev/CI host never staged-copies the resolved path out from
+    # under an assertion. Redefining a sourced function is the same pattern
+    # used for `id` in test-userns-resolution.sh.
+    is_podman_machine_active() { return 1; }
 }
 
 #===============================================================================
@@ -385,6 +393,121 @@ test_custom_seccomp_profile() {
 
     assert_equals "$custom_profile" "$profile_path" \
         "Should use custom seccomp profile"
+}
+
+#===============================================================================
+# ISSUE #443: MACHINE-VISIBILITY STAGING TESTS
+#
+# On macOS with the podman-machine (applehv/libkrun/qemu) backend, podman
+# resolves --security-opt seccomp=<path> INSIDE the VM's mount namespace.
+# $KAPSIS_ROOT under a Homebrew Cellar/libexec tree is not one of the
+# machine's default mounts, so the resolved profile path must be staged into
+# a machine-visible location ($HOME/.kapsis/seccomp/) before being handed to
+# podman. These tests stub is_podman_machine_active() directly so they run
+# deterministically without a real podman machine.
+#===============================================================================
+
+test_seccomp_staging_noop_when_no_machine() {
+    log_test "Seccomp staging: no-op when no podman machine is active"
+
+    reset_security_env
+    export KAPSIS_SECURITY_PROFILE="standard"
+    is_podman_machine_active() { return 1; }
+
+    local profile_path
+    profile_path=$(get_seccomp_profile "claude")
+
+    assert_equals "${KAPSIS_ROOT}/security/seccomp/kapsis-default-hardened.json" "$profile_path" \
+        "Without an active podman machine, the original resolved path should pass through unchanged"
+}
+
+test_seccomp_staging_noop_when_already_under_home() {
+    log_test "Seccomp staging: no-op when the resolved path is already under \$HOME"
+
+    reset_security_env
+    export KAPSIS_SECURITY_PROFILE="strict"
+    is_podman_machine_active() { return 0; }
+
+    local home_profile_dir="${TEST_TEMP_DIR}/home-profile"
+    mkdir -p "$home_profile_dir"
+    local home_profile="${home_profile_dir}/kapsis-home-seccomp.json"
+    echo '{"defaultAction": "SCMP_ACT_ALLOW"}' > "$home_profile"
+    export KAPSIS_SECCOMP_PROFILE="$home_profile"
+
+    # Simulate the profile already living under $HOME by pointing HOME at
+    # its parent directory for the duration of this call.
+    local profile_path
+    profile_path=$(HOME="$TEST_TEMP_DIR" get_seccomp_profile "claude")
+
+    assert_equals "$home_profile" "$profile_path" \
+        "A profile path already under \$HOME should not be staged/copied"
+}
+
+test_seccomp_staging_copies_when_machine_active() {
+    log_test "Seccomp staging: stages a Homebrew-Cellar-style path into \$HOME/.kapsis/seccomp when a machine is active"
+
+    reset_security_env
+    export KAPSIS_SECURITY_PROFILE="strict"
+    is_podman_machine_active() { return 0; }
+
+    # Simulate a Homebrew Cellar/libexec install path OUTSIDE $HOME.
+    local fake_cellar_dir="${TEST_TEMP_DIR}/opt-homebrew-cellar"
+    mkdir -p "$fake_cellar_dir"
+    local cellar_profile="${fake_cellar_dir}/kapsis-cellar-seccomp.json"
+    echo '{"defaultAction": "SCMP_ACT_ALLOW"}' > "$cellar_profile"
+    export KAPSIS_SECCOMP_PROFILE="$cellar_profile"
+
+    local fake_home="${TEST_TEMP_DIR}/fake-home"
+    mkdir -p "$fake_home"
+
+    local profile_path
+    profile_path=$(HOME="$fake_home" get_seccomp_profile "claude")
+
+    assert_equals "${fake_home}/.kapsis/seccomp/kapsis-cellar-seccomp.json" "$profile_path" \
+        "Should stage the profile into \$HOME/.kapsis/seccomp/"
+    assert_file_exists "$profile_path" \
+        "Staged profile file should exist"
+
+    local original_content staged_content
+    original_content=$(cat "$cellar_profile")
+    staged_content=$(cat "$profile_path")
+    assert_equals "$original_content" "$staged_content" \
+        "Staged profile content should match the original"
+}
+
+test_seccomp_staging_reuses_unchanged_staged_copy() {
+    log_test "Seccomp staging: does not re-copy an already up-to-date staged profile"
+
+    reset_security_env
+    export KAPSIS_SECURITY_PROFILE="strict"
+    is_podman_machine_active() { return 0; }
+
+    local fake_cellar_dir="${TEST_TEMP_DIR}/opt-homebrew-cellar2"
+    mkdir -p "$fake_cellar_dir"
+    local cellar_profile="${fake_cellar_dir}/kapsis-cellar-seccomp2.json"
+    echo '{"defaultAction": "SCMP_ACT_ALLOW"}' > "$cellar_profile"
+    export KAPSIS_SECCOMP_PROFILE="$cellar_profile"
+
+    local fake_home="${TEST_TEMP_DIR}/fake-home2"
+    mkdir -p "$fake_home"
+
+    local first_path
+    first_path=$(HOME="$fake_home" get_seccomp_profile "claude")
+    assert_file_exists "$first_path" "First staged copy should exist"
+
+    # Make the staging directory read-only. If a second, identical call were
+    # to re-attempt the copy, `cp` would fail with EACCES and the function
+    # would fall back to returning the original (un-staged) source path —
+    # so a matching second_path proves the copy was correctly skipped.
+    chmod 555 "$(dirname "$first_path")"
+
+    local second_path
+    second_path=$(HOME="$fake_home" get_seccomp_profile "claude" 2>/dev/null)
+
+    chmod 755 "$(dirname "$first_path")"
+
+    assert_equals "$first_path" "$second_path" \
+        "Repeated calls with an unchanged source should not re-copy (read-only staging dir would break a real copy attempt)"
 }
 
 #===============================================================================
@@ -1061,6 +1184,12 @@ main() {
     run_test test_seccomp_env_override
     run_test test_seccomp_profile_path
     run_test test_custom_seccomp_profile
+
+    # Podman-machine seccomp staging tests (issue #443)
+    run_test test_seccomp_staging_noop_when_no_machine
+    run_test test_seccomp_staging_noop_when_already_under_home
+    run_test test_seccomp_staging_copies_when_machine_active
+    run_test test_seccomp_staging_reuses_unchanged_staged_copy
 
     # Process isolation tests
     run_test test_process_isolation_standard

--- a/tests/test-security.sh
+++ b/tests/test-security.sh
@@ -495,19 +495,37 @@ test_seccomp_staging_reuses_unchanged_staged_copy() {
     first_path=$(HOME="$fake_home" get_seccomp_profile "claude")
     assert_file_exists "$first_path" "First staged copy should exist"
 
-    # Make the staging directory read-only. If a second, identical call were
-    # to re-attempt the copy, `cp` would fail with EACCES and the function
-    # would fall back to returning the original (un-staged) source path —
-    # so a matching second_path proves the copy was correctly skipped.
-    chmod 555 "$(dirname "$first_path")"
+    # Make the staged *file itself* read-only (the staging directory stays
+    # writable, so a new file could still be created there). Overwriting an
+    # existing file only requires write permission on the file, not the
+    # directory, so chmod on the directory (as before) could never have
+    # caught a broken "skip when unchanged" optimization -- `cp` would
+    # happily truncate-and-rewrite an owner-writable dest regardless of the
+    # directory's permissions. With the dest file itself read-only, a real
+    # re-copy attempt fails with EACCES, so a matching second_path here
+    # proves the copy was genuinely skipped rather than merely appearing to
+    # succeed either way.
+    chmod 444 "$first_path"
 
     local second_path
     second_path=$(HOME="$fake_home" get_seccomp_profile "claude" 2>/dev/null)
 
-    chmod 755 "$(dirname "$first_path")"
+    chmod 644 "$first_path"
 
     assert_equals "$first_path" "$second_path" \
-        "Repeated calls with an unchanged source should not re-copy (read-only staging dir would break a real copy attempt)"
+        "Repeated calls with an unchanged source should not re-copy (read-only staged file would break a real copy attempt)"
+
+    # Also verify: if the source *does* change, the staged copy IS refreshed
+    # even though this makes the dest read-only along the way -- i.e. the
+    # skip is genuinely content-based (cmp -s), not "never copies again".
+    chmod 644 "$first_path"
+    echo '{"defaultAction": "SCMP_ACT_ERRNO"}' > "$cellar_profile"
+    local third_path
+    third_path=$(HOME="$fake_home" get_seccomp_profile "claude")
+    local third_content
+    third_content=$(cat "$third_path")
+    assert_equals '{"defaultAction": "SCMP_ACT_ERRNO"}' "$third_content" \
+        "Changed source content should be re-staged on the next call"
 }
 
 #===============================================================================


### PR DESCRIPTION
## Summary
On macOS with the podman-machine (applehv/libkrun) backend, `podman run --security-opt seccomp=<path>` resolves the path **inside the VM**, not on the host. When kapsis is installed via Homebrew, the seccomp profile lives under the Cellar `libexec` tree (`/opt/homebrew/Cellar/...`), which is not one of the machine's default mounts — so every container agent fails to launch with exit code 125, even though the file exists on the host. `$HOME` *is* a default machine mount, so profiles staged there resolve fine.

## Fix
- `scripts/lib/compat.sh`: add `is_podman_machine_active()`, probing `.State` (not `.VMType`, which podman 5.8.2+ dropped from `machine inspect` JSON).
- `scripts/lib/security.sh`: add `_stage_profile_for_machine_visibility()` — when a podman-machine VM is active and the resolved profile path isn't already under `$HOME`, copy it into `$HOME/.kapsis/seccomp/` (creating/refreshing as needed) and return that path instead. No-op on Linux, native rootless macOS, or profiles already under `$HOME`.
- `get_seccomp_profile()` now routes through staging before returning.
- Adds `tests/test-compat.sh` / `tests/test-security.sh` coverage for the new functions (podman mocked via stubbed PATH, no real machine required).

## Verification
- `shellcheck` on all 4 changed files: no errors/warnings (a few pre-existing info-level SC2016/SC2030/SC2031 notices in the new tests, matching existing test-file conventions).
- `tests/test-security.sh` (51/51) and `tests/test-compat.sh` (55/55) pass locally.

Fixes #443