### PR TITLE
fix: never stage .kapsis/ internal files during post-container commit (exit 6 dead-end)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,6 +317,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v6
+        with:
+          # Full history + tags: the version-management tests resolve the current
+          # version via `git describe --tags`. The default shallow (depth=1)
+          # checkout has no tags, so describe returns a stale ancestor tag and the
+          # --downgrade tests fail with "no older version found". See version.sh
+          # get_current_version().
+          fetch-depth: 0
 
       - name: Install test dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -521,6 +521,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v6
+        with:
+          # Full history + tags: the version-management tests resolve the current
+          # version via `git describe --tags`. The default shallow (depth=1)
+          # checkout has no tags, so describe returns a stale ancestor tag and the
+          # --downgrade tests fail with "no older version found". See version.sh
+          # get_current_version(). Same fix as the Unit Tests job above.
+          fetch-depth: 0
 
       - name: Configure git for tests
         run: |

--- a/scripts/post-container-git.sh
+++ b/scripts/post-container-git.sh
@@ -536,13 +536,30 @@ commit_changes() {
     # losing the agent's real work with no retry path. Filtering them out of the
     # staging source means validate_staged_files's .kapsis/ check is now just a
     # harmless backstop that should never actually trip.
+    #
+    # ".kapsis/" is a RESERVED worktree-internal directory; a target repo must not
+    # version-control its own directory of that name. It is excluded via THREE
+    # separate mechanisms whose syntaxes differ — keep them in sync if the name
+    # ever changes: (1) the defensive `git reset -- .kapsis/` above, (2) the
+    # `grep -v '^\.kapsis/'` filter just below, and (3) the `:(exclude).kapsis/`
+    # pathspec on the git-add-A fallback. validate_staged_files()'s own
+    # `^\.kapsis/` check is a 4th, final backstop.
     log_info "Staging changes..."
-    local changed_files
-    changed_files=$(git status --porcelain | cut -c4- | grep -v '^\.kapsis/' || true)
+    # Capture porcelain ONCE. The staged_count==0 branch below needs to tell an
+    # ephemeral-only .kapsis/ run (nothing substantive to commit) apart from a
+    # genuine staging failure, and both must read the same snapshot.
+    local porcelain
+    porcelain=$(git status --porcelain)
+    local changed_files=""
+    if [[ -n "$porcelain" ]]; then
+        changed_files=$(printf '%s\n' "$porcelain" | cut -c4- | grep -v '^\.kapsis/' || true)
+    fi
 
+    # expected_count counts only the non-.kapsis/ files we intend to stage, so a
+    # pure-.kapsis worktree yields 0 (and the fallback below never spuriously fires).
     local expected_count=0
     if [[ -n "$changed_files" ]]; then
-        expected_count=$(echo "$changed_files" | wc -l | tr -d ' ')
+        expected_count=$(printf '%s\n' "$changed_files" | wc -l | tr -d ' ')
         while IFS= read -r f; do
             [[ -n "$f" ]] && git add -- "$f" 2>/dev/null || true
         done <<< "$changed_files"
@@ -561,8 +578,19 @@ commit_changes() {
         log_info "Staged $staged_count file(s) after git add -A fallback"
     fi
 
-    # If still nothing staged, log diagnostic state and bail
+    # If still nothing staged, decide between two very different outcomes:
+    #   - Only .kapsis/ internal files changed → ephemeral-only, NOT an error.
+    #     Route to the graceful rc=2 path (the caller reports "no substantive
+    #     changes"), the same as the post-sanitize guard further down. Without
+    #     this, a do-nothing agent run that only wrote gist progress would
+    #     dead-end as "Commit failed" — the very class of failure this fix
+    #     removed for the mixed real-work+.kapsis case.
+    #   - Real (non-.kapsis) files existed but none staged → genuine failure (rc 1).
     if [[ "$staged_count" -eq 0 ]]; then
+        if [[ -z "$changed_files" && -n "$porcelain" ]]; then
+            log_info "Only .kapsis/ internal files changed — nothing substantive to commit"
+            return 2
+        fi
         log_error "Failed to stage any files. Diagnostic state:"
         log_error "  git status --porcelain: $(git status --porcelain | head -10)"
         log_error "  git diff --stat: $(git diff --stat | tail -5)"

--- a/scripts/post-container-git.sh
+++ b/scripts/post-container-git.sh
@@ -517,16 +517,32 @@ commit_changes() {
     # unverified sentinel blocks are preserved and flagged.
     strip_kapsis_injections "$worktree_path" "$agent_id"
 
+    # Defensively unstage any .kapsis/ paths already present in the index.
+    # sync_index_from_container() runs before this function and copies the
+    # container's index verbatim, which can already have .kapsis/ files staged
+    # (e.g. the agent's own gist progress writes). Clear them here so the
+    # staging step below never has to deal with them via the fallback path.
+    git reset -q -- .kapsis/ 2>/dev/null || true
+
     # Stage changes: prefer explicit paths (targeted), fallback to git add -A (#211)
     # Uses cut -c4- to strip the 2-char status + space prefix from porcelain output,
     # which correctly handles filenames with spaces (awk $2 would truncate them).
+    #
+    # Never stage Kapsis's own internal files under .kapsis/ (agent gist progress,
+    # README, etc.). These live at the worktree root and are untracked whenever the
+    # target repo's .gitignore has no .kapsis/ entry. Staging them here used to be
+    # the root cause of a dead-end abort: validate_staged_files would later detect
+    # them as suspicious, unstage them, and abort the ENTIRE commit — silently
+    # losing the agent's real work with no retry path. Filtering them out of the
+    # staging source means validate_staged_files's .kapsis/ check is now just a
+    # harmless backstop that should never actually trip.
     log_info "Staging changes..."
-    local expected_count
-    expected_count=$(git status --porcelain | wc -l | tr -d ' ')
-
     local changed_files
-    changed_files=$(git status --porcelain | cut -c4-)
+    changed_files=$(git status --porcelain | cut -c4- | grep -v '^\.kapsis/' || true)
+
+    local expected_count=0
     if [[ -n "$changed_files" ]]; then
+        expected_count=$(echo "$changed_files" | wc -l | tr -d ' ')
         while IFS= read -r f; do
             [[ -n "$f" ]] && git add -- "$f" 2>/dev/null || true
         done <<< "$changed_files"
@@ -536,10 +552,11 @@ commit_changes() {
     staged_count=$(git diff --cached --name-only | wc -l | tr -d ' ')
     log_info "Staged $staged_count file(s) via explicit paths"
 
-    # Fallback: if explicit staging missed some files, try git add -A
+    # Fallback: if explicit staging missed some files, try git add -A.
+    # Excludes .kapsis/ for the same reason as the explicit-path loop above.
     if [[ "$staged_count" -lt "$expected_count" ]]; then
         log_warn "Only staged $staged_count of $expected_count files — falling back to git add -A"
-        git add -A
+        git add -A -- . ':(exclude).kapsis/'
         staged_count=$(git diff --cached --name-only | wc -l | tr -d ' ')
         log_info "Staged $staged_count file(s) after git add -A fallback"
     fi

--- a/tests/test-commit-failure-handling.sh
+++ b/tests/test-commit-failure-handling.sh
@@ -296,16 +296,23 @@ HOOKEOF
 }
 
 test_commit_changes_returns_1_on_security_violation() {
-    log_test "commit_changes() returns 1 when staged .kapsis/ or tilde files are detected"
+    log_test "commit_changes() returns 1 when staged literal ~ files are detected"
+
+    # Regression note: this used to stage a .kapsis/ internal file to exercise
+    # the security-abort path. That is no longer correct: commit_changes now
+    # never stages .kapsis/ in the first place (see
+    # test_dot_kapsis_never_staged_and_commit_succeeds below), so this test was
+    # updated to use a literal "~" path, which is still a genuine, always-fatal
+    # security violation.
 
     setup_test_repo "security-violation"
     cd "$TEST_REPO"
 
-    # Stage a legitimate file and a .kapsis/ internal file
+    # Stage a legitimate file and a literal ~ path (tilde not expanded in container)
     echo "real agent output" > agent-result.txt
-    mkdir -p .kapsis
-    echo '{"phase":"running"}' > .kapsis/status.json
-    git add agent-result.txt .kapsis/status.json
+    mkdir -p "~"
+    echo "oops" > "~/leaked"
+    git add agent-result.txt "~/leaked"
 
     local exit_code=0
     commit_changes "$TEST_REPO" "feat: test security abort" "agent-test" "" || exit_code=$?
@@ -318,7 +325,7 @@ test_commit_changes_returns_1_on_security_violation() {
         return 1
     fi
 
-    # The legitimate file should still be staged (only .kapsis/ was removed)
+    # The legitimate file should still be staged (only the ~ path was removed)
     local still_staged
     still_staged=$(git diff --cached --name-only | grep "^agent-result.txt" || echo "")
     if [[ -z "$still_staged" ]]; then
@@ -327,7 +334,74 @@ test_commit_changes_returns_1_on_security_violation() {
         return 1
     fi
 
-    log_info "  ✓ Legitimate files remain staged; .kapsis/ removed before abort"
+    log_info "  ✓ Legitimate files remain staged; ~ path removed before abort"
+    cleanup_test_repo
+}
+
+test_dot_kapsis_never_staged_and_commit_succeeds() {
+    log_test "commit_changes() never stages .kapsis/ and commits real work successfully (regression)"
+
+    # Root-cause regression test for the exit-6 dead-end bug: post-container
+    # staging used to sweep in Kapsis's own .kapsis/ internal files (README.md,
+    # gist.txt) alongside the agent's real changes. validate_staged_files would
+    # then detect them, unstage them, and ABORT THE WHOLE COMMIT — silently
+    # losing the agent's real work with no retry path (exit code 6).
+    #
+    # The fix stages "via explicit paths" from git status --porcelain but
+    # filters out .kapsis/ up front, so those files are never staged and
+    # validate_staged_files's .kapsis/ check never has anything to trip on.
+
+    setup_test_repo "dot-kapsis-fix"
+    cd "$TEST_REPO"
+
+    # Simulate a real agent run: legitimate work plus Kapsis's own internal
+    # files written into the worktree (untracked, since the repo's .gitignore
+    # has no .kapsis/ entry).
+    echo "real fix" > bugfix.txt
+    mkdir -p .kapsis
+    echo "# Kapsis" > .kapsis/README.md
+    echo '{"phase":"done"}' > .kapsis/gist.txt
+
+    # Do NOT pre-stage anything — commit_changes does its own staging via
+    # explicit paths from `git status --porcelain`, which is exactly where the
+    # original bug lived.
+
+    local exit_code=0
+    commit_changes "$TEST_REPO" "feat: test dot-kapsis exclusion" "agent-test" "" || exit_code=$?
+
+    if [[ $exit_code -ne 0 ]]; then
+        log_fail "commit_changes returned $exit_code, expected 0 (commit should succeed)"
+        cleanup_test_repo
+        return 1
+    fi
+    log_info "  ✓ commit_changes succeeded (exit 0) instead of dead-ending"
+
+    # The commit must exist and contain the real file, not .kapsis/.
+    local committed_files
+    committed_files=$(git show --name-only --pretty=format: HEAD)
+
+    if ! echo "$committed_files" | grep -q "^bugfix.txt$"; then
+        log_fail "bugfix.txt was not committed"
+        cleanup_test_repo
+        return 1
+    fi
+    log_info "  ✓ Legitimate file (bugfix.txt) was committed"
+
+    if echo "$committed_files" | grep -q "^\.kapsis/"; then
+        log_fail ".kapsis/ files were committed — they must never be staged"
+        cleanup_test_repo
+        return 1
+    fi
+    log_info "  ✓ .kapsis/ files were never staged/committed"
+
+    # .kapsis/ files should remain on disk, untouched, just not tracked.
+    if [[ ! -f "$TEST_REPO/.kapsis/gist.txt" ]]; then
+        log_fail ".kapsis/gist.txt should still exist on disk (only staging is excluded, not the files)"
+        cleanup_test_repo
+        return 1
+    fi
+    log_info "  ✓ .kapsis/ files remain on disk, just untracked"
+
     cleanup_test_repo
 }
 
@@ -372,6 +446,7 @@ main() {
     # Behavioral tests (use real git repo)
     run_test test_commit_changes_returns_1_on_failure
     run_test test_commit_changes_returns_1_on_security_violation
+    run_test test_dot_kapsis_never_staged_and_commit_succeeds
 
     # Print summary
     print_summary

--- a/tests/test-commit-failure-handling.sh
+++ b/tests/test-commit-failure-handling.sh
@@ -410,6 +410,152 @@ test_dot_kapsis_never_staged_and_commit_succeeds() {
     cleanup_test_repo
 }
 
+test_dot_kapsis_prestaged_in_index_still_commits() {
+    log_test "commit_changes() unstages .kapsis/ already in the index and still commits real work (regression)"
+
+    # Second known trigger of the exit-6 bug: sync_index_from_container() copies
+    # the container's index verbatim, which can ALREADY have .kapsis/ files staged
+    # (the agent's own gist-progress writes). The defensive `git reset -q -- .kapsis/`
+    # at the top of commit_changes() must clear them so validate_staged_files never
+    # trips. The other regression test only covers UNTRACKED .kapsis/; this covers
+    # the pre-staged-index path.
+
+    setup_test_repo "dot-kapsis-prestaged"
+    cd "$TEST_REPO"
+
+    echo "real fix" > bugfix.txt
+    mkdir -p .kapsis
+    echo '{"phase":"running"}' > .kapsis/gist.txt
+    # Simulate the container index copied by sync_index_from_container():
+    # .kapsis/ is ALREADY staged when commit_changes() is entered.
+    git add .kapsis/gist.txt
+
+    local exit_code=0
+    commit_changes "$TEST_REPO" "feat: prestaged kapsis" "agent-test" "" || exit_code=$?
+
+    if [[ $exit_code -ne 0 ]]; then
+        log_fail "commit_changes returned $exit_code, expected 0 (should unstage pre-staged .kapsis/ and commit)"
+        cleanup_test_repo
+        return 1
+    fi
+    log_info "  ✓ commit_changes succeeded despite .kapsis/ being pre-staged in the index"
+
+    local committed_files
+    committed_files=$(git show --name-only --pretty=format: HEAD)
+    if ! echo "$committed_files" | grep -q "^bugfix.txt$"; then
+        log_fail "bugfix.txt was not committed"
+        cleanup_test_repo
+        return 1
+    fi
+    if echo "$committed_files" | grep -q "^\.kapsis/"; then
+        log_fail "pre-staged .kapsis/ file reached the commit — defensive 'git reset -- .kapsis/' failed"
+        cleanup_test_repo
+        return 1
+    fi
+    log_info "  ✓ Pre-staged .kapsis/ was unstaged and excluded; bugfix.txt committed"
+
+    cleanup_test_repo
+}
+
+test_dot_kapsis_only_is_ephemeral_rc2() {
+    log_test "commit_changes() returns 2 (ephemeral, not error) when only .kapsis/ changed (regression)"
+
+    # A do-nothing agent run that wrote only .kapsis/ gist progress and no real
+    # work must be reported as "no substantive changes" (rc 2 -> the caller logs
+    # no_changes and returns 0), NOT as a hard commit failure (rc 1). With the
+    # .kapsis/ upstream filter, such a run leaves nothing staged; without the
+    # rc=2 routing it would hit `staged_count -eq 0 -> return 1` and dead-end as
+    # "Commit failed" — the same failure class this fix set out to remove.
+
+    setup_test_repo "dot-kapsis-only"
+    cd "$TEST_REPO"
+
+    local head_before
+    head_before=$(git rev-parse HEAD)
+
+    mkdir -p .kapsis
+    echo "# Kapsis" > .kapsis/README.md
+    echo '{"phase":"done"}' > .kapsis/gist.txt
+    # No real (non-.kapsis) work at all.
+
+    local exit_code=0
+    commit_changes "$TEST_REPO" "feat: only kapsis" "agent-test" "" || exit_code=$?
+
+    if [[ $exit_code -ne 2 ]]; then
+        log_fail "commit_changes returned $exit_code, expected 2 (ephemeral-only, not a hard failure)"
+        cleanup_test_repo
+        return 1
+    fi
+    log_info "  ✓ Returned rc=2 (ephemeral) instead of rc=1 (hard failure)"
+
+    if [[ "$(git rev-parse HEAD)" != "$head_before" ]]; then
+        log_fail "a commit was created for a .kapsis/-only run (expected none)"
+        cleanup_test_repo
+        return 1
+    fi
+    log_info "  ✓ No commit created; HEAD unchanged"
+
+    cleanup_test_repo
+}
+
+test_dot_kapsis_excluded_on_add_A_fallback() {
+    log_test "commit_changes() git-add-A fallback also excludes .kapsis/ (regression)"
+
+    # The explicit-path staging loop excludes .kapsis/, but so must the
+    # `git add -A -- . ':(exclude).kapsis/'` fallback that fires when explicit
+    # staging misses files (staged_count < expected_count). This test forces the
+    # fallback deterministically and proves .kapsis/ is still excluded through it.
+
+    setup_test_repo "dot-kapsis-fallback"
+    cd "$TEST_REPO"
+    # Ensure non-ASCII names are quoted in porcelain output so the explicit
+    # `git add -- "$f"` on the quoted string fails, dropping staged_count below
+    # expected_count — the exact condition that triggers the git-add-A fallback.
+    git config core.quotepath true
+
+    printf 'real work\n' > "café.txt"
+    mkdir -p .kapsis
+    echo '{"phase":"done"}' > .kapsis/gist.txt
+
+    local out exit_code=0
+    out=$(commit_changes "$TEST_REPO" "feat: fallback excludes kapsis" "agent-test" "" 2>&1) || exit_code=$?
+
+    if [[ $exit_code -ne 0 ]]; then
+        log_fail "commit_changes returned $exit_code, expected 0"
+        echo "$out"
+        cleanup_test_repo
+        return 1
+    fi
+
+    # Self-check: the fallback MUST have fired, otherwise this test exercises
+    # nothing (a green result would be meaningless). Fail loudly if it didn't.
+    if ! echo "$out" | grep -q "falling back to git add -A"; then
+        log_fail "git add -A fallback did not fire — test would not cover the fallback exclusion"
+        echo "$out"
+        cleanup_test_repo
+        return 1
+    fi
+    log_info "  ✓ git add -A fallback fired (staged_count < expected_count)"
+
+    local committed_files
+    committed_files=$(git show --name-only --pretty=format: HEAD)
+    if echo "$committed_files" | grep -q "^\.kapsis/"; then
+        log_fail ".kapsis/ files were committed via the git add -A fallback"
+        cleanup_test_repo
+        return 1
+    fi
+    log_info "  ✓ .kapsis/ excluded even through the git add -A fallback"
+
+    if ! echo "$committed_files" | grep -q "caf"; then
+        log_fail "real work file was not committed by the fallback"
+        cleanup_test_repo
+        return 1
+    fi
+    log_info "  ✓ Real work committed via the fallback"
+
+    cleanup_test_repo
+}
+
 test_push_failure_branch_still_works() {
     log_test "Push failure path still sets FINAL_EXIT_CODE=\$POST_EXIT_CODE"
 
@@ -452,6 +598,9 @@ main() {
     run_test test_commit_changes_returns_1_on_failure
     run_test test_commit_changes_returns_1_on_security_violation
     run_test test_dot_kapsis_never_staged_and_commit_succeeds
+    run_test test_dot_kapsis_prestaged_in_index_still_commits
+    run_test test_dot_kapsis_only_is_ephemeral_rc2
+    run_test test_dot_kapsis_excluded_on_add_A_fallback
 
     # Print summary
     print_summary

--- a/tests/test-commit-failure-handling.sh
+++ b/tests/test-commit-failure-handling.sh
@@ -308,10 +308,15 @@ test_commit_changes_returns_1_on_security_violation() {
     setup_test_repo "security-violation"
     cd "$TEST_REPO"
 
-    # Stage a legitimate file and a literal ~ path (tilde not expanded in container)
+    # Stage a legitimate file and a literal ~ path (tilde not expanded in container).
+    # Do NOT change these to $HOME — that would write outside TEST_REPO and
+    # defeat the security check under test (which asserts detection of a
+    # literal, unexpanded "~" path).
     echo "real agent output" > agent-result.txt
     mkdir -p "~"
+    # shellcheck disable=SC2088 # intentional literal ~, see comment above
     echo "oops" > "~/leaked"
+    # shellcheck disable=SC2088 # intentional literal ~, see comment above
     git add agent-result.txt "~/leaked"
 
     local exit_code=0


### PR DESCRIPTION
## Bug

Kapsis runs an AI agent inside a container against a git worktree, then does a post-container `git commit` + push on the host. During that step, `commit_changes()` stages the agent's changed files "via explicit paths" from `git status --porcelain` — and this swept in Kapsis's own internal files living under `.kapsis/` in the worktree (`.kapsis/README.md`, `.kapsis/gist.txt`, the phase-progress file the agent writes to). These are untracked whenever the target repo's `.gitignore` has no `.kapsis/` entry.

`validate_staged_files()` then correctly detected the staged `.kapsis/` files as suspicious internal files, unstaged them, and — because they're treated as a security-class violation — **aborted the entire commit**:

```
[validate_staged_files:129] Found staged .kapsis/ internal files (should be ignored):
[validate_staged_files:131]   - .kapsis/README.md
[validate_staged_files:131]   - .kapsis/gist.txt
[validate_staged_files:242] Suspicious files removed from staging area; aborting commit so caller can retry with clean files.
[commit_changes:558] Staged file validation failed; aborting commit to prevent unsafe files from reaching the repo
```

Nothing ever "retries with clean files" — this is a dead end. `commit_changes` returns failure, `post_container_git` fails, exit code 6 (`KAPSIS_EXIT_COMMIT_FAILURE`) is surfaced to the caller.

### User-facing impact

The agent's real work is silently lost: no commit, no push, no PR branch, worktree left in a state the caller doesn't know how to recover from — despite the agent having done its job correctly.

## Fix

Stop staging `.kapsis/` in the first place, so the `validate_staged_files` check becomes a harmless backstop instead of a load-bearing abort trigger. In `commit_changes()` (`scripts/post-container-git.sh`):

- The explicit-path staging loop now filters `.kapsis/` out of the changed-files list before calling `git add`.
- The `git add -A` fallback path now excludes `.kapsis/` via pathspec (`':(exclude).kapsis/'`).
- Added a defensive `git reset -q -- .kapsis/` at the top of the function, since `sync_index_from_container()` runs beforehand and copies the container's index verbatim — which could already have `.kapsis/` files staged from inside the container.

`validate_staged_files()` itself is untouched — it still catches literal `~` paths, Kapsis git-mount files, and, as defense in depth, any `.kapsis/` files that somehow still reach the index.

## Tests

`tests/test-commit-failure-handling.sh`:
- Added `test_dot_kapsis_never_staged_and_commit_succeeds`: a worktree with `.kapsis/README.md` + `.kapsis/gist.txt` alongside real legitimate changes now commits successfully (exit 0), the real file lands in the commit, `.kapsis/` never gets staged or committed, and the files remain on disk untouched.
- Updated `test_commit_changes_returns_1_on_security_violation` to exercise a literal `~` path instead of `.kapsis/`, since `.kapsis/` is no longer stageable in the first place — the literal-`~`-path abort behavior is still genuine and unchanged.

Ran the full relevant test files locally (all green):
```
tests/test-commit-failure-handling.sh   14/14
tests/test-validate-staged-files.sh     15/15
tests/test-kapsis-artifact-filter.sh     9/9
tests/test-coauthor-fork.sh             29/29
tests/test-committer-identity.sh        17/17
tests/test-ephemeral-artifact-filtering.sh 9/9
tests/test-push-verification.sh         11/11
```
Also ran `tests/run-all-tests.sh` (full suite) — 616 `[PASS]`, 0 `[FAIL]` before it hit the 10-minute tool timeout partway through (suite includes long-running container/integration tests unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)