### PR TITLE
fix(build): correct invalid PROTOC_VERSION pin, wire arm64 yq checksum through config

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -48,7 +48,10 @@ ARG MAVEN_VERSION=3.9.15
 ARG GRADLE_VERSION=9.4.1
 ARG GE_EXT_VERSION=1.20
 ARG GE_CCUD_VERSION=1.12.5
-ARG PROTOC_VERSION=34.1
+# 34.1 never existed on Maven Central (com.google.protobuf:protoc's real
+# version history is 2.x/3.x then a 4.x realignment — no bare "3x.x" line).
+# 3.25.1 matches what every configs/build-profiles/*.yaml already pins.
+ARG PROTOC_VERSION=3.25.1
 
 # System package toggles
 ARG ENABLE_DEV_TOOLS=true

--- a/configs/build-config.yaml
+++ b/configs/build-config.yaml
@@ -155,7 +155,9 @@ build_tools:
   #-----------------------------------------------------------------------------
   protoc:
     enabled: true
-    version: "34.1"
+    # 34.1 never existed on Maven Central (real history is 2.x/3.x then a 4.x
+    # realignment). 3.25.1 matches every configs/build-profiles/*.yaml pin.
+    version: "3.25.1"
     # Pre-cache binaries for both architectures
     cache_binaries: true
     architectures:
@@ -234,6 +236,9 @@ dependency_managers:
   yq:
     version: "4.53.3"
     sha256: "fa52a4e758c63d38299163fbdd1edfb4c4963247918bf9c1c5d31d84789eded4"
+    # arm64 checksum: previously had no override mechanism at all (only amd64
+    # was wired through), so arm64 builds silently skipped verification.
+    sha256_arm64: "578648e463a11c1b6db6010cbf41eafed6bee79466fcffa1bb446672cf7945ea"
 
 #===============================================================================
 # IMAGE CONFIGURATION

--- a/scripts/lib/build-config.sh
+++ b/scripts/lib/build-config.sh
@@ -42,7 +42,7 @@ declare -g DEFAULT_GE_ENABLED="true"
 declare -g DEFAULT_GE_EXT_VERSION="1.20"
 declare -g DEFAULT_GE_CCUD_VERSION="1.12.5"
 declare -g DEFAULT_PROTOC_ENABLED="true"
-declare -g DEFAULT_PROTOC_VERSION="25.1"
+declare -g DEFAULT_PROTOC_VERSION="3.25.1"
 
 # System package defaults
 declare -g DEFAULT_DEV_TOOLS_ENABLED="true"
@@ -54,6 +54,7 @@ declare -g DEFAULT_SECRET_STORE_ENABLED="true"
 # yq defaults
 declare -g DEFAULT_YQ_VERSION="4.44.3"
 declare -g DEFAULT_YQ_SHA256="a2c097180dd884a8d50c956ee16a9cec070f30a7947cf4ebf87d5f36213e9ed7"
+declare -g DEFAULT_YQ_SHA256_ARM64=""
 
 #===============================================================================
 # PARSED VALUES (populated by parse_build_config)
@@ -88,6 +89,7 @@ declare -g CUSTOM_PACKAGES=""
 
 declare -g YQ_VERSION=""
 declare -g YQ_SHA256=""
+declare -g YQ_SHA256_ARM64=""
 declare -g SDKMAN_SHA256=""
 declare -g NVM_SHA256=""
 
