### PR TITLE
Worktree-mode in-container git + hardened host push/PR (fixes dead git + no-PR)

### DIFF
--- a/dashboard/server/src/types.ts
+++ b/dashboard/server/src/types.ts
@@ -37,4 +37,10 @@
 // type (string | null, defined in dashboard/shared/src/index.ts) is
 // unchanged. No schema change here; this comment satisfies dashboard-
 // sync.yml's file-presence check.
+// Worktree in-container git PR (feat/worktree-in-container-push) added a
+// provider-pluggable host-side post-push hook. scripts/lib/status.sh gained
+// AgentStatus.pr_hook_status ("skipped" | "ok" | `failed:${string}` | null) and
+// extended push_status with "diverged" (fetch-before-push guard). Both are
+// defined in dashboard/shared/src/index.ts; this note satisfies dashboard-
+// sync.yml's file-presence check.
 export * from "@kapsis/dashboard-shared";

--- a/dashboard/shared/src/index.ts
+++ b/dashboard/shared/src/index.ts
@@ -35,7 +35,12 @@ export interface AgentStatus {
   error: string | null;
   worktree_path: string | null;
   pr_url: string | null;
-  push_status: "success" | "failed" | "skipped" | "unverified" | null;
+  // Outcome of the provider-pluggable post-push PR hook (git.post_push_hook).
+  // "failed:<reason>" carries the failure reason (e.g. "failed:exit3").
+  // Optional (like transcript_content_missing) so existing status fixtures that
+  // predate this field still satisfy AgentStatus.
+  pr_hook_status?: "skipped" | "ok" | `failed:${string}` | null;
+  push_status: "success" | "failed" | "skipped" | "unverified" | "diverged" | null;
   local_commit: string | null;
   remote_commit: string | null;
   push_fallback_command: string | null;

--- a/dashboard/ui/src/views/AgentDetail.tsx
+++ b/dashboard/ui/src/views/AgentDetail.tsx
@@ -177,6 +177,9 @@ function OverviewTab({ status, health }: { status: AgentStatus; health: AgentHea
         <div className="sub">
           commit: <code>{status.commit_sha?.slice(0, 8) ?? "—"}</code> ({status.commit_status ?? "n/a"})
           <br />push: {status.push_status ?? "n/a"}
+          {status.pr_hook_status && status.pr_hook_status !== "skipped" && (
+            <><br />PR hook: {status.pr_hook_status}</>
+          )}
         </div>
       </div>
       <div className="card">

--- a/designs/2026-08-09-worktree-in-container-push-design.md
+++ b/designs/2026-08-09-worktree-in-container-push-design.md
@@ -1,0 +1,154 @@
+# Worktree-mode in-container push (primary) with fail-closed sanitization
+
+Status: proposed
+Date: 2026-08-09
+Author: aviad.s (with Claude)
+
+## Problem
+
+In **worktree sandbox mode** (the auto-detected default), in-container git is non-functional,
+so the agent cannot commit, push, or open a PR from inside the container. The push only happens
+on the host after the container exits (`post-container-git.sh`). Symptoms observed in production
+(Slack bot, ticket DEV-230844): the agent reports *"in-container git non-functional — the
+worktree pointer references a host path … git status/add/commit/push all fail. I could not commit
+or open a PR"*; the host safety net pushes the branch but no PR is opened.
+
+### Root cause (verified on v3.2.4 == origin/main)
+
+`scripts/entrypoint.sh` line 1938:
+
+```bash
+if [[ "$sandbox_mode" == "worktree" ]] || setup_worktree_git; then
+    # Worktree mode: git is already set up by host   # <- false
+```
+
+`setup_worktree_git()` is the only place `export GIT_DIR="$CONTAINER_GIT_PATH"` (the mounted
+sanitized `.git-safe`) happens. Because `[[ … == "worktree" ]] ||` short-circuits, the function
+is never called in worktree mode → `GIT_DIR` is never set → the agent's git reads
+`/workspace/.git` (a worktree pointer to a host path absent in the container) → all git ops fail.
+Two further blockers even if `GIT_DIR` were set: the sanitized git is mounted `:ro`, and its
+`objects` is a read-only symlink to the parent object DB, so commits have nowhere to write.
+
+Historically, **overlay mode** (legacy) *did* push in-container via a `post_exit_git` EXIT trap
+over a writable CoW git — but that path performs **no sanitization** (`git add -A` with no
+`.kapsis/` exclusion, no injection strip, no invisible-char scan; those live only host-side). So
+"just revive `post_exit_git`" would restore in-container push while silently dropping every
+content guardrail.
+
+## Goals
+
+1. Worktree mode commits **and pushes inside the container** as the primary path.
+2. Host commit/push becomes a **fallback** (mount drop, in-container finalize didn't complete).
+3. **Sanitization always precedes any push**, on both the in-container and host paths.
+4. **Fail-closed**: if pushed/about-to-push content is dirty, the run fails (and the host
+   remediates the remote branch); never a silent bad push.
+5. **Provider-agnostic**: no Bitbucket/GitHub-specific assumptions in the push or sanitization
+   path (kapsis is a general sandbox tool). Reuse the repo's own `origin` + env-provided creds.
+
+## Non-goals
+
+- Cryptographic tamper-proofing against a *fully adversarial* agent inside the container. A single
+  container is a single trust domain: the agent holds the push token (needed for PR creation), so
+  anything the in-container finalize can do, an adversarial agent can replicate. This is out of
+  scope by construction; the host backstop (Layer 2) is the authoritative guarantee.
+- Changing overlay mode's behavior beyond routing it through the shared sanitization lib.
+- Bot / dev-workflow changes (the agent already runs `git push`; it simply starts working).
+
+## Design
+
+### A. Make worktree-mode in-container git writable (plumbing)
+
+1. `entrypoint.sh:1938` — run `setup_worktree_git` in worktree mode so `GIT_DIR` is exported.
+   Restructure so the function always runs when `sandbox_mode == worktree` (evaluate it first, or
+   split the branch), and fix the misleading "git is already set up by host" comment.
+2. `launch-agent.sh` `generate_volume_mounts_worktree` — mount the sanitized git **rw** (drop the
+   `:ro` on `${SANITIZED_GIT_PATH}:${CONTAINER_GIT_PATH}`). Objects mount stays `:ro`.
+3. `worktree-manager.sh` `prepare_sanitized_git` — replace the read-only `objects` symlink with a
+   git **alternate**: a writable local `objects/` dir plus `objects/info/alternates` pointing at
+   `$CONTAINER_OBJECTS_PATH`. New objects land locally (writable); existing objects are borrowed
+   read-only. Parent object DB is never written.
+
+### B. Shared, provider-agnostic sanitization library
+
+Extract the content-safety logic currently in `post-container-git.sh` into a lib sourced by both
+the host and the container:
+
+- `strip_kapsis_injections` (rogue `KAPSIS_GIST` sentinel removal),
+- `.kapsis/` staging exclusion,
+- `sanitize_staged_files` (dangerous invisible-character scan),
+- `build_coauthor_trailers` (attribution),
+- a pure `validate_tree`/`validate_commit_range` predicate (no mutation) for gate/backstop use.
+
+Nothing in this lib references a git provider — it operates on *content*, which is universal.
+
+### C. Two-layer enforcement
+
+**Layer 1 — in-container gate (honest / compromised-content agent).**
+- The agent pushes normally in-container. A kapsis-installed `pre-push` hook (fail-closed) runs
+  `validate_commit_range`; violations → non-zero → push blocked. A companion `pre-commit` may run
+  the mutating strip/exclude so commits are clean before they exist (optional ergonomic layer).
+- Hooks come from a **kapsis-owned, read-only-mounted** hooks dir referenced via `core.hooksPath`;
+  the repo's own `hooks/` is never consulted, so a hook the agent plants during its run **never
+  executes** (preserves today's `core.hooksPath=/dev/null` security intent).
+- **Integrity scan at finalize** (before trusting the in-container push): assert no rogue hook
+  files were planted in the git dir/worktree, `core.hooksPath` was not overridden at
+  local/worktree scope, and the sanitization actually ran (success sentinel with pushed SHA +
+  remote ref). Any anomaly → do not trust → fall through to Layer 2.
+
+**Layer 2 — authoritative host backstop (fail-closed).**
+- Layer 1 is bypassable from inside the container (`git push --no-verify`,
+  `git -c core.hooksPath=…`, or a direct authenticated push), so it is not the guarantee. After
+  the run, the host re-validates the landed commit with the same shared lib:
+  - clean → accept;
+  - **dirty or integrity anomaly → fail-closed: the host declines/rolls back the remote branch**
+    (delete the just-pushed branch / revert) and marks the run failed.
+- The host is also the fallback **pusher** when the in-container push did not happen (sentinel
+  absent): it sanitizes (shared lib) then pushes, exactly as today.
+
+### Fallback/skip decision (host)
+
+```
+if sentinel present AND remote HEAD == sentinel SHA:
+    host re-validates landed commit
+        clean         -> accept (in-container push is authoritative)
+        dirty/anomaly -> FAIL-CLOSED: rollback remote branch + fail run
+else:                       # in-container push didn't happen
+    host sanitizes + pushes (fallback)  # fail-closed on sanitization failure
+```
+
+## Security / threat model
+
+- **Real threat covered:** prompt-injection or a bug causing the *honest* agent to write bad
+  content (rogue injections, invisible chars, `.kapsis/` leakage). Layer 1 blocks it in-container;
+  Layer 2 catches anything that slips (including client-side hook bypass) and fails closed.
+- **Explicitly not covered in-container:** a fully adversarial agent with the push token. Only the
+  host (outside the container's trust domain) is authoritative — hence Layer 2 is mandatory, not
+  optional.
+- Writable surface is limited to the throwaway per-agent sanitized git dir; the parent object DB
+  stays read-only (alternates). Push credentials and network are unchanged from today.
+
+## Testing
+
+Extend `tests/test-post-container-git.sh` and `tests/test-sanitized-git-objects.sh`; add cases:
+- worktree in-container git is writable: `GIT_DIR` set, `git commit` succeeds, new objects land in
+  the local objects dir; parent objects dir remains read-only.
+- Layer 1 `pre-push` rejects a commit containing `.kapsis/` paths / a rogue `KAPSIS_GIST` block /
+  invisible chars; accepts a clean commit.
+- agent-planted repo hook does not execute; `core.hooksPath` override at local scope is detected.
+- host fallback: sentinel absent → host sanitizes + pushes.
+- host backstop fail-closed: dirty landed commit → host rolls back branch + run fails.
+- provider-agnostic: push path uses the repo's own `origin`, no hardcoded host.
+
+## Rollout
+
+- Land on `main`; cut a patch release. The Slack bot runs the Homebrew build (currently 3.2.4), so
+  it picks this up via `kapsis --upgrade` + `restart-bot.sh` after release.
+- The `entrypoint.sh:1938` short-circuit + the false comment are present on `main` too — this fix
+  targets both.
+
+## Open questions
+
+1. Layer 1 granularity: `pre-push` validate only, or add the `pre-commit` auto-strip? (Leaning
+   pre-push-only first; add auto-strip if reject-and-retry UX is annoying.)
+2. Rollback mechanism for Layer 2: delete the remote branch vs push a revert. Delete is simplest
+   when the branch was created by this run; revert is safer if the branch pre-existed.

--- a/designs/2026-08-09-worktree-in-container-push-design.md
+++ b/designs/2026-08-09-worktree-in-container-push-design.md
@@ -1,166 +1,224 @@
 # Worktree-mode in-container push (primary) with fail-closed sanitization
 
-Status: proposed
+Status: proposed (v2 — revised after ensemble review 2026-08-09)
 Date: 2026-08-09
 Author: aviad.s (with Claude)
 
 ## Problem
 
-In **worktree sandbox mode** (the auto-detected default), in-container git is non-functional,
-so the agent cannot commit, push, or open a PR from inside the container. The push only happens
-on the host after the container exits (`post-container-git.sh`). Symptoms observed in production
-(Slack bot, ticket DEV-230844): the agent reports *"in-container git non-functional — the
-worktree pointer references a host path … git status/add/commit/push all fail. I could not commit
-or open a PR"*; the host safety net pushes the branch but no PR is opened.
+In **worktree sandbox mode** (the auto-detected default), in-container git is non-functional, so
+the agent cannot commit, push, or open a PR from inside the container. The push only happens on the
+host after the container exits (`post-container-git.sh`). Production symptom (Slack bot, DEV-230844):
+the agent reports *"in-container git non-functional … git status/add/commit/push all fail. I could
+not commit or open a PR"*; the host safety net pushes the branch but **no PR is opened**.
 
-### Root cause (verified on v3.2.4 == origin/main)
+### Root cause (verified against v3.2.4 == origin/main)
 
-`scripts/entrypoint.sh` line 1938:
+`scripts/entrypoint.sh:1938`:
 
 ```bash
 if [[ "$sandbox_mode" == "worktree" ]] || setup_worktree_git; then
-    # Worktree mode: git is already set up by host   # <- false
 ```
 
 `setup_worktree_git()` is the only place `export GIT_DIR="$CONTAINER_GIT_PATH"` (the mounted
-sanitized `.git-safe`) happens. Because `[[ … == "worktree" ]] ||` short-circuits, the function
-is never called in worktree mode → `GIT_DIR` is never set → the agent's git reads
-`/workspace/.git` (a worktree pointer to a host path absent in the container) → all git ops fail.
-Two further blockers even if `GIT_DIR` were set: the sanitized git is mounted `:ro`, and its
-`objects` is a read-only symlink to the parent object DB, so commits have nowhere to write.
+sanitized `.git-safe`) happens (entrypoint.sh:780). `[[ … == "worktree" ]] ||` short-circuits, so it
+is never called in worktree mode → `GIT_DIR` unset → the agent's git reads `/workspace/.git` (a
+worktree pointer to a host path absent in the container) → all git ops fail. Two further blockers:
+the sanitized git is mounted `:ro` (launch-agent.sh:1598) and its `objects` is a read-only symlink to
+the parent object DB (worktree-manager.sh:526), so commits have nowhere to write.
 
-Historically, **overlay mode** (legacy) *did* push in-container via a `post_exit_git` EXIT trap
-over a writable CoW git — but that path performs **no sanitization** (`git add -A` with no
-`.kapsis/` exclusion, no injection strip, no invisible-char scan; those live only host-side). So
-"just revive `post_exit_git`" would restore in-container push while silently dropping every
-content guardrail.
+Historically, **overlay mode** pushed in-container via a `post_exit_git` EXIT trap over a writable
+CoW git — but that path does a bare `git add -A` with **no sanitization** (entrypoint.sh:1118); the
+guardrails (`strip_kapsis_injections`, `.kapsis/` exclusion, `sanitize_staged_files`,
+`build_coauthor_trailers`) live only host-side in `post-container-git.sh`.
+
+**Correction (ensemble claim-verifier):** worktree mode does **not** disable hooks via
+`core.hooksPath=/dev/null` today — that is gated behind `KAPSIS_DISABLE_HOOKS=true` in the overlay
+path only. What actually prevents hooks in worktree mode today is the **empty, `:ro` hooks dir**
+(worktree-manager.sh:484). This matters: making the git dir writable (below) would let an
+agent-planted hook execute unless we handle it explicitly.
 
 ## Goals
 
-1. Worktree mode commits **and pushes inside the container** as the primary path.
-2. Host commit/push becomes a **fallback** (mount drop, in-container finalize didn't complete).
-3. **Sanitization always precedes any push**, on both the in-container and host paths.
-4. **Fail-closed**: if pushed/about-to-push content is dirty, the run fails (and the host
-   remediates the remote branch); never a silent bad push.
-5. **Provider-agnostic**: no Bitbucket/GitHub-specific assumptions in the push or sanitization
-   path (kapsis is a general sandbox tool). Reuse the repo's own `origin` + env-provided creds.
+1. Worktree mode commits and **pushes inside the container** as the primary path.
+2. Host commit/push becomes a **fallback** (in-container finalize didn't run / push didn't land).
+3. **Sanitization (mutating) always precedes any push**, on both paths.
+4. **Fail-closed**: any content that lands on the remote is validated by a component the agent
+   cannot bypass; dirty content → run fails and the remote is remediated. Never a silent bad push.
+5. **Provider-agnostic**: no hardcoded git provider in kapsis core. Reuse the repo's own `origin`
+   and the container's configured credentials; PR creation is delegated (see §E).
 
 ## Non-goals
 
 - Cryptographic tamper-proofing against a *fully adversarial* agent inside the container. A single
-  container is a single trust domain: the agent holds the push token (needed for PR creation), so
-  anything the in-container finalize can do, an adversarial agent can replicate. This is out of
-  scope by construction; the host backstop (Layer 2) is the authoritative guarantee.
-- Changing overlay mode's behavior beyond routing it through the shared sanitization lib.
-- Bot / dev-workflow changes (the agent already runs `git push`; it simply starts working).
+  container is one trust domain; the authoritative guarantee is the **host** re-validation (§D),
+  outside the container.
+- Hardcoding PR creation for any provider (delegated to a post-push hook, §E).
 
 ## Design
 
+### Pivot (post-ensemble): kapsis finalize pushes; the agent never pushes
+
+The agent only **edits files** (and may commit locally). It has **no push credentials during its
+run**. After the agent exits, a kapsis-controlled **in-container finalize** step (an EXIT-trap,
+registered in worktree mode too) performs the mutating sanitization, the canonical commit, and the
+push. This closes the ensemble's three soundness holes at once: the mutating gist-strip runs
+in-container before the pushed commit (Goal 3), there is no client-side hook to bypass, and
+credentials exist only in the finalize phase.
+
 ### A. Make worktree-mode in-container git writable (plumbing)
 
-1. `entrypoint.sh:1938` — run `setup_worktree_git` in worktree mode so `GIT_DIR` is exported.
-   Restructure so the function always runs when `sandbox_mode == worktree` (evaluate it first, or
-   split the branch), and fix the misleading "git is already set up by host" comment.
-2. `launch-agent.sh` `generate_volume_mounts_worktree` — mount the sanitized git **rw** (drop the
-   `:ro` on `${SANITIZED_GIT_PATH}:${CONTAINER_GIT_PATH}`). Objects mount stays `:ro`.
-3. `worktree-manager.sh` `prepare_sanitized_git` — replace the read-only `objects` symlink with a
-   git **alternate**: a writable local `objects/` dir plus `objects/info/alternates` pointing at
-   `$CONTAINER_OBJECTS_PATH`. New objects land locally (writable); existing objects are borrowed
-   read-only. Parent object DB is never written.
+1. `entrypoint.sh:1938` — run `setup_worktree_git` in worktree mode so `GIT_DIR` is exported
+   (restructure so the function always runs when `sandbox_mode == worktree`); fix the false
+   "git is already set up by host" comment.
+2. `launch-agent.sh` `generate_volume_mounts_worktree` — mount the sanitized git **rw**.
+3. `worktree-manager.sh` `prepare_sanitized_git` — writable local `objects/` + `objects/info/alternates`
+   → `$CONTAINER_OBJECTS_PATH` (parent DB borrowed read-only; new objects land locally). Push
+   negotiates the object delta over the wire, so a missing `refs/remotes/origin/<branch>` does not
+   break push (confirmed by review).
+   - **Objects/repoint impact (ensemble C3):** the host `repoint_sanitized_git_objects()`
+     (launch-agent.sh:3635-3667) currently rewrites the RO symlink to the host path for host use. The
+     host **fallback** operates on the **real worktree gitdir** (not the sanitized dir), so it does
+     not depend on the sanitized dir's objects; update/retire `repoint_*` accordingly and cover with
+     tests (§Testing). The sanitized dir's alternate is validated at finalize (no agent-added
+     alternates; §Security).
 
-### B. Shared, provider-agnostic sanitization library
+### B. Shared, provider-agnostic, self-contained sanitization library
 
-Extract the content-safety logic currently in `post-container-git.sh` into a lib sourced by both
-the host and the container:
+Extract into a lib sourced by both host and container. It must be **self-contained in-container** —
+no host-only deps (`$TMPDIR`, host provenance):
+- `strip_kapsis_injections` (mutating — removes kapsis's own `KAPSIS_GIST` block and rogue variants),
+- `.kapsis/` + `.git-safe/` + `.git-objects/` staging exclusion — **case-insensitive** (APFS),
+- `sanitize_staged_files` (invisible-char scan; reject on unfixable),
+- `build_coauthor_trailers`,
+- `validate_range <base>..<tip>` — a pure predicate over an **explicit commit range** (never whole
+  history) used by the host backstop.
 
-- `strip_kapsis_injections` (rogue `KAPSIS_GIST` sentinel removal),
-- `.kapsis/` staging exclusion,
-- `sanitize_staged_files` (dangerous invisible-character scan),
-- `build_coauthor_trailers` (attribution),
-- a pure `validate_tree`/`validate_commit_range` predicate (no mutation) for gate/backstop use.
+### C. In-container finalize (primary path)
 
-Nothing in this lib references a git provider — it operates on *content*, which is universal.
+Registered as an EXIT trap in worktree mode; runs after the agent process exits:
+1. `git reset --soft <base>` to drop any agent commits, so the pushed commit is kapsis-authored and
+   clean regardless of what the agent staged/committed.
+2. Mutating sanitize on the working tree/index: `strip_kapsis_injections`, exclude `.kapsis/` etc.,
+   `sanitize_staged_files` (**fail-closed** on unfixable content — abort finalize, leave to host).
+3. Canonical commit (kapsis message + co-author trailers), **hooks disabled explicitly**
+   (`-c core.hooksPath= --no-verify`), so no agent-planted hook runs.
+4. Configure credentials **ephemerally** (§F), then `git push` the refspec.
+5. On success: write a sentinel (pushed SHA + remote ref — an *optimization hint*, not proof), then
+   invoke the optional **post-push hook** (§E). Finally scrub credentials (§F).
 
-### C. Two-layer enforcement
+The agent's own `git push` cannot reach the remote during its run (no credentials), so it fails fast
+and locally; dev-workflow guidance will note that kapsis finalizes the push.
 
-**Layer 1 — in-container gate (honest / compromised-content agent).**
-- The agent pushes normally in-container. A kapsis-installed `pre-push` hook (fail-closed) runs
-  `validate_commit_range`; violations → non-zero → push blocked with a clear message, and the agent
-  fixes the content and retries. **Validate-and-reject only — no `pre-commit` auto-strip.** The
-  mutating strip/exclude (`strip_kapsis_injections`, `.kapsis/` exclusion) runs only on the host
-  fallback path, where kapsis controls the commit; in-container we never rewrite the agent's commit,
-  we reject it.
-- Hooks come from a **kapsis-owned, read-only-mounted** hooks dir referenced via `core.hooksPath`;
-  the repo's own `hooks/` is never consulted, so a hook the agent plants during its run **never
-  executes** (preserves today's `core.hooksPath=/dev/null` security intent).
-- **Integrity scan at finalize** (before trusting the in-container push): assert no rogue hook
-  files were planted in the git dir/worktree, `core.hooksPath` was not overridden at
-  local/worktree scope, and the sanitization actually ran (success sentinel with pushed SHA +
-  remote ref). Any anomaly → do not trust → fall through to Layer 2.
+### D. Host: always-revalidate backstop + reconciling fallback (fail-closed)
 
-**Layer 2 — authoritative host backstop (fail-closed).**
-- Layer 1 is bypassable from inside the container (`git push --no-verify`,
-  `git -c core.hooksPath=…`, or a direct authenticated push), so it is not the guarantee. After
-  the run, the host re-validates the landed commit with the same shared lib:
-  - clean → accept;
-  - **dirty or integrity anomaly → fail-closed** remediation chosen by branch provenance, then the
-    run is marked failed:
-    - branch **created by this run** → **delete** the remote branch (nothing pre-existing to keep);
-    - branch **pre-existed** → **restore it to its pre-run remote tip** (reset/revert the ref to the
-      SHA captured at setup) — never delete a branch we did not create.
-    Kapsis already distinguishes these at worktree creation (`create_worktree` logs *"Tracking
-    existing remote branch …"* for pre-existing vs. creating new); record that provenance plus the
-    pre-run remote SHA at setup so the backstop can remediate exactly.
-- The host is also the fallback **pusher** when the in-container push did not happen (sentinel
-  absent): it sanitizes (shared lib) then pushes, exactly as today.
-
-### Fallback/skip decision (host)
+The host runs after the container exits. It does **not** trust the sentinel as a gate — it inspects
+the **actual remote state**:
 
 ```
-if sentinel present AND remote HEAD == sentinel SHA:
-    host re-validates landed commit
-        clean         -> accept (in-container push is authoritative)
-        dirty/anomaly -> FAIL-CLOSED: remediate by provenance (delete if run-created,
-                         else restore to pre-run SHA) + fail run
-else:                       # in-container push didn't happen
-    host sanitizes + pushes (fallback)  # fail-closed on sanitization failure
+git fetch origin <remote_branch>
+if remote has commits beyond the pre-run tip (i.e. something landed):
+    validate_range <pre_run_tip>..<remote_tip>        # FULL range, every commit
+        clean   -> accept (in-container push authoritative)
+        dirty   -> FAIL-CLOSED remediate (see below) + fail run
+    if sentinel present but remote_tip != sentinel SHA -> ANOMALY -> treat as dirty
+else:                                                  # nothing landed in-container
+    host fallback: sanitize(mutate) worktree + commit + fetch/reconcile + push
+        (fetch-before-push; if remote diverged, do NOT blind-push a divergent SHA — reconcile or fail)
 ```
+
+**Fail-closed remediation, provenance-based, with compare-and-swap (ensemble H2/C1):**
+- branch **created by this run** → delete the remote branch **only if** its tip still equals the SHA
+  we pushed (`git push --force-with-lease=<ref>:<pushed_sha> origin :<ref>` semantics);
+- branch **pre-existed** → restore to the pre-run tip **only if** the current tip equals the SHA we
+  pushed (`--force-with-lease`); if it advanced (concurrent legit push), do **not** clobber — fail
+  the run and alert.
+- Provenance (`created_by_run` bool) and the pre-run remote SHA are captured at worktree setup and
+  persisted host-side (status JSON), since `create_worktree` only logs them today.
+
+This makes Layer-2 validation **unconditional** over the full landed range and rollback **safe under
+concurrency** — the two holes the ensemble flagged as CRITICAL.
+
+### E. PR creation — provider-pluggable post-push hook (delegated)
+
+kapsis does not create PRs. After a successful push, the finalize (and the host fallback) invoke an
+**optional** user-configured command, e.g. `git.post_push_hook` in the agent config, with env
+(`KAPSIS_REMOTE_BRANCH`, `KAPSIS_BASE_BRANCH`, pushed SHA). The Slack bot config supplies its
+`bkt/gh pr create` command; unset = no PR (today's behavior). Provider logic stays entirely in
+user config.
+
+### F. Credential hygiene (ensemble H5)
+
+- Push credentials are present **only** during the finalize push (and host fallback), never during
+  the agent's run.
+- Never persist an auth-embedded URL into the sanitized/worktree git config; use an ephemeral
+  credential helper / `GIT_CONFIG_COUNT` env or `-c credential.helper=…` scoped to the push
+  invocation; unset afterward.
+- Keep the token out of the sentinel, reflog, and captured logs (push with `--quiet`, no
+  `set -x`, redact URLs in logs).
 
 ## Security / threat model
 
-- **Real threat covered:** prompt-injection or a bug causing the *honest* agent to write bad
-  content (rogue injections, invisible chars, `.kapsis/` leakage). Layer 1 blocks it in-container;
-  Layer 2 catches anything that slips (including client-side hook bypass) and fails closed.
-- **Explicitly not covered in-container:** a fully adversarial agent with the push token. Only the
-  host (outside the container's trust domain) is authoritative — hence Layer 2 is mandatory, not
-  optional.
-- Writable surface is limited to the throwaway per-agent sanitized git dir; the parent object DB
-  stays read-only (alternates). Push credentials and network are unchanged from today.
+- **Covered:** an *honest* agent whose content got compromised (prompt-injection writing rogue
+  `KAPSIS_GIST` / invisible chars / `.kapsis/` leakage). The finalize mutating-strip removes it
+  before the pushed commit; the host re-validates the full landed range and fails closed on anything
+  dirty — including a bypass push, because host validation is unconditional on remote state.
+- **Not covered in-container:** a fully adversarial agent with the push token. But the agent has
+  **no token during its run** (§F), and the **host** (outside the container) is the authoritative
+  validator/remediator — so even a token exfiltrated from the finalize phase cannot land unvalidated
+  content without the host catching and rolling it back.
+- Writable `$GIT_DIR`: hooks are disabled during finalize (§C); the agent-run keeps the empty hooks
+  dir and we do not rely on a client-side hook as a gate. `objects/info/alternates` is validated at
+  finalize (exactly one expected alternate; reject others). Parent-history exposure via the RO
+  objects mount is inherent to worktree mode today (unchanged).
+- Layer-2 is a **validate-and-remediate** backstop; it rejects/rolls back, it does not "repair"
+  (wording corrected from v1).
 
 ## Testing
 
-Extend `tests/test-post-container-git.sh` and `tests/test-sanitized-git-objects.sh`; add cases:
-- worktree in-container git is writable: `GIT_DIR` set, `git commit` succeeds, new objects land in
-  the local objects dir; parent objects dir remains read-only.
-- Layer 1 `pre-push` rejects a commit containing `.kapsis/` paths / a rogue `KAPSIS_GIST` block /
-  invisible chars; accepts a clean commit.
-- agent-planted repo hook does not execute; `core.hooksPath` override at local scope is detected.
-- host fallback: sentinel absent → host sanitizes + pushes.
-- host backstop fail-closed: dirty landed commit → host rolls back branch + run fails.
-- provider-agnostic: push path uses the repo's own `origin`, no hardcoded host.
+Add a **fake-remote harness** (a local bare repo as `origin`) so in-container finalize push and host
+backstop are testable without a real provider. Extend `tests/test-post-container-git.sh` and
+`tests/test-sanitized-git-objects.sh`:
+- worktree in-container git writable: `GIT_DIR` set, commit succeeds, new objects in local objects
+  dir; parent objects dir stays read-only; alternates has exactly the expected entry.
+- finalize mutating-strip removes an injected `KAPSIS_GIST` block from `CLAUDE.md`; excludes
+  `.kapsis/` (incl. `.KAPSIS/` on case-insensitive FS); rejects invisible chars (fail-closed).
+- finalize push lands on the fake remote; sentinel written; post-push hook invoked with correct env;
+  credentials absent from config/reflog/logs afterward.
+- host backstop: dirty landed commit → fail-closed rollback via `--force-with-lease`; concurrent
+  advance (tip ≠ pushed SHA) → does NOT clobber, run fails.
+- host fallback (in-container push didn't land): fetch-before-push; divergent remote → no blind
+  non-ff push.
+- validate range bounded to `base..tip` (no whole-history scan) incl. first-push (no remote branch).
+- provider-agnostic: push uses the repo's own `origin`; no hardcoded host; post-push hook unset = no
+  PR, run still succeeds.
 
 ## Rollout
 
-- Land on `main`; cut a patch release. The Slack bot runs the Homebrew build (currently 3.2.4), so
-  it picks this up via `kapsis --upgrade` + `restart-bot.sh` after release.
-- The `entrypoint.sh:1938` short-circuit + the false comment are present on `main` too — this fix
-  targets both.
+- Land on `main`; cut a patch release. The Slack bot runs the Homebrew build (currently 3.2.4); it
+  picks this up via `kapsis --upgrade` + `restart-bot.sh`.
+- Back-compat: document behavior for in-flight worktrees created by the old version at upgrade time.
+- Network: the git host must be in the agent's egress allowlist for in-container push (already true
+  for the bot; note for general users).
 
-## Resolved decisions (review 2026-08-09)
+## Resolved decisions
 
-1. **Layer 1 = `pre-push` validate-and-reject only** — no `pre-commit` auto-strip. In-container we
-   reject dirty commits and let the agent fix + retry; the mutating strip/exclude runs only on the
-   host fallback path where kapsis owns the commit.
-2. **Layer 2 rollback is provenance-based** — delete the remote branch if this run created it;
-   otherwise restore it to its pre-run remote tip (SHA captured at setup). Never delete a branch we
-   did not create. Provenance + pre-run SHA are recorded at worktree setup.
+1. **Pivot adopted:** kapsis in-container **finalize pushes**; the agent never pushes (no creds in
+   its run). Replaces v1's "agent pushes."
+2. **Sanitization is mutating, in-container, before the pushed commit** (finalize strip/exclude).
+   Replaces v1's "pre-push validate-only" (which would fail every `CLAUDE.md` run due to kapsis's own
+   gist injection).
+3. **Layer-2 host backstop is unconditional** over the full landed range (sentinel is a hint, not a
+   trigger); **rollback uses compare-and-swap** (`--force-with-lease`) and is provenance-based
+   (delete if run-created, else restore to pre-run tip; never clobber a concurrent advance).
+4. **PR creation** stays out of kapsis core — delegated to an optional provider-pluggable
+   **post-push hook** (bot config supplies `bkt/gh`).
+
+## Ensemble review log (2026-08-09)
+
+Addressed: C1 unconditional full-range host re-validation (§D); C2 mutating in-container strip (§C);
+C3 objects/repoint handling (§A); H1 fetch-before-push fallback (§D); H2 CAS rollback (§D); H3 hooks
+handled via finalize-disable + no client-side gate (§C/Security); H4 post-push PR hook (§E); H5
+credential hygiene (§F); plus medium items: fake-remote harness, self-contained shared lib,
+case-insensitive exclusion, bounded validate range, egress note, alternates validation, over-claim
+wording.

--- a/designs/2026-08-09-worktree-in-container-push-design.md
+++ b/designs/2026-08-09-worktree-in-container-push-design.md
@@ -85,8 +85,11 @@ Nothing in this lib references a git provider — it operates on *content*, whic
 
 **Layer 1 — in-container gate (honest / compromised-content agent).**
 - The agent pushes normally in-container. A kapsis-installed `pre-push` hook (fail-closed) runs
-  `validate_commit_range`; violations → non-zero → push blocked. A companion `pre-commit` may run
-  the mutating strip/exclude so commits are clean before they exist (optional ergonomic layer).
+  `validate_commit_range`; violations → non-zero → push blocked with a clear message, and the agent
+  fixes the content and retries. **Validate-and-reject only — no `pre-commit` auto-strip.** The
+  mutating strip/exclude (`strip_kapsis_injections`, `.kapsis/` exclusion) runs only on the host
+  fallback path, where kapsis controls the commit; in-container we never rewrite the agent's commit,
+  we reject it.
 - Hooks come from a **kapsis-owned, read-only-mounted** hooks dir referenced via `core.hooksPath`;
   the repo's own `hooks/` is never consulted, so a hook the agent plants during its run **never
   executes** (preserves today's `core.hooksPath=/dev/null` security intent).
@@ -100,8 +103,14 @@ Nothing in this lib references a git provider — it operates on *content*, whic
   `git -c core.hooksPath=…`, or a direct authenticated push), so it is not the guarantee. After
   the run, the host re-validates the landed commit with the same shared lib:
   - clean → accept;
-  - **dirty or integrity anomaly → fail-closed: the host declines/rolls back the remote branch**
-    (delete the just-pushed branch / revert) and marks the run failed.
+  - **dirty or integrity anomaly → fail-closed** remediation chosen by branch provenance, then the
+    run is marked failed:
+    - branch **created by this run** → **delete** the remote branch (nothing pre-existing to keep);
+    - branch **pre-existed** → **restore it to its pre-run remote tip** (reset/revert the ref to the
+      SHA captured at setup) — never delete a branch we did not create.
+    Kapsis already distinguishes these at worktree creation (`create_worktree` logs *"Tracking
+    existing remote branch …"* for pre-existing vs. creating new); record that provenance plus the
+    pre-run remote SHA at setup so the backstop can remediate exactly.
 - The host is also the fallback **pusher** when the in-container push did not happen (sentinel
   absent): it sanitizes (shared lib) then pushes, exactly as today.
 
@@ -111,7 +120,8 @@ Nothing in this lib references a git provider — it operates on *content*, whic
 if sentinel present AND remote HEAD == sentinel SHA:
     host re-validates landed commit
         clean         -> accept (in-container push is authoritative)
-        dirty/anomaly -> FAIL-CLOSED: rollback remote branch + fail run
+        dirty/anomaly -> FAIL-CLOSED: remediate by provenance (delete if run-created,
+                         else restore to pre-run SHA) + fail run
 else:                       # in-container push didn't happen
     host sanitizes + pushes (fallback)  # fail-closed on sanitization failure
 ```
@@ -146,9 +156,11 @@ Extend `tests/test-post-container-git.sh` and `tests/test-sanitized-git-objects.
 - The `entrypoint.sh:1938` short-circuit + the false comment are present on `main` too — this fix
   targets both.
 
-## Open questions
+## Resolved decisions (review 2026-08-09)
 
-1. Layer 1 granularity: `pre-push` validate only, or add the `pre-commit` auto-strip? (Leaning
-   pre-push-only first; add auto-strip if reject-and-retry UX is annoying.)
-2. Rollback mechanism for Layer 2: delete the remote branch vs push a revert. Delete is simplest
-   when the branch was created by this run; revert is safer if the branch pre-existed.
+1. **Layer 1 = `pre-push` validate-and-reject only** — no `pre-commit` auto-strip. In-container we
+   reject dirty commits and let the agent fix + retry; the mutating strip/exclude runs only on the
+   host fallback path where kapsis owns the commit.
+2. **Layer 2 rollback is provenance-based** — delete the remote branch if this run created it;
+   otherwise restore it to its pre-run remote tip (SHA captured at setup). Never delete a branch we
+   did not create. Provenance + pre-run SHA are recorded at worktree setup.

--- a/designs/2026-08-09-worktree-in-container-push-design.md
+++ b/designs/2026-08-09-worktree-in-container-push-design.md
@@ -1,16 +1,20 @@
 # Worktree-mode in-container push (primary) with fail-closed sanitization
 
-Status: proposed (v2 — revised after ensemble review 2026-08-09)
+Status: proposed (v3 — architecture B, after two ensemble rounds 2026-08-09)
 Date: 2026-08-09
 Author: aviad.s (with Claude)
 
+> Title retained for continuity. **v3 changes the architecture:** in-container git becomes usable by
+> the agent for **commit / diff / verify**, but the credentialed **push + PR + validation happen on
+> the host** — see "Architecture decision" below for why the literal in-container push was dropped.
+
 ## Problem
 
-In **worktree sandbox mode** (the auto-detected default), in-container git is non-functional, so
-the agent cannot commit, push, or open a PR from inside the container. The push only happens on the
-host after the container exits (`post-container-git.sh`). Production symptom (Slack bot, DEV-230844):
-the agent reports *"in-container git non-functional … git status/add/commit/push all fail. I could
-not commit or open a PR"*; the host safety net pushes the branch but **no PR is opened**.
+In **worktree sandbox mode** (the auto-detected default), in-container git is non-functional: the
+agent cannot commit, diff, verify, or open a PR from inside the container. Production symptom (Slack
+bot, DEV-230844): the agent reports *"in-container git non-functional … git status/add/commit/push
+all fail. I could not commit or open a PR"*; the host safety net pushes the branch but **no PR is
+opened**, so the user sees a failed `/dev` run.
 
 ### Root cause (verified against v3.2.4 == origin/main)
 
@@ -21,204 +25,160 @@ if [[ "$sandbox_mode" == "worktree" ]] || setup_worktree_git; then
 ```
 
 `setup_worktree_git()` is the only place `export GIT_DIR="$CONTAINER_GIT_PATH"` (the mounted
-sanitized `.git-safe`) happens (entrypoint.sh:780). `[[ … == "worktree" ]] ||` short-circuits, so it
-is never called in worktree mode → `GIT_DIR` unset → the agent's git reads `/workspace/.git` (a
+sanitized `.git-safe`) happens (entrypoint.sh:780). The `[[ … == "worktree" ]] ||` short-circuits, so
+it is never called in worktree mode → `GIT_DIR` unset → the agent's git reads `/workspace/.git` (a
 worktree pointer to a host path absent in the container) → all git ops fail. Two further blockers:
 the sanitized git is mounted `:ro` (launch-agent.sh:1598) and its `objects` is a read-only symlink to
 the parent object DB (worktree-manager.sh:526), so commits have nowhere to write.
 
-Historically, **overlay mode** pushed in-container via a `post_exit_git` EXIT trap over a writable
-CoW git — but that path does a bare `git add -A` with **no sanitization** (entrypoint.sh:1118); the
-guardrails (`strip_kapsis_injections`, `.kapsis/` exclusion, `sanitize_staged_files`,
-`build_coauthor_trailers`) live only host-side in `post-container-git.sh`.
+## Architecture decision (why host-side push, not in-container)
 
-**Correction (ensemble claim-verifier):** worktree mode does **not** disable hooks via
-`core.hooksPath=/dev/null` today — that is gated behind `KAPSIS_DISABLE_HOOKS=true` in the overlay
-path only. What actually prevents hooks in worktree mode today is the **empty, `:ro` hooks dir**
-(worktree-manager.sh:484). This matters: making the git dir writable (below) would let an
-agent-planted hook execute unless we handle it explicitly.
+Two ensemble rounds evaluated a pivot that pushed from inside the container via a post-agent-exit
+finalize. Two independent, verified findings killed the literal in-container **push**:
+
+1. **It can't fire on the failure modes we're fixing.** A post-exit finalize can't run when the
+   liveness monitor **SIGKILLs PID 1** (SIGKILL tears down the PID namespace) or when the
+   **virtio-fs mount drops** (the filesystem is gone). DEV-230844 — the motivating incident — *was* a
+   liveness SIGKILL. (Also: an EXIT trap never runs because `entrypoint.sh:2053` `exec "$@"` replaces
+   the shell; overlay's `post_exit_git` trap has been dead for the same reason, so "overlay pushed
+   in-container" was never actually true.)
+2. **Consequence:** because the in-container push can't cover those cases, a fully-capable **host**
+   push + PR + validate path must exist regardless. An in-container credentialed push would then be
+   an unreliable, harder-to-secure **duplicate** of a host path we're forced to build anyway (and
+   running a credentialed push inside a container the agent controlled adds credential-exfil surface
+   — a defense-in-depth concern beyond our honest-agent threat model).
+
+**Decision (B):** make in-container git **writable so the agent can commit / diff / verify** (this
+fixes the reported dead-git symptom), and do the credentialed **push + PR + validation on the host**,
+where creds live safely and the code always runs. This does **not** push from inside the container.
 
 ## Goals
 
-1. Worktree mode commits and **pushes inside the container** as the primary path.
-2. Host commit/push becomes a **fallback** (in-container finalize didn't run / push didn't land).
-3. **Sanitization (mutating) always precedes any push**, on both paths.
-4. **Fail-closed**: any content that lands on the remote is validated by a component the agent
-   cannot bypass; dirty content → run fails and the remote is remediated. Never a silent bad push.
-5. **Provider-agnostic**: no hardcoded git provider in kapsis core. Reuse the repo's own `origin`
-   and the container's configured credentials; PR creation is delegated (see §E).
+1. The agent has **working git inside the container** (status/diff/add/commit/log) for its own
+   workflow and verification. No dead-git.
+2. The host reliably **commits the final worktree state, sanitizes, validates, pushes, and triggers
+   PR creation** — every worktree-mode `/dev` run ends with a pushed branch and (if configured) a PR.
+3. **Sanitization + validation always precede the push**, fail-closed: unfixable/unexpected content
+   → do **not** push, fail the run (nothing lands, so no rollback needed).
+4. **Provider-agnostic**: reuse the repo's own `origin` + host credentials; PR creation delegated to
+   an optional user-configured post-push hook.
 
 ## Non-goals
 
-- Cryptographic tamper-proofing against a *fully adversarial* agent inside the container. A single
-  container is one trust domain; the authoritative guarantee is the **host** re-validation (§D),
-  outside the container.
-- Hardcoding PR creation for any provider (delegated to a post-push hook, §E).
+- Pushing from inside the container (dropped — see Architecture decision).
+- PR creation logic in kapsis core (delegated to the post-push hook).
+- Defending against a fully adversarial in-container agent (honest-but-content-compromised is the
+  threat model; the host is outside the agent's trust domain and is authoritative).
 
 ## Design
 
-### Pivot (post-ensemble): kapsis finalize pushes; the agent never pushes
+### A. Writable in-container git (for the agent's commit/diff/verify)
 
-The agent only **edits files** (and may commit locally). It has **no push credentials during its
-run**. After the agent exits, a kapsis-controlled **in-container finalize** step (an EXIT-trap,
-registered in worktree mode too) performs the mutating sanitization, the canonical commit, and the
-push. This closes the ensemble's three soundness holes at once: the mutating gist-strip runs
-in-container before the pushed commit (Goal 3), there is no client-side hook to bypass, and
-credentials exist only in the finalize phase.
-
-### A. Make worktree-mode in-container git writable (plumbing)
-
-1. `entrypoint.sh:1938` — run `setup_worktree_git` in worktree mode so `GIT_DIR` is exported
-   (restructure so the function always runs when `sandbox_mode == worktree`); fix the false
+1. `entrypoint.sh:1938` — run `setup_worktree_git` in worktree mode so `GIT_DIR="/workspace/.git-safe"`
+   is exported (restructure so the function runs whenever `sandbox_mode == worktree`); fix the false
    "git is already set up by host" comment.
-2. `launch-agent.sh` `generate_volume_mounts_worktree` — mount the sanitized git **rw**.
+2. `launch-agent.sh` `generate_volume_mounts_worktree` — mount the sanitized git **rw** so the agent
+   can stage/commit locally. Objects mount stays `:ro`.
 3. `worktree-manager.sh` `prepare_sanitized_git` — writable local `objects/` + `objects/info/alternates`
-   → `$CONTAINER_OBJECTS_PATH` (parent DB borrowed read-only; new objects land locally). Push
-   negotiates the object delta over the wire, so a missing `refs/remotes/origin/<branch>` does not
-   break push (confirmed by review).
-   - **Objects/repoint impact (ensemble C3):** the host `repoint_sanitized_git_objects()`
-     (launch-agent.sh:3635-3667) currently rewrites the RO symlink to the host path for host use. The
-     host **fallback** operates on the **real worktree gitdir** (not the sanitized dir), so it does
-     not depend on the sanitized dir's objects; update/retire `repoint_*` accordingly and cover with
-     tests (§Testing). The sanitized dir's alternate is validated at finalize (no agent-added
-     alternates; §Security).
+   → `$CONTAINER_OBJECTS_PATH` (parent DB borrowed read-only; new objects land locally), replacing
+   the read-only symlink, so in-container `git commit` works.
+4. The sanitized git config has **no credential helper** (unchanged) and kapsis injects no push
+   creds into it → the agent's git works locally but cannot push. The agent's commits live in the
+   ephemeral sanitized GIT_DIR and are for its own use; the **authoritative** commit is the host's
+   (from the final worktree file state), so nothing depends on the agent's commits surviving.
 
-### B. Shared, provider-agnostic, self-contained sanitization library
+### B. Host: sanitize → validate → commit → push → PR (hardened `post-container-git.sh`)
 
-Extract into a lib sourced by both host and container. It must be **self-contained in-container** —
-no host-only deps (`$TMPDIR`, host provenance):
-- `strip_kapsis_injections` (mutating — removes kapsis's own `KAPSIS_GIST` block and rogue variants),
-- `.kapsis/` + `.git-safe/` + `.git-objects/` staging exclusion — **case-insensitive** (APFS),
-- `sanitize_staged_files` (invisible-char scan; reject on unfixable),
-- `build_coauthor_trailers`,
-- `validate_range <base>..<tip>` — a pure predicate over an **explicit commit range** (never whole
-  history) used by the host backstop.
+The host path already commits+pushes from the real worktree gitdir. Harden it:
 
-### C. In-container finalize (primary path)
+1. **Mutating sanitize** (existing `strip_kapsis_injections`, `.kapsis/`/`.git-safe/`/`.git-objects/`
+   exclusion, `sanitize_staged_files`) — make the exclusion **case-insensitive** (the container runs
+   on a case-sensitive Linux FS, so `.Kapsis/` created in-container is a distinct path today's
+   case-sensitive `grep '^\.kapsis/'` / `:(exclude).kapsis/` would miss and push).
+2. **Clean tree, don't inherit a crafted index** — build the committed tree only from the sanitized
+   worktree (rebuild the index rather than trusting whatever index state exists), and **validate file
+   modes**: reject unexpected symlinks (`120000`), gitlinks/`.gitmodules` (`160000`), and exec-bit
+   flips on non-scripts. (Ensemble: `git add`/index can smuggle mode entries past a content-only
+   sanitizer — real on the host path too.)
+3. **Fail-closed**: if sanitize/validate finds unfixable/unexpected content → do **not** push; fail
+   the run with a clear reason. Because the host is the sole pusher and validates *before* pushing,
+   nothing dirty ever lands → no rollback / CAS / force-with-lease required.
+4. **Fetch-before-push / reconcile** — replace the bare `git push --set-upstream`
+   (post-container-git.sh:845) with fetch + non-fast-forward handling; never blind-push a divergent
+   SHA (avoids the "committed locally, push rejected, no PR" failure).
+5. **Post-push PR hook** (§C) after a verified push.
 
-Registered as an EXIT trap in worktree mode; runs after the agent process exits:
-1. `git reset --soft <base>` to drop any agent commits, so the pushed commit is kapsis-authored and
-   clean regardless of what the agent staged/committed.
-2. Mutating sanitize on the working tree/index: `strip_kapsis_injections`, exclude `.kapsis/` etc.,
-   `sanitize_staged_files` (**fail-closed** on unfixable content — abort finalize, leave to host).
-3. Canonical commit (kapsis message + co-author trailers), **hooks disabled explicitly**
-   (`-c core.hooksPath= --no-verify`), so no agent-planted hook runs.
-4. Configure credentials **ephemerally** (§F), then `git push` the refspec.
-5. On success: write a sentinel (pushed SHA + remote ref — an *optimization hint*, not proof), then
-   invoke the optional **post-push hook** (§E). Finally scrub credentials (§F).
+### C. PR creation — provider-pluggable host-side post-push hook
 
-The agent's own `git push` cannot reach the remote during its run (no credentials), so it fails fast
-and locally; dev-workflow guidance will note that kapsis finalizes the push.
+kapsis does not create PRs. After a verified push, the host invokes an **optional** user-configured
+command, e.g. `git.post_push_hook` in the agent config, with env (`KAPSIS_REMOTE_BRANCH`,
+`KAPSIS_BASE_BRANCH`, pushed SHA). Runs **on the host** (creds host-side; not in the agent
+container). The Slack bot config supplies its `bkt`/`gh pr create` command; unset = no PR (today's
+behavior). **Hook-failure handling:** a failed hook is surfaced (status + non-zero run outcome / a
+clear "pushed but PR-creation failed: <reason>" message), never silently swallowed — otherwise the
+original "branch pushed, no PR" symptom returns invisibly. Env values are agent-influenced → the hook
+contract requires callers to quote and never `eval`; kapsis passes values via env only, never builds
+a shell string.
 
-### D. Host: always-revalidate backstop + reconciling fallback (fail-closed)
+### D. Observability
 
-The host runs after the container exits. It does **not** trust the sentinel as a gate — it inspects
-the **actual remote state**:
-
-```
-git fetch origin <remote_branch>
-if remote has commits beyond the pre-run tip (i.e. something landed):
-    validate_range <pre_run_tip>..<remote_tip>        # FULL range, every commit
-        clean   -> accept (in-container push authoritative)
-        dirty   -> FAIL-CLOSED remediate (see below) + fail run
-    if sentinel present but remote_tip != sentinel SHA -> ANOMALY -> treat as dirty
-else:                                                  # nothing landed in-container
-    host fallback: sanitize(mutate) worktree + commit + fetch/reconcile + push
-        (fetch-before-push; if remote diverged, do NOT blind-push a divergent SHA — reconcile or fail)
-```
-
-**Fail-closed remediation, provenance-based, with compare-and-swap (ensemble H2/C1):**
-- branch **created by this run** → delete the remote branch **only if** its tip still equals the SHA
-  we pushed (`git push --force-with-lease=<ref>:<pushed_sha> origin :<ref>` semantics);
-- branch **pre-existed** → restore to the pre-run tip **only if** the current tip equals the SHA we
-  pushed (`--force-with-lease`); if it advanced (concurrent legit push), do **not** clobber — fail
-  the run and alert.
-- Provenance (`created_by_run` bool) and the pre-run remote SHA are captured at worktree setup and
-  persisted host-side (status JSON), since `create_worktree` only logs them today.
-
-This makes Layer-2 validation **unconditional** over the full landed range and rollback **safe under
-concurrency** — the two holes the ensemble flagged as CRITICAL.
-
-### E. PR creation — provider-pluggable post-push hook (delegated)
-
-kapsis does not create PRs. After a successful push, the finalize (and the host fallback) invoke an
-**optional** user-configured command, e.g. `git.post_push_hook` in the agent config, with env
-(`KAPSIS_REMOTE_BRANCH`, `KAPSIS_BASE_BRANCH`, pushed SHA). The Slack bot config supplies its
-`bkt/gh pr create` command; unset = no PR (today's behavior). Provider logic stays entirely in
-user config.
-
-### F. Credential hygiene (ensemble H5)
-
-- Push credentials are present **only** during the finalize push (and host fallback), never during
-  the agent's run.
-- Never persist an auth-embedded URL into the sanitized/worktree git config; use an ephemeral
-  credential helper / `GIT_CONFIG_COUNT` env or `-c credential.helper=…` scoped to the push
-  invocation; unset afterward.
-- Keep the token out of the sentinel, reflog, and captured logs (push with `--quiet`, no
-  `set -x`, redact URLs in logs).
+Status records which path/outcome occurred: `commit_status`, `push_status`, and a new
+`pr_hook_status` (skipped / ok / failed:<reason>) + the resulting PR URL when the hook emits one, so
+the bot/user can see whether the run truly produced a PR.
 
 ## Security / threat model
 
-- **Covered:** an *honest* agent whose content got compromised (prompt-injection writing rogue
-  `KAPSIS_GIST` / invisible chars / `.kapsis/` leakage). The finalize mutating-strip removes it
-  before the pushed commit; the host re-validates the full landed range and fails closed on anything
-  dirty — including a bypass push, because host validation is unconditional on remote state.
-- **Not covered in-container:** a fully adversarial agent with the push token. But the agent has
-  **no token during its run** (§F), and the **host** (outside the container) is the authoritative
-  validator/remediator — so even a token exfiltrated from the finalize phase cannot land unvalidated
-  content without the host catching and rolling it back.
-- Writable `$GIT_DIR`: hooks are disabled during finalize (§C); the agent-run keeps the empty hooks
-  dir and we do not rely on a client-side hook as a gate. `objects/info/alternates` is validated at
-  finalize (exactly one expected alternate; reject others). Parent-history exposure via the RO
-  objects mount is inherent to worktree mode today (unchanged).
-- Layer-2 is a **validate-and-remediate** backstop; it rejects/rolls back, it does not "repair"
-  (wording corrected from v1).
+- **Threat covered:** honest agent, content compromised (prompt-injection writing rogue
+  `KAPSIS_GIST` / invisible chars / `.kapsis/` leakage / crafted file modes). The **host** sanitizes
+  and validates before pushing; nothing dirty lands. The host is outside the container's trust
+  domain and always runs.
+- Writable in-container git only affects the throwaway per-agent sanitized dir; parent objects stay
+  read-only (alternates). No push credentials are placed in the container. The credentialed push and
+  PR hook run on the host, so the in-container-exfil surface of a credentialed push is avoided
+  entirely.
+- `objects/info/alternates` is validated host-side before the host reads objects (exactly one
+  expected entry; reject symlinked/relative/extra entries).
 
 ## Testing
 
-Add a **fake-remote harness** (a local bare repo as `origin`) so in-container finalize push and host
-backstop are testable without a real provider. Extend `tests/test-post-container-git.sh` and
-`tests/test-sanitized-git-objects.sh`:
-- worktree in-container git writable: `GIT_DIR` set, commit succeeds, new objects in local objects
-  dir; parent objects dir stays read-only; alternates has exactly the expected entry.
-- finalize mutating-strip removes an injected `KAPSIS_GIST` block from `CLAUDE.md`; excludes
-  `.kapsis/` (incl. `.KAPSIS/` on case-insensitive FS); rejects invisible chars (fail-closed).
-- finalize push lands on the fake remote; sentinel written; post-push hook invoked with correct env;
-  credentials absent from config/reflog/logs afterward.
-- host backstop: dirty landed commit → fail-closed rollback via `--force-with-lease`; concurrent
-  advance (tip ≠ pushed SHA) → does NOT clobber, run fails.
-- host fallback (in-container push didn't land): fetch-before-push; divergent remote → no blind
-  non-ff push.
-- validate range bounded to `base..tip` (no whole-history scan) incl. first-push (no remote branch).
-- provider-agnostic: push uses the repo's own `origin`; no hardcoded host; post-push hook unset = no
-  PR, run still succeeds.
+Extend `tests/test-post-container-git.sh`, `tests/test-sanitized-git-objects.sh`; add a fake-remote
+harness (local bare repo as `origin`) for push/PR-hook coverage:
+- worktree in-container git writable: `GIT_DIR` set, `git commit` succeeds, new objects in local
+  objects dir; parent objects dir stays read-only; alternates has exactly the expected entry.
+- host sanitize removes an injected `KAPSIS_GIST` block; excludes `.kapsis/` incl. `.Kapsis/`
+  (case-insensitive); rejects invisible chars (fail-closed → no push).
+- host validate rejects a staged symlink / gitlink / exec-bit-flip (fail-closed → no push).
+- host fetch-before-push: divergent remote → reconcile / no blind non-ff push.
+- post-push hook: invoked with correct env on success; unset = no PR, run still succeeds; hook
+  failure → `pr_hook_status=failed` + non-silent surfacing.
+- provider-agnostic: push uses the repo's own `origin`; no hardcoded host.
 
 ## Rollout
 
 - Land on `main`; cut a patch release. The Slack bot runs the Homebrew build (currently 3.2.4); it
-  picks this up via `kapsis --upgrade` + `restart-bot.sh`.
-- Back-compat: document behavior for in-flight worktrees created by the old version at upgrade time.
-- Network: the git host must be in the agent's egress allowlist for in-container push (already true
-  for the bot; note for general users).
+  picks this up via `kapsis --upgrade` + `restart-bot.sh`, and its config gains a `post_push_hook`
+  invoking `bkt/gh pr create`.
+- Back-compat: in-flight worktrees from the old version still get host commit+push at upgrade.
+- Network: the git host must be in the agent's egress allowlist (already true for the bot) — though
+  in B only in-container *read/commit* needs it locally; push is host-side.
 
 ## Resolved decisions
 
-1. **Pivot adopted:** kapsis in-container **finalize pushes**; the agent never pushes (no creds in
-   its run). Replaces v1's "agent pushes."
-2. **Sanitization is mutating, in-container, before the pushed commit** (finalize strip/exclude).
-   Replaces v1's "pre-push validate-only" (which would fail every `CLAUDE.md` run due to kapsis's own
-   gist injection).
-3. **Layer-2 host backstop is unconditional** over the full landed range (sentinel is a hint, not a
-   trigger); **rollback uses compare-and-swap** (`--force-with-lease`) and is provenance-based
-   (delete if run-created, else restore to pre-run tip; never clobber a concurrent advance).
-4. **PR creation** stays out of kapsis core — delegated to an optional provider-pluggable
-   **post-push hook** (bot config supplies `bkt/gh`).
+1. **Architecture B:** writable in-container git for the agent's commit/diff/verify; credentialed
+   **push + PR + validation on the host**. (Reverses the earlier in-container-push pivot after two
+   ensemble rounds showed it can't fire on SIGKILL/mount-drop and would duplicate a mandatory host
+   path.)
+2. **Fail-closed = don't push** (host validates before pushing); no rollback/CAS/force-with-lease.
+3. **PR creation** delegated to an optional provider-pluggable **host-side** post-push hook; failures
+   surfaced, never silent.
+4. Host hardening carried over from the review regardless of architecture: clean-index/mode
+   validation, case-insensitive `.kapsis` exclusion, fetch-before-push, alternates validation.
 
-## Ensemble review log (2026-08-09)
+## Ensemble review log (2026-08-09, 2 rounds)
 
-Addressed: C1 unconditional full-range host re-validation (§D); C2 mutating in-container strip (§C);
-C3 objects/repoint handling (§A); H1 fetch-before-push fallback (§D); H2 CAS rollback (§D); H3 hooks
-handled via finalize-disable + no client-side gate (§C/Security); H4 post-push PR hook (§E); H5
-credential hygiene (§F); plus medium items: fake-remote harness, self-contained shared lib,
-case-insensitive exclusion, bounded validate range, egress note, alternates validation, over-claim
-wording.
+Round 1 (v1→v2): C1 unconditional validation, C2 mutating strip, C3 objects, H1 fetch-before-push,
+H2 CAS rollback, H3 hooks, H4 PR hook, H5 creds, plus mediums. Round 2 (v2 re-review): confirmed C1/
+C2/H1 resolved; found the finalize-EXIT-trap is dead (`exec`), SIGKILL/mount-drop defeat in-container
+finalize, and credentialed-push-in-container exfil surface → **architecture pivot to B**. Surviving
+hardening folded into §B (clean index + mode validation; fetch-before-push; case-insensitive
+exclusion; alternates validation). Rollback/CAS/force-with-lease **removed** as unnecessary under B.

--- a/docs/CONFIG-REFERENCE.md
+++ b/docs/CONFIG-REFERENCE.md
@@ -736,6 +736,17 @@ git:
   # {base_url}, {repo_path}, {branch} placeholders. Overrides `provider`.
   # pr_url_template: "{base_url}/{repo_path}/pull-requests/new?source={branch}"
 
+  # Provider-agnostic post-push hook. A shell command run on the HOST after a
+  # verified push (e.g. to open a pull request). kapsis stays provider-neutral —
+  # you supply the command (gh, glab, bitbucket CLI, curl, etc.). Unset = kapsis
+  # just prints PR instructions (default). The command runs via `bash -c` and
+  # receives these environment variables (agent-influenced — quote them, never
+  # eval): KAPSIS_REMOTE_BRANCH, KAPSIS_BASE_BRANCH, KAPSIS_PUSHED_SHA,
+  # KAPSIS_REMOTE_URL. If the command prints a URL on stdout it is captured as the
+  # PR URL. The outcome is recorded in the status file as `pr_hook_status`
+  # (skipped | ok | failed:<reason>); a failed hook is surfaced, never silent.
+  # post_push_hook: 'gh pr create --head "$KAPSIS_REMOTE_BRANCH" --base "$KAPSIS_BASE_BRANCH" --fill'
+
     # Commit message template
     # Available placeholders (substituted at launch time):
     #   {task}      - Task description (from --task or spec filename)

--- a/docs/superpowers/plans/2026-08-09-worktree-in-container-git-and-host-push.md
+++ b/docs/superpowers/plans/2026-08-09-worktree-in-container-git-and-host-push.md
@@ -1,0 +1,482 @@
+# Worktree in-container git + hardened host push/PR Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the worktree-mode agent working in-container git (commit/diff/verify), and make the host reliably sanitize → validate → commit → push → create a PR, fail-closed.
+
+**Architecture:** Architecture B from `designs/2026-08-09-worktree-in-container-push-design.md`. Three plumbing fixes make the sandboxed git writable for the agent's own use; the host (`post-container-git.sh`) remains the sole pusher and is hardened (case-insensitive kapsis-path exclusion, file-mode validation, fetch-before-push, provider-pluggable post-push PR hook, observability). No credentialed push happens inside the container.
+
+**Tech Stack:** Bash; kapsis test framework (`tests/lib/test-framework.sh`, `assert_*`, `run_test`); `yq` for config; git; podman (not exercised by unit tests).
+
+## Global Constraints
+
+- Target branch `feat/worktree-in-container-push` off `origin/main` (== v3.2.4).
+- Bash with `set -euo pipefail` in scripts; guard optional vars with `${var:-}`.
+- Tests are functions in `tests/test-*.sh`, registered with `run_test <fn>` in the file's `main`, and must pass under `bash tests/<file>.sh`. Add new tests to `tests/run-all-tests.sh` if a new file is created.
+- Provider-agnostic: never hardcode a git host/provider in kapsis scripts.
+- No credential material in the container's git config, logs, sentinels, or argv.
+- Preserve existing public behavior when the new config key is unset (`git.post_push_hook` absent ⇒ today's "print PR instructions" behavior).
+
+---
+
+### Task 1: Run `setup_worktree_git` in worktree mode (GIT_DIR fix)
+
+**Files:**
+- Modify: `scripts/entrypoint.sh` (the sandbox-mode dispatch ~1938; `setup_worktree_git` ~764-793)
+- Test: `tests/test-worktree-incontainer-git.sh` (new)
+
+**Interfaces:**
+- Consumes: `setup_worktree_git()` (exports `GIT_DIR="$CONTAINER_GIT_PATH"` when `$CONTAINER_GIT_PATH/kapsis-meta` exists).
+- Produces: after the dispatch, in worktree mode `GIT_DIR` is exported to the sanitized `.git-safe`.
+
+- [ ] **Step 1: Write the failing test** — create `tests/test-worktree-incontainer-git.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+KAPSIS_ROOT="$(dirname "$SCRIPT_DIR")"
+# shellcheck disable=SC1090
+source "$SCRIPT_DIR/lib/test-framework.sh"
+source "$KAPSIS_ROOT/scripts/lib/logging.sh"; log_init "test-worktree-incontainer-git"
+source "$KAPSIS_ROOT/scripts/lib/constants.sh"
+source "$KAPSIS_ROOT/scripts/entrypoint.sh" >/dev/null 2>&1 || true  # source funcs only
+
+test_setup_worktree_git_exports_gitdir() {
+    local d; d=$(mktemp -d)
+    mkdir -p "$d/gitsafe"
+    printf 'BRANCH=feature/x\n' > "$d/gitsafe/kapsis-meta"
+    CONTAINER_GIT_PATH="$d/gitsafe" GIT_DIR="" setup_worktree_git
+    assert_equals "$d/gitsafe" "${GIT_DIR:-}" "GIT_DIR should point at sanitized .git-safe"
+    rm -rf "$d"
+}
+
+main() { run_test test_setup_worktree_git_exports_gitdir; print_test_summary; }
+main "$@"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bash tests/test-worktree-incontainer-git.sh`
+Expected: FAIL — either `setup_worktree_git` not found (sourcing guarded) or `GIT_DIR` empty. (If sourcing `entrypoint.sh` executes `main`, guard it — see Step 3 note.)
+
+- [ ] **Step 3: Make the dispatch call `setup_worktree_git` in worktree mode**
+
+In `scripts/entrypoint.sh`, replace the short-circuit at ~1938:
+
+```bash
+    # Worktree mode needs GIT_DIR exported by setup_worktree_git() so the
+    # in-container agent has working git; the old `[[ ==worktree ]] || setup…`
+    # short-circuited that call away. Run it explicitly in worktree mode.
+    local _kapsis_is_worktree=false
+    if [[ "$sandbox_mode" == "worktree" ]]; then
+        setup_worktree_git || log_warn "worktree git setup incomplete; in-container git may be limited"
+        _kapsis_is_worktree=true
+    elif setup_worktree_git; then
+        _kapsis_is_worktree=true
+    fi
+    if [[ "$_kapsis_is_worktree" == "true" ]]; then
+```
+
+Update the closing comment (was "git is already set up by host") to: `# Worktree mode: GIT_DIR now points at the sanitized .git-safe (setup_worktree_git).` Ensure `entrypoint.sh` only runs `main "$@"` under `if [[ "${BASH_SOURCE[0]}" == "${0}" ]]`, so tests can source functions without executing (add this guard if absent).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bash tests/test-worktree-incontainer-git.sh`
+Expected: PASS.
+
+- [ ] **Step 5: Register + commit**
+
+Add `run_test`s file to `tests/run-all-tests.sh` list. Then:
+```bash
+git add scripts/entrypoint.sh tests/test-worktree-incontainer-git.sh tests/run-all-tests.sh
+git commit -m "fix(worktree): export GIT_DIR in worktree mode (in-container git was dead)"
+```
+
+---
+
+### Task 2: Mount the sanitized git read-write
+
+**Files:**
+- Modify: `scripts/launch-agent.sh` `generate_volume_mounts_worktree()` (~1590-1605)
+- Test: `tests/test-worktree-incontainer-git.sh` (extend)
+
+**Interfaces:**
+- Consumes: globals `SANITIZED_GIT_PATH`, `CONTAINER_GIT_PATH`, `OBJECTS_PATH`, `CONTAINER_OBJECTS_PATH`; populates `VOLUME_MOUNTS` array.
+- Produces: `VOLUME_MOUNTS` contains `-v ${SANITIZED_GIT_PATH}:${CONTAINER_GIT_PATH}` (writable, no `:ro`); objects mount stays `:ro`.
+
+- [ ] **Step 1: Write the failing test** (append to the new test file, register in `main`):
+
+```bash
+test_sanitized_git_mounted_rw() {
+    source "$KAPSIS_ROOT/scripts/launch-agent.sh" >/dev/null 2>&1 || true
+    SANITIZED_GIT_PATH="/tmp/sg"; CONTAINER_GIT_PATH="/workspace/.git-safe"
+    OBJECTS_PATH="/tmp/obj"; CONTAINER_OBJECTS_PATH="/workspace/.git-objects"
+    WORKTREE_PATH="/tmp/wt"; VOLUME_MOUNTS=()
+    generate_volume_mounts_worktree
+    local joined="${VOLUME_MOUNTS[*]}"
+    assert_contains "$joined" "${SANITIZED_GIT_PATH}:${CONTAINER_GIT_PATH}" "git-safe mounted"
+    assert_not_contains "$joined" "${SANITIZED_GIT_PATH}:${CONTAINER_GIT_PATH}:ro" "git-safe must be RW"
+    assert_contains "$joined" "${OBJECTS_PATH}:${CONTAINER_OBJECTS_PATH}:ro" "objects stay RO"
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bash tests/test-worktree-incontainer-git.sh`
+Expected: FAIL on `assert_not_contains` (`:ro` still present).
+
+- [ ] **Step 3: Drop `:ro` on the git-safe mount** — in `generate_volume_mounts_worktree`:
+
+```bash
+    # RW so the in-container agent can stage/commit into the sanitized GIT_DIR.
+    # (Objects DB below stays :ro; new objects land in the writable objects dir
+    # created by prepare_sanitized_git via objects/info/alternates.)
+    VOLUME_MOUNTS+=("-v" "${SANITIZED_GIT_PATH}:${CONTAINER_GIT_PATH}")
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `bash tests/test-worktree-incontainer-git.sh`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/launch-agent.sh tests/test-worktree-incontainer-git.sh
+git commit -m "fix(worktree): mount sanitized git read-write for in-container commit"
+```
+
+---
+
+### Task 3: Objects via git alternate (writable) instead of RO symlink
+
+**Files:**
+- Modify: `scripts/worktree-manager.sh` `prepare_sanitized_git()` (~522-527 objects handling)
+- Modify: `scripts/launch-agent.sh` `repoint_sanitized_git_objects()` (~3635-3667) — adapt/retire
+- Test: `tests/test-sanitized-git-objects.sh` (extend)
+
+**Interfaces:**
+- Consumes: `$sanitized_dir`, `$CONTAINER_OBJECTS_PATH`.
+- Produces: `$sanitized_dir/objects/` is a real directory containing `info/alternates` (single line = `$CONTAINER_OBJECTS_PATH`) and writable `pack/`; NOT a symlink.
+
+- [ ] **Step 1: Write the failing test** (append to `tests/test-sanitized-git-objects.sh`, register in `main`):
+
+```bash
+test_objects_is_writable_dir_with_alternate() {
+    local d; d=$(mktemp -d); local sg="$d/sg"; mkdir -p "$sg"
+    CONTAINER_OBJECTS_PATH="/workspace/.git-objects"
+    _prepare_objects_alternate "$sg"   # helper extracted in Step 3
+    assert_dir_exists "$sg/objects" "objects must be a real dir"
+    assert_false "[ -L \"$sg/objects\" ]" "objects must NOT be a symlink"
+    assert_file_contains "$sg/objects/info/alternates" "$CONTAINER_OBJECTS_PATH" "alternate points at parent DB"
+    rm -rf "$d"
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bash tests/test-sanitized-git-objects.sh`
+Expected: FAIL — `_prepare_objects_alternate` not defined.
+
+- [ ] **Step 3: Extract + implement the alternate** — in `worktree-manager.sh`, replace the `ln -sfn "$CONTAINER_OBJECTS_PATH" "$sanitized_dir/objects"` line with a call to a new helper, and define it:
+
+```bash
+# Writable local objects dir + read-only borrow of the parent object DB via
+# alternates, so in-container `git commit` can write new objects while existing
+# objects are borrowed RO. Replaces the old RO symlink (which made commit fail).
+_prepare_objects_alternate() {
+    local sanitized_dir="$1"
+    rm -f "$sanitized_dir/objects" 2>/dev/null || true   # drop any prior symlink
+    mkdir -p "$sanitized_dir/objects/info" "$sanitized_dir/objects/pack"
+    printf '%s\n' "$CONTAINER_OBJECTS_PATH" > "$sanitized_dir/objects/info/alternates"
+}
+```
+Call `_prepare_objects_alternate "$sanitized_dir"` where the symlink was created.
+
+- [ ] **Step 4: Adapt the host repoint** — `repoint_sanitized_git_objects()` rewrote the symlink to the host path for host use. The host commit/push operates on the **real worktree gitdir**, not the sanitized dir, so this is no longer load-bearing. Make it idempotently rewrite the alternate's parent path to the host `OBJECTS_PATH` (for any host-side read of the sanitized dir) instead of `ln -sfn`:
+
+```bash
+    # sanitized objects now use an alternates file, not a symlink.
+    if [[ -f "$sanitized_git/objects/info/alternates" ]]; then
+        printf '%s\n' "$host_objects_path" > "$sanitized_git/objects/info/alternates"
+    fi
+```
+(Keep the function's existing signature/callers; only the body's rewrite mechanism changes.)
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run: `bash tests/test-sanitized-git-objects.sh`
+Expected: PASS (new test + existing tests still green).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/worktree-manager.sh scripts/launch-agent.sh tests/test-sanitized-git-objects.sh
+git commit -m "fix(worktree): objects via alternates (writable) so in-container commit works"
+```
+
+---
+
+### Task 4: Host exclusion case-insensitive + file-mode validation (fail-closed)
+
+**Files:**
+- Modify: `scripts/post-container-git.sh` `validate_staged_files()` (~97-150+)
+- Test: `tests/test-post-container-git.sh` (extend)
+
+**Interfaces:**
+- Consumes: `worktree_path` on a git repo with a staged index.
+- Produces: `validate_staged_files` returns non-zero (security issue) when a staged path matches `.kapsis/` / `.git-safe/` / `.git-objects/` **case-insensitively**, or when a staged entry is a symlink (`120000`), gitlink (`160000`), or an exec-bit flip (`100755`) on a non-script.
+
+- [ ] **Step 1: Write failing tests** (append to `tests/test-post-container-git.sh`, register in `main`):
+
+```bash
+_mk_repo() { local r; r=$(mktemp -d); ( cd "$r"; git init -q; git config user.email a@b.c; git config user.name a ); echo "$r"; }
+
+test_reject_uppercase_kapsis_dir() {
+    local r; r=$(_mk_repo); mkdir -p "$r/.Kapsis"; echo x > "$r/.Kapsis/f"
+    ( cd "$r"; git add -A -f )
+    assert_command_fails "validate_staged_files '$r'" ".Kapsis/ must be rejected (case-insensitive)"
+    rm -rf "$r"
+}
+test_reject_symlink_entry() {
+    local r; r=$(_mk_repo); ( cd "$r"; ln -s /etc/passwd link; git add -A )
+    assert_command_fails "validate_staged_files '$r'" "symlink (120000) must be rejected"
+    rm -rf "$r"
+}
+test_reject_gitlink_entry() {
+    local r; r=$(_mk_repo)
+    ( cd "$r"; git update-index --add --cacheinfo 160000,0000000000000000000000000000000000000000,sub )
+    assert_command_fails "validate_staged_files '$r'" "gitlink (160000) must be rejected"
+    rm -rf "$r"
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `bash tests/test-post-container-git.sh`
+Expected: FAIL — uppercase `.Kapsis`, symlink, gitlink currently pass validation.
+
+- [ ] **Step 3: Make exclusion case-insensitive + add mode check** — in `validate_staged_files`, change the three greps to `grep -iE` and add a mode gate before the return:
+
+```bash
+    # Case-insensitive: the container FS is case-sensitive, so `.Kapsis/` is a
+    # distinct path a case-sensitive filter would miss and commit.
+    kapsis_files=$(git diff --cached --name-only 2>/dev/null | grep -iE "^\.kapsis/" || true)
+    ...
+    kapsis_mount_files=$(git diff --cached --name-only 2>/dev/null | grep -iE "^\.git-(safe|objects)/" || true)
+    ...
+    # File-mode validation: reject smuggled symlinks/gitlinks. `reset --soft` /
+    # `git add` can carry crafted index modes past a content-only sanitizer.
+    local bad_modes
+    bad_modes=$(git diff --cached --raw 2>/dev/null | awk '{print $2}' | grep -E "^(120000|160000)$" || true)
+    if [[ -n "$bad_modes" ]]; then
+        log_warn "Rejecting staged symlink/gitlink entries (modes: $(echo "$bad_modes" | tr '\n' ' '))"
+        has_security_issues=1
+    fi
+```
+(Keep the existing `has_security_issues` → non-zero return contract so `commit_changes` aborts = fail-closed, no push.)
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `bash tests/test-post-container-git.sh`
+Expected: PASS (new + existing).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/post-container-git.sh tests/test-post-container-git.sh
+git commit -m "fix(host): case-insensitive kapsis exclusion + reject symlink/gitlink (fail-closed)"
+```
+
+---
+
+### Task 5: Host fetch-before-push / no blind non-fast-forward
+
+**Files:**
+- Modify: `scripts/post-container-git.sh` `push_changes()` (~813-875)
+- Test: `tests/test-post-container-git.sh` (extend, fake local remote)
+
+**Interfaces:**
+- Consumes: `worktree_path`, `remote`, `remote_branch`.
+- Produces: before pushing, fetch the remote branch; if the remote advanced beyond the local's known base (divergence), do **not** blind-push — return non-zero with a clear reason (reconcile is out of scope for the automated path; fail-closed and surface the fallback command, which already exists via `status_set_push_fallback`).
+
+- [ ] **Step 1: Write the failing test** — a bare repo as `origin`, advance it, expect push_changes to refuse the non-ff:
+
+```bash
+test_push_refuses_non_fast_forward() {
+    local up; up=$(mktemp -d); ( cd "$up"; git init -q --bare )
+    local a; a=$(_mk_repo); ( cd "$a"; git remote add origin "$up"; echo 1>f; git add -A; git commit -qm base; git push -q -u origin HEAD:refs/heads/main )
+    # second clone advances origin/main
+    local b; b=$(mktemp -d); git clone -q "$up" "$b"; ( cd "$b"; echo 2>f; git add -A; git commit -qm adv; git push -q origin HEAD:main )
+    # 'a' makes a divergent commit on its stale base
+    ( cd "$a"; echo 3>g; git add -A; git commit -qm local )
+    assert_command_fails "push_changes '$a' origin main" "divergent remote must not be blind-pushed"
+    rm -rf "$up" "$a" "$b"
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bash tests/test-post-container-git.sh`
+Expected: FAIL — current `push_changes` does a bare `git push --set-upstream` and would non-ff-reject via git's own error but with exit 1 (acceptable) OR force nothing; assert it returns non-zero *and* logs the divergence reason. If it already returns non-zero, tighten the assertion to check the divergence log line so the test is meaningful.
+
+- [ ] **Step 3: Add fetch + divergence guard** — near the top of `push_changes`, before the push:
+
+```bash
+    # Fetch-before-push: detect divergence so we never emit a confusing bare
+    # non-ff push (which stranded work as "committed locally, no PR").
+    GIT_TERMINAL_PROMPT=0 timeout "${KAPSIS_FETCH_TIMEOUT:-60}" \
+        git fetch "$remote" "$remote_branch" 2>/dev/null || true
+    if git rev-parse --verify -q "refs/remotes/${remote}/${remote_branch}" >/dev/null 2>&1 \
+       || git rev-parse --verify -q "FETCH_HEAD" >/dev/null 2>&1; then
+        local _remote_tip _base
+        _remote_tip=$(git rev-parse -q --verify FETCH_HEAD 2>/dev/null || git rev-parse "refs/remotes/${remote}/${remote_branch}")
+        _base=$(git merge-base HEAD "$_remote_tip" 2>/dev/null || echo "")
+        if [[ -n "$_remote_tip" && "$_base" != "$_remote_tip" ]]; then
+            log_error "Remote ${remote}/${remote_branch} has advanced beyond our base — refusing non-fast-forward push"
+            status_set_push_fallback "$worktree_path" "$remote" "$branch" "$remote_branch"
+            status_set_push_info "diverged" "$(git rev-parse HEAD)" "$_remote_tip"
+            return 1
+        fi
+    fi
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `bash tests/test-post-container-git.sh`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/post-container-git.sh tests/test-post-container-git.sh
+git commit -m "fix(host): fetch-before-push; refuse blind non-fast-forward"
+```
+
+---
+
+### Task 6: Provider-pluggable post-push PR hook + observability
+
+**Files:**
+- Modify: `scripts/launch-agent.sh` (read `git.post_push_hook` from config ~915-920; pass through the `post_container_git` call ~3727)
+- Modify: `scripts/post-container-git.sh` `post_container_git()` signature + after verified push invoke the hook; set `pr_hook_status`
+- Modify: `scripts/lib/status.sh` — add `status_set_pr_hook_info` (mirror `status_set_push_info`)
+- Test: `tests/test-post-container-git.sh` (extend, fake hook)
+- Docs: `CONFIG-REFERENCE.md` — document `git.post_push_hook`
+
+**Interfaces:**
+- Consumes: config `git.post_push_hook` (string command); env for the hook: `KAPSIS_REMOTE_BRANCH`, `KAPSIS_BASE_BRANCH`, `KAPSIS_PUSHED_SHA`, `KAPSIS_REMOTE_URL`.
+- Produces: `run_post_push_hook(worktree, remote_branch, base_branch, pushed_sha, hook_cmd)` → sets `pr_hook_status` ∈ `skipped|ok|failed:<reason>` and `PR_URL` when the hook prints a URL on stdout.
+
+- [ ] **Step 1: Write the failing test**:
+
+```bash
+test_post_push_hook_invoked_with_env() {
+    local r; r=$(_mk_repo); ( cd "$r"; git remote add origin /dev/null 2>/dev/null || true )
+    local out; out=$(mktemp)
+    local hook="printf 'BRANCH=%s SHA=%s\n' \"\$KAPSIS_REMOTE_BRANCH\" \"\$KAPSIS_PUSHED_SHA\" > $out; echo https://pr.example/1"
+    run_post_push_hook "$r" "feature/x" "main" "deadbeef" "$hook"
+    assert_equals "ok" "${pr_hook_status:-}" "hook ok"
+    assert_file_contains "$out" "BRANCH=feature/x SHA=deadbeef" "hook got env"
+    assert_equals "https://pr.example/1" "${PR_URL:-}" "PR_URL captured from hook stdout"
+    rm -rf "$r" "$out"
+}
+test_post_push_hook_unset_skips() {
+    run_post_push_hook "/tmp" "feature/x" "main" "deadbeef" ""
+    assert_equals "skipped" "${pr_hook_status:-}" "unset hook = skipped"
+}
+test_post_push_hook_failure_surfaced() {
+    run_post_push_hook "/tmp" "feature/x" "main" "deadbeef" "exit 3"
+    assert_matches "${pr_hook_status:-}" "^failed:" "hook failure surfaced, not swallowed"
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `bash tests/test-post-container-git.sh`
+Expected: FAIL — `run_post_push_hook` not defined.
+
+- [ ] **Step 3: Implement `run_post_push_hook`** in `post-container-git.sh`:
+
+```bash
+# Provider-agnostic PR creation seam. Runs a user-configured command on the HOST
+# after a verified push. kapsis knows nothing about gh/bkt/glab — the command is
+# supplied by config. Env values are agent-influenced: passed via env ONLY (never
+# interpolated into a shell string); the hook contract requires it to quote and
+# never eval. Failures are surfaced via pr_hook_status, never swallowed.
+run_post_push_hook() {
+    local worktree_path="$1" remote_branch="$2" base_branch="$3" pushed_sha="$4" hook_cmd="$5"
+    if [[ -z "$hook_cmd" ]]; then pr_hook_status="skipped"; return 0; fi
+    local remote_url; remote_url=$(cd "$worktree_path" && git remote get-url origin 2>/dev/null || echo "")
+    local out rc=0
+    out=$(cd "$worktree_path" && \
+        KAPSIS_REMOTE_BRANCH="$remote_branch" KAPSIS_BASE_BRANCH="$base_branch" \
+        KAPSIS_PUSHED_SHA="$pushed_sha" KAPSIS_REMOTE_URL="$remote_url" \
+        bash -c "$hook_cmd" 2>&1) || rc=$?
+    if [[ $rc -eq 0 ]]; then
+        pr_hook_status="ok"
+        local url; url=$(printf '%s\n' "$out" | grep -oE 'https?://[^[:space:]]+' | tail -1 || true)
+        [[ -n "$url" ]] && PR_URL="$url"
+        return 0
+    fi
+    pr_hook_status="failed:exit${rc}"
+    log_error "post_push_hook failed (exit $rc): $(printf '%s' "$out" | tail -3)"
+    return 0   # push already succeeded; do not fail the whole run, but surface status
+}
+```
+Note: the hook command itself comes from trusted config, so `bash -c "$hook_cmd"` is acceptable; the *agent-influenced* values are passed only as env, never concatenated into `hook_cmd`.
+
+- [ ] **Step 4: Wire it after a verified push** — in `push_changes` success branch, replace the bare `show_pr_instructions` call path so that when a hook is configured it runs the hook, else falls back to printing instructions:
+
+```bash
+        if verify_push "$worktree_path" "$remote" "$remote_branch"; then
+            local _pushed_sha; _pushed_sha=$(git rev-parse HEAD)
+            if [[ -n "${KAPSIS_POST_PUSH_HOOK:-}" ]]; then
+                run_post_push_hook "$worktree_path" "$remote_branch" "${KAPSIS_BASE_BRANCH:-}" "$_pushed_sha" "$KAPSIS_POST_PUSH_HOOK"
+            else
+                pr_hook_status="skipped"
+                show_pr_instructions "$worktree_path" "$remote_branch"
+            fi
+            return 0
+        else
+```
+
+- [ ] **Step 5: Read config + export** — in `launch-agent.sh` near the other `git.auto_push` reads (~917):
+
+```bash
+        KAPSIS_POST_PUSH_HOOK=$(yq -r '.git.post_push_hook // ""' "$CONFIG_FILE")
+        export KAPSIS_POST_PUSH_HOOK
+```
+`post_container_git` is sourced in the host shell, so the exported env is visible; no signature change required. (Also export `KAPSIS_BASE_BRANCH="$BASE_BRANCH"` alongside.)
+
+- [ ] **Step 6: Add `status_set_pr_hook_info`** in `scripts/lib/status.sh` (mirror `status_set_push_info`) to persist `pr_hook_status` + `PR_URL` into the status JSON; call it from `push_changes` after the hook.
+
+- [ ] **Step 7: Run tests to verify pass**
+
+Run: `bash tests/test-post-container-git.sh`
+Expected: PASS.
+
+- [ ] **Step 8: Document + commit**
+
+Add a `git.post_push_hook` entry to `CONFIG-REFERENCE.md` (string; runs on host after verified push; env `KAPSIS_REMOTE_BRANCH/BASE_BRANCH/PUSHED_SHA/REMOTE_URL`; must quote, must not eval; print the PR URL on stdout to capture it). Then:
+```bash
+git add scripts/launch-agent.sh scripts/post-container-git.sh scripts/lib/status.sh tests/test-post-container-git.sh CONFIG-REFERENCE.md
+git commit -m "feat(host): provider-pluggable post-push PR hook + pr_hook_status observability"
+```
+
+---
+
+### Task 7: Full suite + design/plan cross-check
+
+- [ ] **Step 1:** Run the affected suites: `bash tests/test-worktree-incontainer-git.sh && bash tests/test-sanitized-git-objects.sh && bash tests/test-post-container-git.sh`. Expected: all PASS.
+- [ ] **Step 2:** Run `bash tests/run-all-tests.sh` (or the worktree/git-tagged subset) to check for regressions in neighbouring worktree/objects/commit tests.
+- [ ] **Step 3:** Re-read `designs/2026-08-09-...-design.md` §A–§D and confirm each mechanism has a task. Note any container-only integration behavior (GIT_DIR actually effective for the agent process; egress) that unit tests can't cover, for manual/sandbox verification.
+- [ ] **Step 4:** Open a **draft** PR on the kapsis repo (`gh pr create --draft`) referencing the design doc.
+
+## Self-Review
+
+**Spec coverage:** §A → Tasks 1-3; §B(sanitize/case-insensitive/mode) → Task 4; §B(fetch-before-push/fail-closed) → Task 5; §C(post-push hook)+§D(observability) → Task 6; tests/fake-remote → Tasks 4-6 + Task 7. Objects/repoint (§A4) → Task 3 Step 4.
+**Placeholder scan:** none — every code step shows the code; commands have expected results.
+**Type consistency:** `run_post_push_hook(worktree, remote_branch, base_branch, pushed_sha, hook_cmd)` and `pr_hook_status` values (`skipped|ok|failed:<n>`) are consistent across Task 6 steps and the status helper; `_prepare_objects_alternate(sanitized_dir)` consistent Task 3.
+**Known limitation (documented, not a gap):** whether `GIT_DIR` is effective for the *agent* process and container egress are integration concerns exercised only in a real sandbox run, not by these bash unit tests (Task 7 Step 3).

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1935,8 +1935,20 @@ main() {
         protect_dns_files
     fi
 
-    if [[ "$sandbox_mode" == "worktree" ]] || setup_worktree_git; then
-        # Worktree mode: git is already set up by host
+    # Worktree mode needs GIT_DIR exported by setup_worktree_git() so the
+    # in-container agent has working git (status/diff/add/commit). The old
+    # `[[ ==worktree ]] || setup_worktree_git` short-circuited that call away in
+    # worktree mode, leaving GIT_DIR unset and in-container git non-functional.
+    # Run it explicitly whenever we are in worktree mode.
+    local _kapsis_is_worktree=false
+    if [[ "$sandbox_mode" == "worktree" ]]; then
+        setup_worktree_git || log_warn "worktree git setup incomplete; in-container git may be limited"
+        _kapsis_is_worktree=true
+    elif setup_worktree_git; then
+        _kapsis_is_worktree=true
+    fi
+    if [[ "$_kapsis_is_worktree" == "true" ]]; then
+        # Worktree mode: GIT_DIR now points at the sanitized .git-safe.
         log_info "Sandbox mode: worktree"
         log_debug "Setting up worktree mode environment"
 
@@ -2054,4 +2066,7 @@ main() {
     fi
 }
 
-main "$@"
+# Only run main when executed directly (not when sourced by unit tests).
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/scripts/launch-agent.sh
+++ b/scripts/launch-agent.sh
@@ -917,6 +917,12 @@ parse_config() {
         GIT_REMOTE=$(yq -r '.git.auto_push.remote // "origin"' "$CONFIG_FILE")
         GIT_COMMIT_MSG=$(yq -r '.git.auto_push.commit_message // "feat: AI agent changes"' "$CONFIG_FILE")
 
+        # Provider-pluggable post-push hook (PR creation etc.). Runs on the HOST
+        # after a verified push (see run_post_push_hook in post-container-git.sh).
+        # kapsis stays provider-agnostic — the command is supplied by config.
+        KAPSIS_POST_PUSH_HOOK=$(yq -r '.git.post_push_hook // ""' "$CONFIG_FILE")
+        export KAPSIS_POST_PUSH_HOOK
+
         # Parse co-authors (newline-separated list). Each entry is run through
         # validate_author_format to block multi-line / shell-metachar injection
         # via .kapsis/config.yaml (security review of PR #416). Invalid entries
@@ -3724,6 +3730,8 @@ post_container_worktree() {
         # writes to the same shell's _KAPSIS_COMMIT_STATUS variable, which is read later
         # by status_get_commit_status in the FINAL_EXIT_CODE logic (Issue #256)
         source "$post_container_script"
+        # Expose the base branch to the host post-push hook (run_post_push_hook).
+        export KAPSIS_BASE_BRANCH="${BASE_BRANCH:-}"
         # post_container_git sets PR_URL global variable
         # Capture return code to prevent set -e from killing the function (Issue #256)
         # CRITICAL: This || capture is inseparable from the outer || capture at the

--- a/scripts/launch-agent.sh
+++ b/scripts/launch-agent.sh
@@ -1593,9 +1593,12 @@ generate_volume_mounts_worktree() {
     # Mount worktree directly (no overlay needed!)
     VOLUME_MOUNTS+=("-v" "${WORKTREE_PATH}:/workspace")
 
-    # Mount sanitized git at $CONTAINER_GIT_PATH, replacing the worktree's .git file
-    # This makes git work without needing GIT_DIR environment variable
-    VOLUME_MOUNTS+=("-v" "${SANITIZED_GIT_PATH}:${CONTAINER_GIT_PATH}:ro")
+    # Mount sanitized git at $CONTAINER_GIT_PATH, replacing the worktree's .git file.
+    # Read-WRITE so the in-container agent can stage/commit into the sanitized
+    # GIT_DIR (setup_worktree_git exports GIT_DIR here). New commit objects land in
+    # the writable objects/ dir created by prepare_sanitized_git via
+    # objects/info/alternates; the parent object DB below stays :ro.
+    VOLUME_MOUNTS+=("-v" "${SANITIZED_GIT_PATH}:${CONTAINER_GIT_PATH}")
 
     # Mount objects directory read-only
     VOLUME_MOUNTS+=("-v" "${OBJECTS_PATH}:${CONTAINER_OBJECTS_PATH}:ro")

--- a/scripts/launch-agent.sh
+++ b/scripts/launch-agent.sh
@@ -3682,6 +3682,30 @@ repoint_sanitized_git_objects() {
     fi
 }
 
+# Restore the worktree's /workspace/.git pointer to the REAL, host-side gitdir
+# before the host runs any git op. The worktree root is mounted read-write into the
+# container, so a compromised agent can repoint /workspace/.git at an
+# agent-controlled gitdir (e.g. the sanitized .git-safe, or a dir under the
+# worktree) whose config/hooks then execute on the HOST when kapsis does
+# `cd "$worktree" && git ...`. The real gitdir ($PROJECT_PATH/.git/worktrees/<name>)
+# is NOT mounted into the container, so forcing the pointer back to it makes host
+# git resolve only the trusted (non-agent-writable) config/hooks. Fixes #467.
+_restore_real_worktree_gitpointer() {
+    local worktree_path="${1:-${WORKTREE_PATH:-}}"
+    local project_path="${2:-${PROJECT_PATH:-}}"
+    [[ -z "$worktree_path" || -z "$project_path" ]] && return 0
+    local name real_gitdir
+    name=$(basename "$worktree_path")
+    real_gitdir="$project_path/.git/worktrees/$name"
+    if [[ -d "$real_gitdir" ]]; then
+        # Overwrite unconditionally (a no-op for an untampered pointer).
+        printf 'gitdir: %s\n' "$real_gitdir" > "$worktree_path/.git"
+        log_debug "Restored worktree git pointer -> $real_gitdir (anti-tamper, #467)"
+    else
+        log_warn "Real worktree gitdir not found ($real_gitdir) — leaving .git pointer as-is"
+    fi
+}
+
 # Strip any agent-planted hook / core.hooksPath from the (rw-mounted) sanitized
 # git dir before the host runs git ops. Defense-in-depth for the writable-git
 # change; a no-op when the dir/config is absent.
@@ -3703,12 +3727,15 @@ post_container_worktree() {
     # Declare unconditionally so cleanup guard and return always have a defined value (Issue #256)
     local _pcg_rc=0
 
+    # Anti-tamper (issue #467): before ANY host git op, force /workspace/.git back
+    # to the real, host-side gitdir so a repointed pointer can't make host git
+    # resolve an agent-controlled config/hook. Must run first.
+    _restore_real_worktree_gitpointer "$WORKTREE_PATH" "$PROJECT_PATH"
+
     # Defense-in-depth: the sanitized git dir is mounted rw for the agent's
     # in-container git, so the agent could have planted a hook in its hooks/ dir or
-    # a core.hooksPath in its config. Neutralize both BEFORE any host git op that
-    # might resolve GIT_DIR into the sanitized dir, so no agent-planted hook fires
-    # on the host. (This closes the plant surface opened by the rw mount; the
-    # broader "host must not trust /workspace/.git" hardening is tracked separately.)
+    # a core.hooksPath in its config. Neutralize both before host git ops so no
+    # agent-planted hook fires on the host even if something resolves into it.
     _neutralize_sanitized_git_hooks "$SANITIZED_GIT_PATH"
 
     # Re-point sanitized git objects symlink BEFORE any git operations (#219)

--- a/scripts/launch-agent.sh
+++ b/scripts/launch-agent.sh
@@ -3649,12 +3649,20 @@ repoint_sanitized_git_objects() {
         return 0
     fi
 
-    # Only re-point if objects is a symlink or doesn't exist yet
-    if [[ -L "$sanitized_git/objects" ]] || [[ ! -e "$sanitized_git/objects" ]]; then
+    # Current model: objects is a writable dir with a git alternate borrowing the
+    # parent object DB. Re-point the alternate from the container path (used inside
+    # the container) to the host objects path so host-side git (status, index sync)
+    # can resolve objects after the container exits. The agent's newly-written
+    # objects remain in the local objects dir and are preserved.
+    if [[ -f "$sanitized_git/objects/info/alternates" ]]; then
+        printf '%s\n' "$objects_path" > "$sanitized_git/objects/info/alternates"
+        log_debug "Re-pointed sanitized git objects alternate -> $objects_path"
+    # Legacy model: objects is a symlink to the container path (or absent).
+    elif [[ -L "$sanitized_git/objects" ]] || [[ ! -e "$sanitized_git/objects" ]]; then
         ln -sfn "$objects_path" "$sanitized_git/objects"
-        log_debug "Re-pointed sanitized git objects: $sanitized_git/objects -> $objects_path"
+        log_debug "Re-pointed sanitized git objects symlink -> $objects_path"
     else
-        log_warn "sanitized git objects is not a symlink — skipping re-point"
+        log_warn "sanitized git objects is neither an alternate nor a symlink — skipping re-point"
     fi
 }
 

--- a/scripts/launch-agent.sh
+++ b/scripts/launch-agent.sh
@@ -3661,8 +3661,18 @@ repoint_sanitized_git_objects() {
     # can resolve objects after the container exits. The agent's newly-written
     # objects remain in the local objects dir and are preserved.
     if [[ -f "$sanitized_git/objects/info/alternates" ]]; then
-        printf '%s\n' "$objects_path" > "$sanitized_git/objects/info/alternates"
-        log_debug "Re-pointed sanitized git objects alternate -> $objects_path"
+        # Harden against a symlinked alternates file: the agent had write access to
+        # the sanitized dir during its run and could have replaced this file with a
+        # symlink to an arbitrary host path; a bare `>` would then clobber that host
+        # file. Refuse a symlinked info/ dir and rm -f the target so the redirect
+        # writes a fresh regular file in place.
+        if [[ -L "$sanitized_git/objects/info" ]]; then
+            log_warn "sanitized objects/info is a symlink — skipping re-point (possible tampering)"
+        else
+            rm -f "$sanitized_git/objects/info/alternates" 2>/dev/null || true
+            printf '%s\n' "$objects_path" > "$sanitized_git/objects/info/alternates"
+            log_debug "Re-pointed sanitized git objects alternate -> $objects_path"
+        fi
     # Legacy model: objects is a symlink to the container path (or absent).
     elif [[ -L "$sanitized_git/objects" ]] || [[ ! -e "$sanitized_git/objects" ]]; then
         ln -sfn "$objects_path" "$sanitized_git/objects"
@@ -3672,12 +3682,34 @@ repoint_sanitized_git_objects() {
     fi
 }
 
+# Strip any agent-planted hook / core.hooksPath from the (rw-mounted) sanitized
+# git dir before the host runs git ops. Defense-in-depth for the writable-git
+# change; a no-op when the dir/config is absent.
+_neutralize_sanitized_git_hooks() {
+    local sanitized_git="${1:-${SANITIZED_GIT_PATH:-}}"
+    [[ -z "$sanitized_git" || ! -d "$sanitized_git" ]] && return 0
+    if [[ -d "$sanitized_git/hooks" && ! -L "$sanitized_git/hooks" ]]; then
+        find "$sanitized_git/hooks" -mindepth 1 -maxdepth 1 -exec rm -rf {} + 2>/dev/null || true
+    fi
+    if [[ -f "$sanitized_git/config" && ! -L "$sanitized_git/config" ]]; then
+        git config --file "$sanitized_git/config" --unset-all core.hooksPath 2>/dev/null || true
+    fi
+}
+
 post_container_worktree() {
     log_debug "Processing worktree post-container operations..."
     log_debug "  WORKTREE_PATH=$WORKTREE_PATH"
 
     # Declare unconditionally so cleanup guard and return always have a defined value (Issue #256)
     local _pcg_rc=0
+
+    # Defense-in-depth: the sanitized git dir is mounted rw for the agent's
+    # in-container git, so the agent could have planted a hook in its hooks/ dir or
+    # a core.hooksPath in its config. Neutralize both BEFORE any host git op that
+    # might resolve GIT_DIR into the sanitized dir, so no agent-planted hook fires
+    # on the host. (This closes the plant surface opened by the rw mount; the
+    # broader "host must not trust /workspace/.git" hardening is tracked separately.)
+    _neutralize_sanitized_git_hooks "$SANITIZED_GIT_PATH"
 
     # Re-point sanitized git objects symlink BEFORE any git operations (#219)
     # Must happen first so git status and sync_index_from_container work correctly

--- a/scripts/lib/status.sh
+++ b/scripts/lib/status.sh
@@ -56,7 +56,8 @@ _KAPSIS_STATUS_STARTED=""
 _KAPSIS_STATUS_INITIALIZED=false
 
 # Push verification state
-_KAPSIS_PUSH_STATUS=""           # "success", "failed", "skipped", "unverified"
+_KAPSIS_PUSH_STATUS=""           # "success", "failed", "skipped", "unverified", "diverged"
+_KAPSIS_PR_HOOK_STATUS=""        # "skipped", "ok", "failed:<reason>" (post-push PR hook)
 _KAPSIS_PUSH_FALLBACK_CMD=""     # Fallback command for agent recovery when push fails
 _KAPSIS_LOCAL_COMMIT=""     # Local HEAD commit SHA
 _KAPSIS_REMOTE_COMMIT=""    # Remote HEAD commit SHA after push
@@ -268,6 +269,12 @@ status_set_push_info() {
     _KAPSIS_PUSH_STATUS="${1:-unverified}"
     _KAPSIS_LOCAL_COMMIT="${2:-}"
     _KAPSIS_REMOTE_COMMIT="${3:-}"
+}
+
+# Record the outcome of the provider-pluggable post-push PR hook.
+# Arguments: $1 - status ("skipped" | "ok" | "failed:<reason>")
+status_set_pr_hook_info() {
+    _KAPSIS_PR_HOOK_STATUS="${1:-skipped}"
 }
 
 # Set push fallback command for agent recovery
@@ -616,6 +623,9 @@ _status_write() {
     local push_status_json="null"
     [[ -n "$_KAPSIS_PUSH_STATUS" ]] && push_status_json="\"$_KAPSIS_PUSH_STATUS\""
 
+    local pr_hook_status_json="null"
+    [[ -n "$_KAPSIS_PR_HOOK_STATUS" ]] && pr_hook_status_json="\"$(_status_json_escape "$_KAPSIS_PR_HOOK_STATUS")\""
+
     local local_commit_json="null"
     [[ -n "$_KAPSIS_LOCAL_COMMIT" ]] && local_commit_json="\"$_KAPSIS_LOCAL_COMMIT\""
 
@@ -687,6 +697,7 @@ _status_write() {
   "error": ${error_json},
   "worktree_path": ${worktree_json},
   "pr_url": ${pr_url_json},
+  "pr_hook_status": ${pr_hook_status_json},
   "push_status": ${push_status_json},
   "local_commit": ${local_commit_json},
   "remote_commit": ${remote_commit_json},

--- a/scripts/post-container-git.sh
+++ b/scripts/post-container-git.sh
@@ -893,8 +893,16 @@ push_changes() {
         # Verify the push actually succeeded
         echo ""
         if verify_push "$worktree_path" "$remote" "$remote_branch"; then
-            # Show PR instructions only after verified push
-            show_pr_instructions "$worktree_path" "$remote_branch"
+            # After a verified push: run the provider-pluggable PR hook if
+            # configured, else fall back to printing PR instructions (legacy).
+            if [[ -n "${KAPSIS_POST_PUSH_HOOK:-}" ]]; then
+                local _pushed_sha
+                _pushed_sha=$(git rev-parse HEAD 2>/dev/null)
+                run_post_push_hook "$worktree_path" "$remote_branch" "${KAPSIS_BASE_BRANCH:-}" "$_pushed_sha" "$KAPSIS_POST_PUSH_HOOK"
+            else
+                status_set_pr_hook_info "skipped"
+                show_pr_instructions "$worktree_path" "$remote_branch"
+            fi
             return 0
         else
             log_error "Push reported success but verification failed!"
@@ -928,6 +936,45 @@ export PR_URL=""
 
 # Display PR creation instructions with URL
 # Uses generate_pr_url from git-remote-utils.sh
+# Provider-agnostic PR-creation seam. Runs a user-configured command on the HOST
+# after a verified push. kapsis knows nothing about gh/bkt/glab — the command is
+# supplied by config (git.post_push_hook). Agent-influenced values are passed via
+# env ONLY (never interpolated into the command string); the hook contract requires
+# it to quote and never eval. The hook command itself comes from trusted config.
+# Failures are surfaced via pr_hook_status (never swallowed): the push already
+# succeeded, so we do not fail the whole run, but a failed hook is recorded and a
+# non-silent warning is logged so "pushed but no PR" can't happen invisibly.
+# Sets globals: PR_URL (if the hook prints a URL on stdout), and via
+# status_set_pr_hook_info the pr_hook_status field.
+run_post_push_hook() {
+    local worktree_path="$1" remote_branch="$2" base_branch="$3" pushed_sha="$4" hook_cmd="$5"
+    if [[ -z "$hook_cmd" ]]; then
+        status_set_pr_hook_info "skipped"
+        return 0
+    fi
+    local remote_url
+    remote_url=$(cd "$worktree_path" && git remote get-url origin 2>/dev/null || echo "")
+    local out rc=0
+    out=$(cd "$worktree_path" && \
+        KAPSIS_REMOTE_BRANCH="$remote_branch" KAPSIS_BASE_BRANCH="$base_branch" \
+        KAPSIS_PUSHED_SHA="$pushed_sha" KAPSIS_REMOTE_URL="$remote_url" \
+        bash -c "$hook_cmd" 2>&1) || rc=$?
+    if [[ $rc -eq 0 ]]; then
+        status_set_pr_hook_info "ok"
+        local url
+        url=$(printf '%s\n' "$out" | grep -oE 'https?://[^[:space:]]+' | tail -1 || true)
+        if [[ -n "$url" ]]; then
+            PR_URL="$url"
+            echo "  Post-push hook created PR: $url"
+        fi
+        return 0
+    fi
+    status_set_pr_hook_info "failed:exit${rc}"
+    log_error "post_push_hook failed (exit $rc). Branch was pushed but PR creation did NOT succeed:"
+    printf '%s\n' "$out" | tail -3 | while IFS= read -r _l; do log_error "  $_l"; done
+    return 0   # push already succeeded; surface the failure, don't fail the run
+}
+
 show_pr_instructions() {
     local worktree_path="$1"
     local branch="$2"

--- a/scripts/post-container-git.sh
+++ b/scripts/post-container-git.sh
@@ -861,23 +861,31 @@ push_changes() {
     # fail-closed with a clear reason + a manual fallback command, rather than
     # emitting the bare-push failure that stranded work as "committed, no PR".
     local _fetch_timeout="${KAPSIS_FETCH_TIMEOUT:-60}"
-    GIT_TERMINAL_PROMPT=0 timeout "$_fetch_timeout" git fetch "$remote" "$remote_branch" 2>/dev/null || true
-    local _remote_tip=""
-    _remote_tip=$(git rev-parse -q --verify FETCH_HEAD 2>/dev/null || true)
-    if [[ -z "$_remote_tip" ]]; then
-        _remote_tip=$(git rev-parse -q --verify "refs/remotes/${remote}/${remote_branch}" 2>/dev/null || true)
+    local _fetch_ok=0
+    if GIT_TERMINAL_PROMPT=0 timeout "$_fetch_timeout" git fetch "$remote" -- "$remote_branch" 2>/dev/null; then
+        _fetch_ok=1
     fi
-    if [[ -n "$_remote_tip" ]]; then
-        local _base
-        _base=$(git merge-base HEAD "$_remote_tip" 2>/dev/null || echo "")
-        # Divergence = remote tip is not an ancestor of HEAD (i.e. base != remote tip).
-        if [[ "$_base" != "$_remote_tip" ]]; then
-            log_error "Remote ${remote}/${remote_branch} advanced beyond our base — refusing non-fast-forward push"
-            log_error "  remote tip: ${_remote_tip}"
-            log_error "  local head: ${local_commit}"
-            status_set_push_info "diverged" "$local_commit" "$_remote_tip"
-            status_set_push_fallback "$worktree_path" "$remote" "$branch" "$remote_branch"
-            return 1
+    # Only evaluate divergence when the fetch ACTUALLY succeeded. On failure we do
+    # NOT fall back to refs/remotes/<branch> — that shared ref is not refreshed by a
+    # failed fetch, so a stale tip could falsely refuse a legitimate push or mask a
+    # real divergence. A failed fetch (incl. the common case of a brand-new branch
+    # that doesn't exist on the remote yet) simply skips the guard; the push below
+    # then proceeds (first push) or surfaces any genuine non-fast-forward itself.
+    if [[ "$_fetch_ok" -eq 1 ]]; then
+        local _remote_tip=""
+        _remote_tip=$(git rev-parse -q --verify FETCH_HEAD 2>/dev/null || true)
+        if [[ -n "$_remote_tip" ]]; then
+            local _base
+            _base=$(git merge-base HEAD "$_remote_tip" 2>/dev/null || echo "")
+            # Divergence = remote tip is not an ancestor of HEAD (i.e. base != remote tip).
+            if [[ "$_base" != "$_remote_tip" ]]; then
+                log_error "Remote ${remote}/${remote_branch} advanced beyond our base — refusing non-fast-forward push"
+                log_error "  remote tip: ${_remote_tip}"
+                log_error "  local head: ${local_commit}"
+                status_set_push_info "diverged" "$local_commit" "$_remote_tip"
+                status_set_push_fallback "$worktree_path" "$remote" "$branch" "$remote_branch"
+                return 1
+            fi
         fi
     fi
 

--- a/scripts/post-container-git.sh
+++ b/scripts/post-container-git.sh
@@ -727,7 +727,7 @@ commit_changes() {
                          GIT_COMMITTER_EMAIL="$KAPSIS_COMMITTER_EMAIL" \
                          GIT_AUTHOR_NAME="$KAPSIS_COMMITTER_NAME" \
                          GIT_AUTHOR_EMAIL="$KAPSIS_COMMITTER_EMAIL" \
-                         git commit $_no_verify_flag -m "$full_message" 2>&1) || _commit_exit=$?
+                         git -c core.hooksPath=/dev/null commit $_no_verify_flag -m "$full_message" 2>&1) || _commit_exit=$?
     else
         _commit_output=$(git commit $_no_verify_flag -m "$full_message" 2>&1) || _commit_exit=$?
     fi

--- a/scripts/post-container-git.sh
+++ b/scripts/post-container-git.sh
@@ -855,6 +855,32 @@ push_changes() {
     local local_commit
     local_commit=$(git rev-parse HEAD 2>/dev/null)
 
+    # Fetch-before-push divergence guard: if the remote branch has advanced beyond
+    # our base (someone else pushed), a bare push would either non-fast-forward
+    # reject with a confusing error or, worse, be forced. Detect divergence and
+    # fail-closed with a clear reason + a manual fallback command, rather than
+    # emitting the bare-push failure that stranded work as "committed, no PR".
+    local _fetch_timeout="${KAPSIS_FETCH_TIMEOUT:-60}"
+    GIT_TERMINAL_PROMPT=0 timeout "$_fetch_timeout" git fetch "$remote" "$remote_branch" 2>/dev/null || true
+    local _remote_tip=""
+    _remote_tip=$(git rev-parse -q --verify FETCH_HEAD 2>/dev/null || true)
+    if [[ -z "$_remote_tip" ]]; then
+        _remote_tip=$(git rev-parse -q --verify "refs/remotes/${remote}/${remote_branch}" 2>/dev/null || true)
+    fi
+    if [[ -n "$_remote_tip" ]]; then
+        local _base
+        _base=$(git merge-base HEAD "$_remote_tip" 2>/dev/null || echo "")
+        # Divergence = remote tip is not an ancestor of HEAD (i.e. base != remote tip).
+        if [[ "$_base" != "$_remote_tip" ]]; then
+            log_error "Remote ${remote}/${remote_branch} advanced beyond our base — refusing non-fast-forward push"
+            log_error "  remote tip: ${_remote_tip}"
+            log_error "  local head: ${local_commit}"
+            status_set_push_info "diverged" "$local_commit" "$_remote_tip"
+            status_set_push_fallback "$worktree_path" "$remote" "$branch" "$remote_branch"
+            return 1
+        fi
+    fi
+
     # Use refspec to push local branch to (potentially different) remote branch.
     # GIT_TERMINAL_PROMPT=0 prevents interactive prompts in non-TTY containers.
     # timeout guards against credential helper hangs (Issue #227).

--- a/scripts/post-container-git.sh
+++ b/scripts/post-container-git.sh
@@ -124,7 +124,9 @@ validate_staged_files() {
 
     # Check for .kapsis/ internal files
     local kapsis_files
-    kapsis_files=$(git diff --cached --name-only 2>/dev/null | grep "^\.kapsis/" || true)
+    # Case-insensitive: the container FS is case-sensitive, so `.Kapsis/` is a
+    # distinct path a case-sensitive filter would miss and commit.
+    kapsis_files=$(git diff --cached --name-only 2>/dev/null | grep -iE "^\.kapsis/" || true)
     if [[ -n "$kapsis_files" ]]; then
         log_warn "Found staged .kapsis/ internal files (should be ignored):"
         while IFS= read -r f; do
@@ -141,7 +143,7 @@ validate_staged_files() {
     # repo size doubles (entire object DB ships as tracked files).
     # Regression: products PR #102836.
     local kapsis_mount_files
-    kapsis_mount_files=$(git diff --cached --name-only 2>/dev/null | grep -E "^\.git-(safe|objects)/" || true)
+    kapsis_mount_files=$(git diff --cached --name-only 2>/dev/null | grep -iE "^\.git-(safe|objects)/" || true)
     if [[ -n "$kapsis_mount_files" ]]; then
         log_warn "Found staged Kapsis git-mount files (should be ignored):"
         while IFS= read -r f; do
@@ -164,6 +166,22 @@ validate_staged_files() {
             log_warn "  - $path (submodule)"
             suspicious_files+=("$path")
         done <<< "$submodule_refs"
+        has_security_issues=1
+    fi
+
+    # Check for symlink entries (mode 120000). A crafted symlink (e.g. a file
+    # pointing at /etc/passwd) can be smuggled through the index past content-only
+    # sanitizers. The NEW mode is the 2nd field of `git diff --cached --raw`.
+    local symlink_refs
+    symlink_refs=$(git diff --cached --raw 2>/dev/null | awk '{print $2}' | grep -E "^120000$" || true)
+    if [[ -n "$symlink_refs" ]]; then
+        log_warn "Found staged symlink entries (mode 120000) — rejecting:"
+        while IFS= read -r line; do
+            local spath
+            spath=$(echo "$line" | awk '{print $NF}')
+            log_warn "  - $spath (symlink)"
+            suspicious_files+=("$spath")
+        done < <(git diff --cached --raw 2>/dev/null | awk '$2=="120000"')
         has_security_issues=1
     fi
 

--- a/scripts/worktree-manager.sh
+++ b/scripts/worktree-manager.sh
@@ -442,9 +442,25 @@ create_worktree() {
 # Security measures:
 # - Empty hooks directory (prevents execution of malicious hooks)
 # - Minimal config (no credential helpers, fixed identity)
-# - Read-only objects link (prevents object corruption)
+# - Writable objects dir borrowing the parent DB read-only via an alternate
 # - Isolated refs (agent only sees its own branch)
 #===============================================================================
+
+# Set up the sanitized git objects store as a writable local dir that borrows the
+# parent object DB read-only via objects/info/alternates. This lets in-container
+# `git commit` write new objects locally while existing objects resolve from the
+# (read-only) parent mount. Replaces the old read-only symlink, which made commit
+# fail. $2 is the objects path to borrow (container path at prepare time; the host
+# re-points it via repoint_sanitized_git_objects post-container).
+_prepare_objects_alternate() {
+    local sanitized_dir="$1"
+    local objects_path="$2"
+    rm -f "$sanitized_dir/objects" 2>/dev/null || true   # drop any prior symlink
+    mkdir -p "$sanitized_dir/objects/info" "$sanitized_dir/objects/pack"
+    printf '%s\n' "$objects_path" > "$sanitized_dir/objects/info/alternates"
+    log_debug "Created objects dir + alternate -> $objects_path"
+}
+
 prepare_sanitized_git() {
     local worktree_path="$1"
     local agent_id="$2"
@@ -519,12 +535,14 @@ prepare_sanitized_git() {
     # Create minimal safe config
     create_safe_git_config "$sanitized_dir/config" "$worktree_path" "$agent_id"
 
-    # Create objects symlink pointing to container mount path
-    # The sanitized git will be mounted at $CONTAINER_GIT_PATH
-    # and objects will be mounted at $CONTAINER_OBJECTS_PATH
-    # This symlink allows git to find objects when running inside the container
-    ln -sfn "$CONTAINER_OBJECTS_PATH" "$sanitized_dir/objects"
-    log_debug "Created objects symlink -> $CONTAINER_OBJECTS_PATH"
+    # Objects: writable local dir + a git ALTERNATE borrowing the parent object DB
+    # read-only. A plain symlink to the (read-only) parent objects mount made
+    # in-container `git commit` fail (nowhere to write new objects). With an
+    # alternate, new commit objects land in the writable local objects/ dir while
+    # existing objects are borrowed read-only from $CONTAINER_OBJECTS_PATH.
+    # The host re-points this alternate to the host objects path post-container
+    # (see repoint_sanitized_git_objects).
+    _prepare_objects_alternate "$sanitized_dir" "$CONTAINER_OBJECTS_PATH"
 
     # Create info/exclude with protective patterns (issue #89)
     # This ensures the container's git operations respect our exclude patterns

--- a/tests/run-all-tests.sh
+++ b/tests/run-all-tests.sh
@@ -48,7 +48,7 @@ echo "test-input-validation.sh test-path-spaces.sh test-dry-run-completeness.sh 
 echo "test-security.sh test-security-no-root.sh test-agent-id-unique.sh test-env-api-keys.sh test-container-libs.sh test-container-plugin-hooks.sh test-ssh-keychain.sh test-keychain-retrieval.sh test-ssh-cache-cleanup.sh test-keychain-platform.sh test-config-security.sh test-network-isolation.sh test-scope-validation.sh test-sanitize-files.sh test-ssh-config-portability.sh test-git-credential-helper.sh test-secret-store-injection.sh test-secret-store.sh test-audit-patterns.sh test-container-status-hooks.sh test-container-gist-hook.sh test-container-all-hooks.sh test-gist-injection-provenance.sh test-host-strip-audit.sh"
             ;;
         git)
-            echo "test-git-new-branch.sh test-git-auto-commit-push.sh test-worktree-isolation.sh test-worktree-cleanup.sh test-push-verification.sh test-git-excludes.sh test-validate-staged-files.sh test-ephemeral-artifact-filtering.sh test-coauthor-fork.sh test-post-container-git.sh test-sanitized-git-objects.sh test-init-git-branch.sh test-post-exit-git.sh test-kapsis-artifact-filter.sh"
+            echo "test-git-new-branch.sh test-git-auto-commit-push.sh test-worktree-isolation.sh test-worktree-cleanup.sh test-push-verification.sh test-git-excludes.sh test-validate-staged-files.sh test-ephemeral-artifact-filtering.sh test-coauthor-fork.sh test-post-container-git.sh test-sanitized-git-objects.sh test-init-git-branch.sh test-post-exit-git.sh test-kapsis-artifact-filter.sh test-worktree-incontainer-git.sh"
             ;;
         cleanup)
             echo "test-cleanup-sandbox.sh test-cleanup-snapshots.sh test-cleanup-conversations.sh test-cleanup-status-lifecycle.sh test-volume-cleanup.sh"

--- a/tests/test-post-container-git.sh
+++ b/tests/test-post-container-git.sh
@@ -328,6 +328,39 @@ test_push_fast_forward_succeeds() {
 }
 
 #===============================================================================
+# TEST CASES: post-push PR hook (Task 6)
+#===============================================================================
+
+test_post_push_hook_invoked_with_env() {
+    log_test "run_post_push_hook: invoked with env, captures PR URL"
+    local r; r=$(_mk_repo)
+    local out; out=$(mktemp)
+    local hook="printf 'BRANCH=%s SHA=%s\n' \"\$KAPSIS_REMOTE_BRANCH\" \"\$KAPSIS_PUSHED_SHA\" > $out; echo https://pr.example/1"
+    PR_URL=""; _KAPSIS_PR_HOOK_STATUS=""
+    run_post_push_hook "$r" "feature/x" "main" "deadbeef" "$hook"
+    assert_equals "ok" "${_KAPSIS_PR_HOOK_STATUS:-}" "hook status ok"
+    assert_file_contains "$out" "BRANCH=feature/x SHA=deadbeef" "hook received env"
+    assert_equals "https://pr.example/1" "${PR_URL:-}" "PR_URL captured from hook stdout"
+    rm -rf "$r" "$out"
+}
+
+test_post_push_hook_unset_skips() {
+    log_test "run_post_push_hook: empty command => skipped"
+    _KAPSIS_PR_HOOK_STATUS=""
+    run_post_push_hook "/tmp" "feature/x" "main" "deadbeef" ""
+    assert_equals "skipped" "${_KAPSIS_PR_HOOK_STATUS:-}" "unset hook = skipped"
+}
+
+test_post_push_hook_failure_surfaced() {
+    log_test "run_post_push_hook: hook failure is surfaced, not swallowed"
+    local r; r=$(_mk_repo)
+    _KAPSIS_PR_HOOK_STATUS=""
+    run_post_push_hook "$r" "feature/x" "main" "deadbeef" "exit 3"
+    assert_matches "${_KAPSIS_PR_HOOK_STATUS:-}" "^failed:" "hook failure surfaced as failed:*"
+    rm -rf "$r"
+}
+
+#===============================================================================
 # MAIN
 #===============================================================================
 
@@ -357,6 +390,11 @@ main() {
     log_info "=== push_changes fetch-before-push ==="
     run_test test_push_refuses_non_fast_forward
     run_test test_push_fast_forward_succeeds
+
+    log_info "=== post-push PR hook ==="
+    run_test test_post_push_hook_invoked_with_env
+    run_test test_post_push_hook_unset_skips
+    run_test test_post_push_hook_failure_surfaced
 
     # Print summary
     print_summary

--- a/tests/test-post-container-git.sh
+++ b/tests/test-post-container-git.sh
@@ -297,6 +297,37 @@ test_accept_clean_regular_file() {
 }
 
 #===============================================================================
+# TEST CASES: push_changes fetch-before-push (Task 5)
+#===============================================================================
+
+test_push_refuses_non_fast_forward() {
+    log_test "push_changes: refuse non-fast-forward when remote advanced"
+    local up; up=$(mktemp -d); ( cd "$up"; git init -q --bare -b main )
+    local a; a=$(mktemp -d)
+    ( cd "$a"; git init -q -b main; git config user.email a@b.c; git config user.name a
+      git remote add origin "$up"; echo 1 > f; git add -A; git commit -qm base; git push -q origin main )
+    # advance origin/main from another clone (real descendant, so it truly advances)
+    local b; b=$(mktemp -d); git clone -q "$up" "$b"
+    ( cd "$b"; git config user.email a@b.c; git config user.name a; echo 2 > f; git add -A
+      git commit -qm adv; git push -q origin main )
+    # 'a' makes a divergent commit on its now-stale base
+    ( cd "$a"; echo 3 > g; git add -A; git commit -qm local )
+    assert_command_fails "( push_changes '$a' origin main )" "divergent remote must not be blind-pushed"
+    rm -rf "$up" "$a" "$b"
+}
+
+test_push_fast_forward_succeeds() {
+    log_test "push_changes: fast-forward push succeeds"
+    local up; up=$(mktemp -d); ( cd "$up"; git init -q --bare -b main )
+    local a; a=$(mktemp -d)
+    ( cd "$a"; git init -q -b main; git config user.email a@b.c; git config user.name a
+      git remote add origin "$up"; echo 1 > f; git add -A; git commit -qm base; git push -q origin main
+      echo 2 > f; git add -A; git commit -qm next )
+    assert_command_succeeds "( push_changes '$a' origin main )" "fast-forward push should succeed"
+    rm -rf "$up" "$a"
+}
+
+#===============================================================================
 # MAIN
 #===============================================================================
 
@@ -322,6 +353,10 @@ main() {
     run_test test_reject_symlink_entry
     run_test test_reject_gitlink_entry
     run_test test_accept_clean_regular_file
+
+    log_info "=== push_changes fetch-before-push ==="
+    run_test test_push_refuses_non_fast_forward
+    run_test test_push_fast_forward_succeeds
 
     # Print summary
     print_summary

--- a/tests/test-post-container-git.sh
+++ b/tests/test-post-container-git.sh
@@ -257,6 +257,46 @@ test_sync_index_cache_tree_rebuild() {
 }
 
 #===============================================================================
+# TEST CASES: validate_staged_files hardening (Task 4)
+#===============================================================================
+
+_mk_repo() {
+    local r; r=$(mktemp -d)
+    ( cd "$r"; git init -q; git config user.email a@b.c; git config user.name a )
+    echo "$r"
+}
+
+test_reject_uppercase_kapsis_dir() {
+    log_test "validate_staged_files: reject .Kapsis/ (case-insensitive)"
+    local r; r=$(_mk_repo); mkdir -p "$r/.Kapsis"; echo x > "$r/.Kapsis/f"
+    ( cd "$r"; git add -A -f >/dev/null 2>&1 )
+    assert_command_fails "validate_staged_files '$r'" ".Kapsis/ must be rejected (case-insensitive)"
+    rm -rf "$r"
+}
+
+test_reject_symlink_entry() {
+    log_test "validate_staged_files: reject staged symlink (mode 120000)"
+    local r; r=$(_mk_repo); ( cd "$r"; ln -s /etc/passwd link; git add -A >/dev/null 2>&1 )
+    assert_command_fails "validate_staged_files '$r'" "symlink (120000) must be rejected"
+    rm -rf "$r"
+}
+
+test_reject_gitlink_entry() {
+    log_test "validate_staged_files: reject staged gitlink (mode 160000)"
+    local r; r=$(_mk_repo)
+    ( cd "$r"; git update-index --add --cacheinfo 160000,1234567890123456789012345678901234567890,sub >/dev/null 2>&1 )
+    assert_command_fails "validate_staged_files '$r'" "gitlink (160000) must be rejected"
+    rm -rf "$r"
+}
+
+test_accept_clean_regular_file() {
+    log_test "validate_staged_files: accept a clean regular file"
+    local r; r=$(_mk_repo); echo hi > "$r/normal.txt"; ( cd "$r"; git add -A >/dev/null 2>&1 )
+    assert_command_succeeds "validate_staged_files '$r'" "clean regular file must pass"
+    rm -rf "$r"
+}
+
+#===============================================================================
 # MAIN
 #===============================================================================
 
@@ -276,6 +316,12 @@ main() {
     run_test test_sync_index_no_git
     run_test test_sync_index_no_index_in_sanitized
     run_test test_sync_index_cache_tree_rebuild
+
+    log_info "=== validate_staged_files hardening ==="
+    run_test test_reject_uppercase_kapsis_dir
+    run_test test_reject_symlink_entry
+    run_test test_reject_gitlink_entry
+    run_test test_accept_clean_regular_file
 
     # Print summary
     print_summary

--- a/tests/test-post-container-git.sh
+++ b/tests/test-post-container-git.sh
@@ -327,6 +327,23 @@ test_push_fast_forward_succeeds() {
     rm -rf "$up" "$a"
 }
 
+test_push_first_push_new_branch_succeeds() {
+    # The most common kapsis case: a brand-new branch not yet on the remote. The
+    # fetch of a non-existent remote branch fails, so the divergence guard must
+    # SKIP (not falsely refuse) and let the first push create the branch.
+    log_test "push_changes: first push of a new branch succeeds (guard skips)"
+    local up; up=$(mktemp -d); ( cd "$up"; git init -q --bare -b main )
+    local a; a=$(mktemp -d)
+    ( cd "$a"; git init -q -b feature/new; git config user.email a@b.c; git config user.name a
+      git remote add origin "$up"; echo 1 > f; git add -A; git commit -qm work )
+    assert_command_succeeds "( push_changes '$a' origin feature/new )" "first push of new branch should succeed"
+    # And it actually landed on the remote. cd into the bare repo first: an earlier
+    # test may have left the shell cwd in a since-deleted tmp dir, which would make a
+    # bare `git ls-remote` fail on "cannot access current directory" (not our bug).
+    assert_command_succeeds "( cd '$up' && git ls-remote --exit-code --heads . feature/new )" "new branch exists on remote"
+    rm -rf "$up" "$a"
+}
+
 #===============================================================================
 # TEST CASES: post-push PR hook (Task 6)
 #===============================================================================
@@ -390,6 +407,7 @@ main() {
     log_info "=== push_changes fetch-before-push ==="
     run_test test_push_refuses_non_fast_forward
     run_test test_push_fast_forward_succeeds
+    run_test test_push_first_push_new_branch_succeeds
 
     log_info "=== post-push PR hook ==="
     run_test test_post_push_hook_invoked_with_env

--- a/tests/test-sanitized-git-objects.sh
+++ b/tests/test-sanitized-git-objects.sh
@@ -30,6 +30,7 @@ fi
 eval "$(sed -n '/^repoint_sanitized_git_objects()/,/^}/p' "$KAPSIS_ROOT/scripts/launch-agent.sh")"
 eval "$(sed -n '/^_prepare_objects_alternate()/,/^}/p' "$KAPSIS_ROOT/scripts/worktree-manager.sh")"
 eval "$(sed -n '/^_neutralize_sanitized_git_hooks()/,/^}/p' "$KAPSIS_ROOT/scripts/launch-agent.sh")"
+eval "$(sed -n '/^_restore_real_worktree_gitpointer()/,/^}/p' "$KAPSIS_ROOT/scripts/launch-agent.sh")"
 
 _alt() { cat "$1/objects/info/alternates" 2>/dev/null; }  # read alternate line
 
@@ -177,6 +178,40 @@ test_neutralize_removes_planted_hooks_and_hookspath() {
     rm -rf "$sg"
 }
 
+#=== security: restore real gitdir pointer defeats an agent repoint (#467) =====
+test_restore_gitpointer_defeats_repoint_rce() {
+    log_test "restore: repointed /workspace/.git is forced back to real gitdir (no host hook exec)"
+    local root; root=$(mktemp -d)
+    local proj="$root/project"
+    ( cd "$root"; git init -q -b main project; cd project; git config user.email a@b.c; git config user.name a; echo x > f; git add -A; git commit -qm base )
+    # Real worktree created by kapsis (git worktree add).
+    local wt="$root/wt-agent1"
+    ( cd "$proj"; git worktree add -q -b feature/x "$wt" >/dev/null 2>&1 )
+    local real_gitdir; real_gitdir="$proj/.git/worktrees/$(basename "$wt")"
+    assert_dir_exists "$real_gitdir" "real gitdir exists after worktree add"
+
+    # Simulate a compromised agent: repoint /workspace/.git at an evil gitdir whose
+    # post-commit hook would run on the host.
+    local evil="$root/evil-gitdir"; mkdir -p "$evil/hooks"
+    cp "$real_gitdir/HEAD" "$evil/HEAD" 2>/dev/null || echo "ref: refs/heads/feature/x" > "$evil/HEAD"
+    printf '%s\n' "$(cat "$real_gitdir/commondir" 2>/dev/null || echo ../..)" > "$evil/commondir"
+    local pwned="$root/PWNED"
+    printf '#!/bin/sh\ntouch "%s"\n' "$pwned" > "$evil/hooks/post-commit"; chmod +x "$evil/hooks/post-commit"
+    printf 'gitdir: %s\n' "$evil" > "$wt/.git"
+
+    # Host hardening runs before any host git op.
+    _restore_real_worktree_gitpointer "$wt" "$proj"
+
+    # Pointer must be back to the real gitdir, not the evil one.
+    assert_file_contains "$wt/.git" "gitdir: $real_gitdir" "pointer restored to real gitdir"
+    assert_file_not_contains "$wt/.git" "$evil" "evil gitdir no longer referenced"
+
+    # A host commit must resolve the real gitdir → the evil post-commit hook must NOT fire.
+    ( cd "$wt"; echo y > g; git add -A; git -c core.hooksPath=/dev/null commit -qm host >/dev/null 2>&1 )
+    assert_file_not_exists "$pwned" "evil post-commit hook must NOT run on the host"
+    rm -rf "$root"
+}
+
 #=== metadata =================================================================
 test_kapsis_meta_written_by_production() {
     log_test "prepare writes HOST_OBJECTS_PATH to kapsis-meta"
@@ -207,6 +242,7 @@ main() {
     log_info "=== Security hardening ==="
     run_test test_repoint_refuses_symlinked_info
     run_test test_neutralize_removes_planted_hooks_and_hookspath
+    run_test test_restore_gitpointer_defeats_repoint_rce
 
     log_info "=== Metadata ==="
     run_test test_kapsis_meta_written_by_production

--- a/tests/test-sanitized-git-objects.sh
+++ b/tests/test-sanitized-git-objects.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 #===============================================================================
-# Tests for Sanitized Git Objects Symlink Fix (Issue #219)
+# Tests for Sanitized Git Objects (writable dir + alternate) — Architecture B.
 #
-# Verifies that the objects symlink in sanitized-git directories is re-pointed
-# from the container path (/workspace/.git-objects) to the host path after
-# container exit, so post-container git operations can access objects.
+# The sanitized-git objects store is a WRITABLE local dir that borrows the parent
+# object DB read-only via objects/info/alternates (so in-container `git commit`
+# can write new objects). After container exit the host re-points the alternate
+# from the container path (/workspace/.git-objects) to the host objects path.
 #
-# Tests exercise the production repoint_sanitized_git_objects() function
-# sourced from launch-agent.sh.
+# Exercises the production repoint_sanitized_git_objects() (launch-agent.sh) and
+# _prepare_objects_alternate() (worktree-manager.sh).
 #
 # Run: ./tests/test-sanitized-git-objects.sh
 #===============================================================================
@@ -18,271 +19,162 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/lib/test-framework.sh"
 
 LIB_DIR="$KAPSIS_ROOT/scripts/lib"
-
-# Source constants for CONTAINER_OBJECTS_PATH
 source "$LIB_DIR/constants.sh"
 
-# Source the production function we're testing
-# repoint_sanitized_git_objects() is defined in launch-agent.sh
-# We need logging stubs since launch-agent.sh expects them
+# Logging stubs expected by the extracted production functions
 if ! type log_debug &>/dev/null; then
     log_debug() { :; }
     log_warn() { echo "[WARN] $*" >&2; }
 fi
-# Extract just the function from launch-agent.sh
+# Extract the production functions under test (avoids sourcing whole scripts)
 eval "$(sed -n '/^repoint_sanitized_git_objects()/,/^}/p' "$KAPSIS_ROOT/scripts/launch-agent.sh")"
+eval "$(sed -n '/^_prepare_objects_alternate()/,/^}/p' "$KAPSIS_ROOT/scripts/worktree-manager.sh")"
+
+_alt() { cat "$1/objects/info/alternates" 2>/dev/null; }  # read alternate line
 
 setup_test_env() {
     TEST_DIR=$(mktemp -d)
-    # Simulate a project with .git/objects
     mkdir -p "$TEST_DIR/project/.git/objects/pack"
     echo "test-object" > "$TEST_DIR/project/.git/objects/test.obj"
-
-    # Simulate sanitized git directory with container-path symlink
+    # sanitized git dir with a container-path alternate (as prepared in-container)
     mkdir -p "$TEST_DIR/sanitized-git/abc123"
-    ln -sfn "$CONTAINER_OBJECTS_PATH" "$TEST_DIR/sanitized-git/abc123/objects"
+    _prepare_objects_alternate "$TEST_DIR/sanitized-git/abc123" "$CONTAINER_OBJECTS_PATH"
 }
+cleanup_test_env() { [[ -n "${TEST_DIR:-}" ]] && rm -rf "$TEST_DIR"; TEST_DIR=""; }
 
-cleanup_test_env() {
-    [[ -n "${TEST_DIR:-}" ]] && rm -rf "$TEST_DIR"
-    TEST_DIR=""
-}
-
-#===============================================================================
-# TEST: Basic path re-pointing via production function
-#===============================================================================
-
-test_repoint_via_production_function() {
-    log_test "Testing repoint_sanitized_git_objects() re-points symlink"
+#=== prepare: objects is a writable dir + alternate (not a symlink) ============
+test_prepare_creates_writable_objects_with_alternate() {
+    log_test "prepare: objects is a writable dir with an alternate (not a symlink)"
     setup_test_env
+    local sg="$TEST_DIR/sanitized-git/abc123"
+    assert_dir_exists "$sg/objects" "objects must be a real directory"
+    assert_true "[[ ! -L \"$sg/objects\" ]]" "objects must NOT be a symlink"
+    assert_dir_exists "$sg/objects/pack" "objects/pack must exist for new packs"
+    assert_equals "$CONTAINER_OBJECTS_PATH" "$(_alt "$sg")" "alternate points at parent objects"
+    cleanup_test_env
+}
 
-    local sanitized="$TEST_DIR/sanitized-git/abc123"
+#=== functional: in-container commit writes objects locally, parent stays RO ===
+test_in_container_commit_writes_locally() {
+    log_test "functional: commit via alternate writes new objects locally"
+    local root; root=$(mktemp -d)
+    ( cd "$root"; git init -q parent && cd parent && git config user.email a@b.c \
+        && git config user.name a && echo hello > f && git add f && git commit -qm base )
+    local parent_obj="$root/parent/.git/objects"
+    mkdir -p "$root/sg/refs/heads"; printf 'ref: refs/heads/main\n' > "$root/sg/HEAD"
+    _prepare_objects_alternate "$root/sg" "$parent_obj"
+    chmod -R a-w "$parent_obj"                    # parent objects read-only
+    mkdir -p "$root/wt"; echo world > "$root/wt/g"
+    local rc=0
+    GIT_DIR="$root/sg" GIT_WORK_TREE="$root/wt" git add g >/dev/null 2>&1 || rc=$?
+    GIT_DIR="$root/sg" GIT_WORK_TREE="$root/wt" \
+        git -c user.email=a@b.c -c user.name=a commit -qm "in-sandbox" >/dev/null 2>&1 || rc=$?
+    chmod -R u+w "$parent_obj" 2>/dev/null || true
+    assert_equals "0" "$rc" "commit against RO parent (via alternate) must succeed"
+    local n
+    n=$(find "$root/sg/objects" -type f \( -name '*.pack' -o -path '*/[0-9a-f][0-9a-f]/*' \) 2>/dev/null | wc -l | tr -d ' ')
+    assert_true "[[ $n -ge 1 ]]" "new commit objects must land in the local objects dir"
+    rm -rf "$root"
+}
+
+#=== repoint: rewrite the alternate from container path to host path ===========
+test_repoint_rewrites_alternate_to_host() {
+    log_test "repoint: alternate rewritten container-path -> host-path"
+    setup_test_env
+    local sg="$TEST_DIR/sanitized-git/abc123"
     local host_objects="$TEST_DIR/project/.git/objects"
-
-    # Before: symlink points to container path
-    local before
-    before=$(readlink "$sanitized/objects")
-    assert_equals "$CONTAINER_OBJECTS_PATH" "$before" "Before: should point to container path"
-
-    # Call production function
-    repoint_sanitized_git_objects "$sanitized" "$host_objects"
-
-    # After: symlink points to host path
-    local after
-    after=$(readlink "$sanitized/objects")
-    assert_equals "$host_objects" "$after" "After: should point to host objects path"
-
-    # Verify the symlink target exists and is accessible
-    assert_true "[[ -d \"$sanitized/objects\" ]]" "Symlink target should be a valid directory"
-    assert_true "[[ -f \"$sanitized/objects/test.obj\" ]]" "Should be able to read through symlink"
-
+    assert_equals "$CONTAINER_OBJECTS_PATH" "$(_alt "$sg")" "before: container path"
+    repoint_sanitized_git_objects "$sg" "$host_objects"
+    assert_equals "$host_objects" "$(_alt "$sg")" "after: host objects path"
     cleanup_test_env
 }
 
-#===============================================================================
-# TEST: Skip when sanitized git directory doesn't exist
-#===============================================================================
-
-test_skip_when_no_sanitized_git() {
-    log_test "Testing skip when sanitized git directory doesn't exist"
+test_repoint_idempotent() {
+    log_test "repoint: idempotent when alternate already host path"
     setup_test_env
-
-    local sanitized="$TEST_DIR/sanitized-git/abc123"
-
-    # Call production function with nonexistent sanitized git
-    repoint_sanitized_git_objects "/nonexistent/path" "$TEST_DIR/project/.git/objects"
-
-    # Original symlink should be unchanged
-    local current
-    current=$(readlink "$sanitized/objects")
-    assert_equals "$CONTAINER_OBJECTS_PATH" "$current" "Should remain unchanged when sanitized git missing"
-
+    local sg="$TEST_DIR/sanitized-git/abc123"
+    local host_objects="$TEST_DIR/project/.git/objects"
+    repoint_sanitized_git_objects "$sg" "$host_objects"
+    repoint_sanitized_git_objects "$sg" "$host_objects"
+    assert_equals "$host_objects" "$(_alt "$sg")" "stays host objects path"
     cleanup_test_env
 }
-
-#===============================================================================
-# TEST: Skip when objects_path is empty
-#===============================================================================
-
-test_skip_when_no_objects_path() {
-    log_test "Testing skip when objects_path is empty"
-    setup_test_env
-
-    local sanitized="$TEST_DIR/sanitized-git/abc123"
-
-    # Call production function with empty objects path
-    repoint_sanitized_git_objects "$sanitized" ""
-
-    # Original symlink should be unchanged (no kapsis-meta fallback)
-    local current
-    current=$(readlink "$sanitized/objects")
-    assert_equals "$CONTAINER_OBJECTS_PATH" "$current" "Should remain unchanged when objects_path empty"
-
-    cleanup_test_env
-}
-
-#===============================================================================
-# TEST: Fallback to kapsis-meta when objects_path empty
-#===============================================================================
 
 test_fallback_to_kapsis_meta() {
-    log_test "Testing fallback to HOST_OBJECTS_PATH from kapsis-meta"
+    log_test "repoint: falls back to HOST_OBJECTS_PATH from kapsis-meta"
     setup_test_env
-
-    local sanitized="$TEST_DIR/sanitized-git/abc123"
+    local sg="$TEST_DIR/sanitized-git/abc123"
     local host_objects="$TEST_DIR/project/.git/objects"
-
-    # Write kapsis-meta with HOST_OBJECTS_PATH
-    cat > "$sanitized/kapsis-meta" << EOF
-# Kapsis Sanitized Git Metadata
-WORKTREE_PATH=/tmp/test-worktree
-PROJECT_PATH=$TEST_DIR/project
-PARENT_GIT=$TEST_DIR/project/.git
+    cat > "$sg/kapsis-meta" << EOF
 AGENT_ID=abc123
 BRANCH=test-branch
 HOST_OBJECTS_PATH=$host_objects
 EOF
-
-    # Call production function with empty objects_path — should fall back to kapsis-meta
-    repoint_sanitized_git_objects "$sanitized" ""
-
-    local after
-    after=$(readlink "$sanitized/objects")
-    assert_equals "$host_objects" "$after" "Should fall back to HOST_OBJECTS_PATH from kapsis-meta"
-
+    repoint_sanitized_git_objects "$sg" ""
+    assert_equals "$host_objects" "$(_alt "$sg")" "alternate from kapsis-meta"
     cleanup_test_env
 }
 
-#===============================================================================
-# TEST: kapsis-meta contains HOST_OBJECTS_PATH (production write)
-#===============================================================================
+#=== guard conditions =========================================================
+test_skip_when_no_sanitized_git() {
+    log_test "repoint: skip when sanitized git dir missing"
+    setup_test_env
+    local sg="$TEST_DIR/sanitized-git/abc123"
+    repoint_sanitized_git_objects "/nonexistent/path" "$TEST_DIR/project/.git/objects"
+    assert_equals "$CONTAINER_OBJECTS_PATH" "$(_alt "$sg")" "unchanged when target missing"
+    cleanup_test_env
+}
 
+test_skip_when_no_objects_path() {
+    log_test "repoint: skip when objects_path empty and no kapsis-meta"
+    setup_test_env
+    local sg="$TEST_DIR/sanitized-git/abc123"
+    repoint_sanitized_git_objects "$sg" ""
+    assert_equals "$CONTAINER_OBJECTS_PATH" "$(_alt "$sg")" "unchanged when objects_path empty"
+    cleanup_test_env
+}
+
+#=== legacy symlink still handled =============================================
+test_repoint_legacy_symlink() {
+    log_test "repoint: legacy symlink form still re-pointed"
+    setup_test_env
+    local sg="$TEST_DIR/sanitized-git/abc123"
+    local host_objects="$TEST_DIR/project/.git/objects"
+    rm -rf "$sg/objects"; ln -sfn "$CONTAINER_OBJECTS_PATH" "$sg/objects"
+    repoint_sanitized_git_objects "$sg" "$host_objects"
+    assert_equals "$host_objects" "$(readlink "$sg/objects")" "legacy symlink re-pointed to host"
+    cleanup_test_env
+}
+
+#=== metadata =================================================================
 test_kapsis_meta_written_by_production() {
-    log_test "Testing prepare_sanitized_git writes HOST_OBJECTS_PATH to kapsis-meta"
-
-    # Verify the production source contains the HOST_OBJECTS_PATH line
+    log_test "prepare writes HOST_OBJECTS_PATH to kapsis-meta"
     local wm_source="$KAPSIS_ROOT/scripts/worktree-manager.sh"
     local grep_result
     grep_result=$(grep "HOST_OBJECTS_PATH=" "$wm_source" 2>/dev/null || echo "")
-    assert_contains "$grep_result" "HOST_OBJECTS_PATH=" "worktree-manager.sh should write HOST_OBJECTS_PATH"
-    assert_contains "$grep_result" '.git/objects' "HOST_OBJECTS_PATH should reference .git/objects"
+    assert_contains "$grep_result" "HOST_OBJECTS_PATH=" "worktree-manager.sh writes HOST_OBJECTS_PATH"
+    assert_contains "$grep_result" '.git/objects' "HOST_OBJECTS_PATH references .git/objects"
 }
-
-#===============================================================================
-# TEST: Container path symlink is dangling on host
-#===============================================================================
-
-test_container_symlink_is_dangling() {
-    log_test "Testing container path symlink is dangling on host"
-    setup_test_env
-
-    local sanitized="$TEST_DIR/sanitized-git/abc123"
-
-    # The container path should not exist on the host
-    assert_true "[[ ! -e \"$sanitized/objects\" ]]" "Container path symlink should be dangling on host"
-    assert_true "[[ -L \"$sanitized/objects\" ]]" "Should still be a symlink (just dangling)"
-
-    cleanup_test_env
-}
-
-#===============================================================================
-# TEST: Objects symlink absent (fresh sanitized-git dir)
-#===============================================================================
-
-test_repoint_when_symlink_absent() {
-    log_test "Testing re-point when objects symlink doesn't exist yet"
-    setup_test_env
-
-    local sanitized="$TEST_DIR/sanitized-git/abc123"
-    local host_objects="$TEST_DIR/project/.git/objects"
-
-    # Remove the symlink entirely
-    rm -f "$sanitized/objects"
-    assert_true "[[ ! -e \"$sanitized/objects\" ]]" "Symlink should not exist"
-
-    # Call production function — should create the symlink
-    repoint_sanitized_git_objects "$sanitized" "$host_objects"
-
-    local after
-    after=$(readlink "$sanitized/objects")
-    assert_equals "$host_objects" "$after" "Should create new symlink to host objects"
-
-    cleanup_test_env
-}
-
-#===============================================================================
-# TEST: Idempotent re-point (already correct)
-#===============================================================================
-
-test_repoint_idempotent() {
-    log_test "Testing re-point is safe when symlink already correct"
-    setup_test_env
-
-    local sanitized="$TEST_DIR/sanitized-git/abc123"
-    local host_objects="$TEST_DIR/project/.git/objects"
-
-    # Set up symlink already pointing to host path
-    ln -sfn "$host_objects" "$sanitized/objects"
-
-    # Call production function — should be a no-op
-    repoint_sanitized_git_objects "$sanitized" "$host_objects"
-
-    local after
-    after=$(readlink "$sanitized/objects")
-    assert_equals "$host_objects" "$after" "Should remain pointing to host objects"
-    assert_true "[[ -d \"$sanitized/objects\" ]]" "Should still resolve to directory"
-
-    cleanup_test_env
-}
-
-#===============================================================================
-# TEST: Real directory (not symlink) is not replaced
-#===============================================================================
-
-test_skip_when_objects_is_real_directory() {
-    log_test "Testing skip when objects is a real directory (not symlink)"
-    setup_test_env
-
-    local sanitized="$TEST_DIR/sanitized-git/abc123"
-    local host_objects="$TEST_DIR/project/.git/objects"
-
-    # Replace symlink with a real directory
-    rm -f "$sanitized/objects"
-    mkdir -p "$sanitized/objects"
-    echo "real-file" > "$sanitized/objects/real.obj"
-
-    # Call production function — should skip (not a symlink)
-    repoint_sanitized_git_objects "$sanitized" "$host_objects"
-
-    # Should still be a real directory, not a symlink
-    assert_true "[[ -d \"$sanitized/objects\" ]]" "Should still be a directory"
-    assert_true "[[ ! -L \"$sanitized/objects\" ]]" "Should NOT be a symlink"
-    assert_true "[[ -f \"$sanitized/objects/real.obj\" ]]" "Original contents should be preserved"
-
-    cleanup_test_env
-}
-
-#===============================================================================
-# MAIN
-#===============================================================================
 
 main() {
-    print_test_header "Sanitized Git Objects Symlink (Issue #219)"
+    print_test_header "Sanitized Git Objects (writable dir + alternate)"
 
-    log_info "=== Symlink Re-pointing ==="
-    run_test test_repoint_via_production_function
-    run_test test_container_symlink_is_dangling
-    run_test test_repoint_when_symlink_absent
+    log_info "=== Prepare + functional commit ==="
+    run_test test_prepare_creates_writable_objects_with_alternate
+    run_test test_in_container_commit_writes_locally
+
+    log_info "=== Alternate re-pointing ==="
+    run_test test_repoint_rewrites_alternate_to_host
     run_test test_repoint_idempotent
+    run_test test_fallback_to_kapsis_meta
+    run_test test_repoint_legacy_symlink
 
     log_info "=== Guard Conditions ==="
     run_test test_skip_when_no_sanitized_git
     run_test test_skip_when_no_objects_path
-    run_test test_skip_when_objects_is_real_directory
 
     log_info "=== Metadata ==="
     run_test test_kapsis_meta_written_by_production
-    run_test test_fallback_to_kapsis_meta
 
     print_summary
 }

--- a/tests/test-sanitized-git-objects.sh
+++ b/tests/test-sanitized-git-objects.sh
@@ -29,6 +29,7 @@ fi
 # Extract the production functions under test (avoids sourcing whole scripts)
 eval "$(sed -n '/^repoint_sanitized_git_objects()/,/^}/p' "$KAPSIS_ROOT/scripts/launch-agent.sh")"
 eval "$(sed -n '/^_prepare_objects_alternate()/,/^}/p' "$KAPSIS_ROOT/scripts/worktree-manager.sh")"
+eval "$(sed -n '/^_neutralize_sanitized_git_hooks()/,/^}/p' "$KAPSIS_ROOT/scripts/launch-agent.sh")"
 
 _alt() { cat "$1/objects/info/alternates" 2>/dev/null; }  # read alternate line
 
@@ -146,6 +147,36 @@ test_repoint_legacy_symlink() {
     cleanup_test_env
 }
 
+#=== security: repoint refuses symlinked info/ (no host-file clobber) =========
+test_repoint_refuses_symlinked_info() {
+    log_test "repoint: symlinked objects/info is refused (no clobber of host file)"
+    setup_test_env
+    local sg="$TEST_DIR/sanitized-git/abc123"
+    local host_objects="$TEST_DIR/project/.git/objects"
+    # Agent replaces objects/info with a symlink to a sensitive host file.
+    local victim="$TEST_DIR/victim.txt"; echo "PRECIOUS" > "$victim"
+    rm -rf "$sg/objects/info"; ln -sfn "$TEST_DIR" "$sg/objects/info"
+    # Point the (symlinked) alternates target at the victim so a naive `>` clobbers it.
+    ln -sfn "$victim" "$sg/objects/info/alternates" 2>/dev/null || true
+    repoint_sanitized_git_objects "$sg" "$host_objects"
+    assert_file_contains "$victim" "PRECIOUS" "host file must NOT be clobbered via symlinked info/"
+    cleanup_test_env
+}
+
+#=== security: neutralize agent-planted hooks/config before host git ops =======
+test_neutralize_removes_planted_hooks_and_hookspath() {
+    log_test "neutralize: strips planted hooks + core.hooksPath from sanitized dir"
+    local sg; sg=$(mktemp -d)
+    mkdir -p "$sg/hooks"
+    printf '#!/bin/sh\necho pwned\n' > "$sg/hooks/pre-commit"; chmod +x "$sg/hooks/pre-commit"
+    git config --file "$sg/config" core.hooksPath /evil 2>/dev/null || printf '[core]\n\thooksPath = /evil\n' > "$sg/config"
+    _neutralize_sanitized_git_hooks "$sg"
+    assert_file_not_exists "$sg/hooks/pre-commit" "planted hook must be removed"
+    local hp; hp=$(git config --file "$sg/config" --get core.hooksPath 2>/dev/null || echo "")
+    assert_equals "" "$hp" "core.hooksPath must be unset"
+    rm -rf "$sg"
+}
+
 #=== metadata =================================================================
 test_kapsis_meta_written_by_production() {
     log_test "prepare writes HOST_OBJECTS_PATH to kapsis-meta"
@@ -172,6 +203,10 @@ main() {
     log_info "=== Guard Conditions ==="
     run_test test_skip_when_no_sanitized_git
     run_test test_skip_when_no_objects_path
+
+    log_info "=== Security hardening ==="
+    run_test test_repoint_refuses_symlinked_info
+    run_test test_neutralize_removes_planted_hooks_and_hookspath
 
     log_info "=== Metadata ==="
     run_test test_kapsis_meta_written_by_production

--- a/tests/test-worktree-incontainer-git.sh
+++ b/tests/test-worktree-incontainer-git.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Tests for worktree-mode in-container git: GIT_DIR export + rw sanitized mount.
+# Architecture B (designs/2026-08-09-worktree-in-container-push-design.md).
+set -uo pipefail
+# shellcheck disable=SC2016  # single-quoted ${...} are intentional literal source-match patterns
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+KAPSIS_ROOT="$(dirname "$SCRIPT_DIR")"
+# shellcheck disable=SC1090,SC1091
+source "$SCRIPT_DIR/lib/test-framework.sh"
+
+ENTRYPOINT="$KAPSIS_ROOT/scripts/entrypoint.sh"
+LAUNCH="$KAPSIS_ROOT/scripts/launch-agent.sh"
+
+# --- Task 1: GIT_DIR export in worktree mode ---
+# CONTAINER_GIT_PATH is a readonly constant (/workspace/.git-safe), so we cannot
+# exercise setup_worktree_git against a temp dir on the host. The bug was in the
+# DISPATCH (short-circuiting the call away), so guard that via source inspection.
+
+test_dispatch_calls_setup_worktree_git_not_shortcircuit() {
+    assert_file_not_contains "$ENTRYPOINT" '== "worktree" ]] || setup_worktree_git' \
+        "dispatch must not short-circuit setup_worktree_git away in worktree mode"
+    assert_file_contains "$ENTRYPOINT" 'setup_worktree_git || log_warn' \
+        "worktree branch must call setup_worktree_git explicitly"
+}
+
+test_setup_worktree_git_still_exports_gitdir() {
+    # The function that makes in-container git work must still export GIT_DIR
+    # to the mounted sanitized .git-safe.
+    assert_file_contains "$ENTRYPOINT" 'export GIT_DIR="${CONTAINER_GIT_PATH}"' \
+        "setup_worktree_git must export GIT_DIR to the sanitized git dir"
+}
+
+test_entrypoint_main_is_source_guarded() {
+    # Needed so unit tests can source the script without running the container.
+    assert_file_contains "$ENTRYPOINT" 'if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then' \
+        "main must be guarded so the file is sourceable in tests"
+}
+
+# --- Task 2: sanitized git mounted read-write ---
+
+test_sanitized_git_mounted_rw() {
+    # generate_volume_mounts_worktree calls add_common_volume_mounts, which needs
+    # many run-time globals, so assert on the source: the sanitized git mount must
+    # NOT carry :ro (agent must be able to commit), while the objects DB stays :ro.
+    local body
+    body=$(awk '/^generate_volume_mounts_worktree\(\)/{f=1} f{print} f&&/^}/{exit}' "$LAUNCH")
+    assert_contains "$body" '${SANITIZED_GIT_PATH}:${CONTAINER_GIT_PATH}"' \
+        "sanitized git must be mounted read-write (no :ro)"
+    assert_not_contains "$body" '${SANITIZED_GIT_PATH}:${CONTAINER_GIT_PATH}:ro"' \
+        "sanitized git must NOT be mounted :ro"
+    assert_contains "$body" '${OBJECTS_PATH}:${CONTAINER_OBJECTS_PATH}:ro"' \
+        "objects DB must stay read-only"
+}
+
+main() {
+    run_test test_dispatch_calls_setup_worktree_git_not_shortcircuit
+    run_test test_setup_worktree_git_still_exports_gitdir
+    run_test test_entrypoint_main_is_source_guarded
+    run_test test_sanitized_git_mounted_rw
+    print_summary
+}
+main "$@"

--- a/tests/test-worktree-incontainer-git.sh
+++ b/tests/test-worktree-incontainer-git.sh
@@ -11,10 +11,42 @@ source "$SCRIPT_DIR/lib/test-framework.sh"
 ENTRYPOINT="$KAPSIS_ROOT/scripts/entrypoint.sh"
 LAUNCH="$KAPSIS_ROOT/scripts/launch-agent.sh"
 
-# --- Task 1: GIT_DIR export in worktree mode ---
-# CONTAINER_GIT_PATH is a readonly constant (/workspace/.git-safe), so we cannot
-# exercise setup_worktree_git against a temp dir on the host. The bug was in the
-# DISPATCH (short-circuiting the call away), so guard that via source inspection.
+# Exercise setup_worktree_git for real against a temp CONTAINER_GIT_PATH. The real
+# constant is readonly (= /workspace/.git-safe, absent on the host) and
+# test-framework.sh already sourced constants.sh, so we run the function in a fresh
+# bash subprocess where CONTAINER_GIT_PATH is not readonly. Prints "rc=<n> gitdir=<GIT_DIR>".
+_run_setup_worktree_git() {
+    local cgp="$1"
+    bash -c '
+        log_debug(){ :; }; log_info(){ :; }; log_warn(){ :; }
+        CONTAINER_GIT_PATH="'"$cgp"'"
+        eval "$(sed -n "/^setup_worktree_git()/,/^}/p" "'"$ENTRYPOINT"'")"
+        GIT_DIR=""
+        setup_worktree_git; rc=$?
+        printf "rc=%s gitdir=%s\n" "$rc" "${GIT_DIR:-}"
+    '
+}
+
+# --- Task 1 (functional): setup_worktree_git exports GIT_DIR ---
+
+test_setup_worktree_git_exports_gitdir_when_meta_present() {
+    local d; d=$(mktemp -d); mkdir -p "$d/gitsafe"
+    printf 'BRANCH=feature/x\n' > "$d/gitsafe/kapsis-meta"
+    local out; out=$(_run_setup_worktree_git "$d/gitsafe")
+    assert_equals "rc=0 gitdir=$d/gitsafe" "$out" "GIT_DIR exported to sanitized .git-safe (rc=0)"
+    rm -rf "$d"
+}
+
+test_setup_worktree_git_returns_nonzero_without_meta() {
+    local d; d=$(mktemp -d); mkdir -p "$d/gitsafe"  # no kapsis-meta
+    local out; out=$(_run_setup_worktree_git "$d/gitsafe")
+    assert_equals "rc=1 gitdir=" "$out" "returns non-zero + GIT_DIR unset when kapsis-meta absent"
+    rm -rf "$d"
+}
+
+# --- Task 1 (regression guard): dispatch must CALL setup_worktree_git ---
+# The bug was the dispatch short-circuiting the call away in worktree mode; guard
+# the exact buggy/fixed wording so a refactor can't silently reintroduce it.
 
 test_dispatch_calls_setup_worktree_git_not_shortcircuit() {
     assert_file_not_contains "$ENTRYPOINT" '== "worktree" ]] || setup_worktree_git' \
@@ -23,15 +55,7 @@ test_dispatch_calls_setup_worktree_git_not_shortcircuit() {
         "worktree branch must call setup_worktree_git explicitly"
 }
 
-test_setup_worktree_git_still_exports_gitdir() {
-    # The function that makes in-container git work must still export GIT_DIR
-    # to the mounted sanitized .git-safe.
-    assert_file_contains "$ENTRYPOINT" 'export GIT_DIR="${CONTAINER_GIT_PATH}"' \
-        "setup_worktree_git must export GIT_DIR to the sanitized git dir"
-}
-
 test_entrypoint_main_is_source_guarded() {
-    # Needed so unit tests can source the script without running the container.
     assert_file_contains "$ENTRYPOINT" 'if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then' \
         "main must be guarded so the file is sourceable in tests"
 }
@@ -39,9 +63,6 @@ test_entrypoint_main_is_source_guarded() {
 # --- Task 2: sanitized git mounted read-write ---
 
 test_sanitized_git_mounted_rw() {
-    # generate_volume_mounts_worktree calls add_common_volume_mounts, which needs
-    # many run-time globals, so assert on the source: the sanitized git mount must
-    # NOT carry :ro (agent must be able to commit), while the objects DB stays :ro.
     local body
     body=$(awk '/^generate_volume_mounts_worktree\(\)/{f=1} f{print} f&&/^}/{exit}' "$LAUNCH")
     assert_contains "$body" '${SANITIZED_GIT_PATH}:${CONTAINER_GIT_PATH}"' \
@@ -53,8 +74,9 @@ test_sanitized_git_mounted_rw() {
 }
 
 main() {
+    run_test test_setup_worktree_git_exports_gitdir_when_meta_present
+    run_test test_setup_worktree_git_returns_nonzero_without_meta
     run_test test_dispatch_calls_setup_worktree_git_not_shortcircuit
-    run_test test_setup_worktree_git_still_exports_gitdir
     run_test test_entrypoint_main_is_source_guarded
     run_test test_sanitized_git_mounted_rw
     print_summary


### PR DESCRIPTION
## Summary

Worktree sandbox mode had **dead in-container git**: the agent couldn't commit, diff, verify, or open a PR from inside the container, and `/dev`-style runs ended with a pushed branch but **no PR** (root cause: `entrypoint.sh` ran the agent without ever calling `setup_worktree_git`, so `GIT_DIR` was never exported; the sanitized git was also mounted read-only with a read-only objects symlink).

This PR (architecture **B** — see `designs/2026-08-09-worktree-in-container-push-design.md`):

- Gives the agent **working in-container git** for commit/diff/verify.
- Keeps the credentialed **push + PR creation + validation on the host** (reliable and outside the agent's trust domain — an in-container push can't fire on the SIGKILL / virtio-fs-mount-drop failure modes that motivated this, and would duplicate a host path that must exist anyway).
- Fixes the **"no PR"** symptom via a provider-pluggable **host-side post-push hook**.

Design decisions were pressure-tested across **two adversarial review rounds** (see `designs/…-design.md` "Ensemble review log"), which caught and corrected an earlier in-container-push pivot.

## Changes

**Writable in-container git (agent commit/diff/verify)**
- `entrypoint.sh`: run `setup_worktree_git` in worktree mode (was short-circuited by `[[ ==worktree ]] || setup_worktree_git`), so `GIT_DIR` is exported; guard `main` so the script is unit-test-sourceable.
- `launch-agent.sh`: mount the sanitized git **read-write**.
- `worktree-manager.sh`: objects become a **writable dir + `objects/info/alternates`** (borrowing the parent DB read-only) instead of a read-only symlink, so `git commit` can write new objects; `repoint_sanitized_git_objects` rewrites the alternate (legacy symlink path kept as fallback).

**Hardened host push/PR (`post-container-git.sh`, `status.sh`, `launch-agent.sh`)**
- `validate_staged_files`: **case-insensitive** `.kapsis`/`.git-safe`/`.git-objects` exclusion (container FS is case-sensitive) + reject staged **symlinks** (`120000`); gitlinks (`160000`) were already rejected. Fail-closed (no push on violation).
- `push_changes`: **fetch-before-push** divergence guard — refuse a non-fast-forward instead of emitting a bare rejection that stranded work as "committed, no PR".
- Provider-pluggable **`git.post_push_hook`** run on the host after a verified push (PR creation via `gh`/`bkt`/etc., supplied by config; agent-influenced values passed via env only). Outcome recorded as `pr_hook_status` (`skipped|ok|failed:<reason>`) and surfaced, never silent. Unset = legacy PR-instructions behavior.

## Tests

- New `tests/test-worktree-incontainer-git.sh` (GIT_DIR dispatch guard, rw mount).
- Rewrote `tests/test-sanitized-git-objects.sh` to the alternate model + a **functional commit-against-read-only-parent** test.
- Extended `tests/test-post-container-git.sh`: case-insensitive/symlink/gitlink rejection, fetch-before-push (fake bare remote), post-push hook (env, unset-skip, failure-surfaced).
- Affected suites green: worktree-incontainer 4, objects 9, post-container-git 14, post-exit-git 10, status-reporting 30, validate-staged-files 15, commit-failure 17, git-excludes 7, worktree-cleanup 26, coauthor-fork 29, push-verification 11.

## Not covered by unit tests (integration)

Whether `GIT_DIR` is effective for the *agent* process and container egress are exercised only in a real sandbox run — worth a manual verification before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
