### PR TITLE
fix(entrypoint): guard maven cache-marker touch so a cache hiccup can't kill the agent

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -964,7 +964,12 @@ setup_environment() {
         # unlike checking for one hardcoded jar path would.
         if [[ ! -f "$user_m2/.kapsis-m2-cache-populated" ]]; then
             cp -r "$KAPSIS_HOME/m2-cache/"* "$user_m2/" 2>/dev/null || true
-            touch "$user_m2/.kapsis-m2-cache-populated"
+            # Guard the marker touch: under `set -euo pipefail` an unwritable
+            # cache dir (e.g. an image/volume uid mismatch) would abort the whole
+            # entrypoint and exit 1 *before the agent starts* — turning a benign
+            # cache hiccup into a total agent failure. Degrade to a warning instead.
+            touch "$user_m2/.kapsis-m2-cache-populated" 2>/dev/null \
+                || log_warn "Maven cache marker not writable ($user_m2) — skipping; cache may re-populate next run"
             log_info "Maven local repo: pre-populated from image cache"
         fi
     fi


### PR DESCRIPTION
## Problem
Under `set -euo pipefail`, the entrypoint's `touch "$user_m2/.kapsis-m2-cache-populated"` was **unguarded**. If that dir is not writable by the runtime user (e.g. an image/volume uid mismatch), the failing touch aborts the **entire entrypoint** and the container exits 1 — **before the agent process even starts**. A benign Maven-cache hiccup becomes a total agent failure with no useful output.

Observed in the wild: a slack-bot image rebuild chowned `/home/developer/.m2` to uid 1001 while the runtime user is uid 1000, and **every** agent from that image died at this exact line before Claude ran.

## Fix
Degrade the marker touch to a `log_warn`, matching the `|| true` already on the `cp` directly above it. The marker only avoids re-copying the cache on container restart; skipping it costs at most one extra cache-populate next run.

```diff
-            touch "$user_m2/.kapsis-m2-cache-populated"
+            touch "$user_m2/.kapsis-m2-cache-populated" 2>/dev/null \
+                || log_warn "Maven cache marker not writable ($user_m2) — skipping; cache may re-populate next run"
```

## Notes
- `bash -n` clean; 23/23 build-config tests unaffected.
- Complementary to the uid-mismatch root fix on the consumer side; this is defense-in-depth so a single cache-write failure can never again take down every agent.