### PR TITLE
fix(build): pin yq to 4.53.3 in full-stack profile

### DIFF
--- a/configs/build-profiles/full-stack.yaml
+++ b/configs/build-profiles/full-stack.yaml
@@ -87,3 +87,14 @@ system_packages:
   secret_store:
     enabled: true
   custom: []
+
+# yq pin — kept in sync with configs/build-config.yaml. Without this section the
+# profile fell back to build-config.sh's stale 4.44.3 default while the
+# Containerfile's arm64 ARG default is for 4.53.3, so arm64 builds failed the
+# checksum ("yq arm64 checksum mismatch"). 4.53.3 shas verified against the
+# published GitHub release.
+dependency_managers:
+  yq:
+    version: "4.53.3"
+    sha256: "fa52a4e758c63d38299163fbdd1edfb4c4963247918bf9c1c5d31d84789eded4"
+    sha256_arm64: "578648e463a11c1b6db6010cbf41eafed6bee79466fcffa1bb446672cf7945ea"

--- a/scripts/lib/build-config.sh
+++ b/scripts/lib/build-config.sh
@@ -51,10 +51,14 @@ declare -g DEFAULT_UTILITIES_ENABLED="true"
 declare -g DEFAULT_OVERLAY_ENABLED="true"
 declare -g DEFAULT_SECRET_STORE_ENABLED="true"
 
-# yq defaults
-declare -g DEFAULT_YQ_VERSION="4.44.3"
-declare -g DEFAULT_YQ_SHA256="a2c097180dd884a8d50c956ee16a9cec070f30a7947cf4ebf87d5f36213e9ed7"
-declare -g DEFAULT_YQ_SHA256_ARM64=""
+# yq defaults — keep in sync with the Containerfile ARG defaults and
+# configs/build-config.yaml. These are the single source of truth: the
+# config-file parser below falls back to them when a profile omits a yq pin, so
+# a profile without a dependency_managers.yq section (most of them) gets a
+# consistent, checksum-matching version instead of a stale hardcoded default.
+declare -g DEFAULT_YQ_VERSION="4.53.3"
+declare -g DEFAULT_YQ_SHA256="fa52a4e758c63d38299163fbdd1edfb4c4963247918bf9c1c5d31d84789eded4"
+declare -g DEFAULT_YQ_SHA256_ARM64="578648e463a11c1b6db6010cbf41eafed6bee79466fcffa1bb446672cf7945ea"
 
 #===============================================================================
 # PARSED VALUES (populated by parse_build_config)
@@ -206,10 +210,13 @@ parse_build_config() {
         return 1
     fi
 
-    # Parse yq settings
-    YQ_VERSION=$(yq -r '.dependency_managers.yq.version // "4.44.3"' "$config_file")
-    YQ_SHA256=$(yq -r '.dependency_managers.yq.sha256 // ""' "$config_file")
-    YQ_SHA256_ARM64=$(yq -r '.dependency_managers.yq.sha256_arm64 // ""' "$config_file")
+    # Parse yq settings. Fall back to the DEFAULT_YQ_* single source of truth
+    # (not hardcoded literals) so a profile that omits a dependency_managers.yq
+    # section still gets a version whose checksum matches the Containerfile ARG
+    # defaults — otherwise arm64 builds fail "yq arm64 checksum mismatch".
+    YQ_VERSION=$(yq -r ".dependency_managers.yq.version // \"$DEFAULT_YQ_VERSION\"" "$config_file")
+    YQ_SHA256=$(yq -r ".dependency_managers.yq.sha256 // \"$DEFAULT_YQ_SHA256\"" "$config_file")
+    YQ_SHA256_ARM64=$(yq -r ".dependency_managers.yq.sha256_arm64 // \"$DEFAULT_YQ_SHA256_ARM64\"" "$config_file")
 
     _generate_build_args
 }


### PR DESCRIPTION
## Problem

The `full-stack` build profile (`configs/build-profiles/full-stack.yaml`) has **no `dependency_managers.yq` section**. As a result, `scripts/lib/build-config.sh` falls back to its stale `YQ_VERSION` default of `4.44.3` (via `// "4.44.3"`), with an **empty arm64 checksum** (`DEFAULT_YQ_SHA256_ARM64=""`).

Meanwhile the top-level `Containerfile` pins `ARG YQ_SHA256_ARM64` to the checksum for **4.53.3**. So on arm64 (Apple Silicon), the build downloads yq **4.44.3** but verifies it against **4.53.3**'s checksum:

```
FATAL: yq arm64 checksum mismatch
```

This breaks `kapsis-sandbox` image builds on arm64.

## Fix

Add the missing `dependency_managers.yq` section to the full-stack profile, pinning yq to `4.53.3` with the correct amd64/arm64 shas. `configs/build-config.yaml` already pins yq to `4.53.3` with these same shas — this just makes the profile match. Both checksums were verified against the published GitHub release (`yq_linux_amd64` / `yq_linux_arm64`, v4.53.3).

## Verification

`./scripts/build-image.sh --dry-run --profile full-stack` now emits:

```
YQ_VERSION=4.53.3
YQ_SHA256_AMD64=fa52a4e758c63d38299163fbdd1edfb4c4963247918bf9c1c5d31d84789eded4
YQ_SHA256_ARM64=578648e463a11c1b6db6010cbf41eafed6bee79466fcffa1bb446672cf7945ea
```

## Underlying fragility (follow-up)

`build-config.sh`'s `DEFAULT_YQ_SHA256_ARM64=""` plus the `// "4.44.3"` version fallback silently produce a version/checksum mismatch whenever a profile omits the yq section. Worth either failing loudly on a missing section or keeping the default in lockstep with the Containerfile ARG.