@@ -186,7 +188,7 @@ parse_build_config() {
     GE_CCUD_VERSION=$(yq -r '.build_tools.gradle_enterprise.ccud_version // "1.12.5"' "$config_file")
 
     ENABLE_PROTOC=$(_yq_bool '.build_tools.protoc.enabled' "true" "$config_file")
-    PROTOC_VERSION=$(yq -r '.build_tools.protoc.version // "25.1"' "$config_file")
+    PROTOC_VERSION=$(yq -r '.build_tools.protoc.version // "3.25.1"' "$config_file")
 
     # Parse system packages
     ENABLE_DEV_TOOLS=$(_yq_bool '.system_packages.development.enabled' "true" "$config_file")
@@ -207,6 +209,7 @@ parse_build_config() {
     # Parse yq settings
     YQ_VERSION=$(yq -r '.dependency_managers.yq.version // "4.44.3"' "$config_file")
     YQ_SHA256=$(yq -r '.dependency_managers.yq.sha256 // ""' "$config_file")
+    YQ_SHA256_ARM64=$(yq -r '.dependency_managers.yq.sha256_arm64 // ""' "$config_file")
 
     _generate_build_args
 }
@@ -252,6 +255,7 @@ _apply_defaults() {
 
     YQ_VERSION="$DEFAULT_YQ_VERSION"
     YQ_SHA256="$DEFAULT_YQ_SHA256"
+    YQ_SHA256_ARM64="$DEFAULT_YQ_SHA256_ARM64"
 }
 
 #===============================================================================
@@ -307,6 +311,9 @@ _generate_build_args() {
     # Only add SHA256 if provided
     if [[ -n "$YQ_SHA256" ]]; then
         BUILD_ARGS+=("--build-arg" "YQ_SHA256_AMD64=$YQ_SHA256")
+    fi
+    if [[ -n "$YQ_SHA256_ARM64" ]]; then
+        BUILD_ARGS+=("--build-arg" "YQ_SHA256_ARM64=$YQ_SHA256_ARM64")
     fi
     if [[ -n "$SDKMAN_SHA256" ]]; then
         BUILD_ARGS+=("--build-arg" "SDKMAN_SHA256=$SDKMAN_SHA256")

--- a/tests/test-build-config.sh
+++ b/tests/test-build-config.sh
@@ -286,6 +286,25 @@ test_build_args_generation() {
     assert_contains "$args_string" "JAVA_DEFAULT=17.0.14-zulu" "Should include JAVA_DEFAULT"
 }
 
+test_build_args_yq_arm64_checksum() {
+    log_test "Testing YQ_SHA256_ARM64 is wired into BUILD_ARGS from config"
+
+    if ! check_yq_installed; then
+        return 0
+    fi
+
+    unset _KAPSIS_BUILD_CONFIG_LOADED
+    source "$BUILD_CONFIG_LIB"
+
+    parse_build_config "$CONFIGS_DIR/build-config.yaml"
+
+    local args_string
+    args_string=$(printf '%s ' "${BUILD_ARGS[@]}")
+
+    assert_contains "$args_string" "YQ_SHA256_AMD64=" "Should include YQ_SHA256_AMD64"
+    assert_contains "$args_string" "YQ_SHA256_ARM64=" "Should include YQ_SHA256_ARM64 (previously had no config override at all)"
+}
+
 test_build_args_for_minimal() {
     log_test "Testing BUILD_ARGS for minimal profile"
 
@@ -531,6 +550,7 @@ main() {
 
     # Build args tests
     run_test test_build_args_generation
+run_test test_build_args_yq_arm64_checksum
     run_test test_build_args_for_minimal
 
     # Size estimation tests


### PR DESCRIPTION
## Summary

Follow-up to #452, fixing the two pre-existing issues that PR noted but left out of scope. Stacked on #452 since this needs the yq 4.53.3 version/hash it introduced (the arm64 checksum fix here is scoped to whatever version is currently pinned).

### 1. Invalid `PROTOC_VERSION` pin
`PROTOC_VERSION=34.1` (Containerfile ARG default, `configs/build-config.yaml`, and `build-config.sh`'s internal fallback) never existed on Maven Central — `com.google.protobuf:protoc`'s real version history is 2.x/3.x then a 4.x realignment, no bare `3x.x` line. This silently broke the `protoc-cache` build stage (caught by an existing `|| true`, so non-fatal but the cache was never actually populated). Confirmed by checking `maven-metadata.xml` directly. Aligned all three pins to `3.25.1`, which every `configs/build-profiles/*.yaml` already pins and uses successfully.

### 2. No config override for `YQ_SHA256_ARM64`
Only `YQ_SHA256_AMD64` was ever wired from config into `--build-arg` — arm64 builds always relied on the Containerfile's own arm64 default, which could silently desync from whatever `YQ_VERSION` a profile/config resolved to (and defaulted to `""` before #452, meaning checksum verification was skipped entirely on arm64). Added `YQ_SHA256_ARM64` parsing in `build-config.sh` (mirroring the existing amd64 pattern) and a `sha256_arm64` key in `build-config.yaml`. Doesn't affect shipped images (confirmed amd64-only), but fixes local builds on Apple Silicon.

## Verification
- `tests/test-build-config.sh`: 24/24 pass, including a new `test_build_args_yq_arm64_checksum`.
- `shellcheck` on `build-config.sh`: clean.
- Rebuilt `kapsis-sandbox` natively on arm64 (no QEMU) via the exact default-config path `release.yml` uses (`./scripts/build-image.sh --name ... --platform linux/arm64`, no `--profile` flag). Both the `protoc-cache` Maven resolve and the `yq-installer` arm64 checksum check completed without error — this exact invocation previously failed at `protoc-cache` with `Could not resolve dependencies ... protoc:34.1`.

Fixes the two "not in scope" items noted in #452.